### PR TITLE
fix: ensure bundled themes are discoverable without ghostty installation

### DIFF
--- a/mux0/Theme/GhosttyConfigReader.swift
+++ b/mux0/Theme/GhosttyConfigReader.swift
@@ -19,14 +19,19 @@ enum GhosttyConfigReader {
         ]
     }
 
-    /// 默认主题搜索路径。
+    /// 默认主题搜索路径。用户自定义路径优先，bundle 内置主题（build-vendor.sh 打包）作为 fallback，
+    /// 确保 ~/.config/ghostty/themes/<Name> 能覆盖同名 bundle 主题。
     static var themeSearchPaths: [String] {
         let home = NSHomeDirectory()
-        return [
+        var paths: [String] = [
             "/Applications/Ghostty.app/Contents/Resources/ghostty/themes",
             "\(home)/Library/Application Support/com.mitchellh.ghostty/themes",
             "\(home)/.config/ghostty/themes",
         ]
+        if let base = Bundle.main.resourcePath {
+            paths.append((base as NSString).appendingPathComponent("ghostty/themes"))
+        }
+        return paths
     }
 
     /// 加载并解析当前用户的 ghostty 配置 + theme 文件 + mux0 override，返回组合后的颜色。


### PR DESCRIPTION
## Summary

- Append `Bundle.main.resourcePath/ghostty/themes` to `GhosttyConfigReader.themeSearchPaths` as a fallback, so bundled themes (shipped via `build-vendor.sh`) are discoverable without Ghostty.app installed.

## Problem

Without Ghostty.app installed and no user-provided `~/.config/ghostty/themes`, the theme picker in Settings listed all 486 bundled themes (because `ThemeCatalog` reads `Bundle.main.resourcePath/ghostty/themes`), but **selecting a theme had no visible effect** — neither mux0's own chrome (sidebar/tab colors via `ThemeManager`) nor the terminal surface (via `GhosttyBridge.resolvedThemePath()`) picked up the theme colors.

Root cause: `GhosttyConfigReader.themeSearchPaths` only searched three external paths (`/Applications/Ghostty.app/...`, `~/Library/Application Support/com.mitchellh.ghostty/themes`, `~/.config/ghostty/themes`). With none of them present, `locateTheme(named:)` returned nil.

## Fix

Append `Bundle.main.resourcePath/ghostty/themes` as the last entry in the search path list, so:

- **Ghostty.app users**: existing first-match behavior is preserved (no regression).
- **Users with `~/.config/ghostty/themes/<Name>`**: their custom overrides still win over same-named bundled themes (user > bundle).
- **Fresh install without Ghostty.app**: bundled themes are now found via the fallback path.