### PR TITLE
fix(models): focus new pane after split so unfocused-opacity applies

### DIFF
--- a/mux0/Models/WorkspaceStore.swift
+++ b/mux0/Models/WorkspaceStore.swift
@@ -146,7 +146,7 @@ final class WorkspaceStore {
                                         .terminal(terminalId), .terminal(newTermId))
         workspaces[wsIdx].tabs[tIdx].layout =
             workspaces[wsIdx].tabs[tIdx].layout.replacing(terminalId: terminalId, with: splitNode)
-        // 焦点保持在被 split 的原 pane（用户上次聚焦的那个），不自动切到新 pane。
+        workspaces[wsIdx].tabs[tIdx].focusedTerminalId = newTermId
         save()
         return newTermId
     }

--- a/mux0/TabContent/TabContentView.swift
+++ b/mux0/TabContent/TabContentView.swift
@@ -378,7 +378,6 @@ final class TabContentView: NSView {
         else { return }
         pwdStore?.inherit(from: sourceId, to: newId)
         reloadFromStore()
-        // reloadFromStore 会根据 store 里的 focusedTerminalId 恢复焦点到原 pane。
     }
 
     private func cycleTab(forward: Bool) {


### PR DESCRIPTION
## Summary
- `splitTerminal` 现在把 `focusedTerminalId` 指到新 pane，而不是保留在原 pane。
- 连带修复「非聚焦窗格不透明度」对新分屏不生效的问题：原逻辑下焦点没动，`makeFrontmost` 的 `guard currentFrontmost !== front` 早退，`applyUnfocusedOpacity` 从未对新 pane 跑过一轮，alpha 停留在默认的 1.0。焦点切到新 pane 后，`applyUnfocusedOpacity` 被正常触发，老 pane 变暗、新 pane 保持 1.0。
- `TabContentView.splitCurrentPane` 顺带删掉那条已经和代码行为相反的陈旧注释。
- 既有单元测试 `testSplitTerminal` 正好在断言这一行为（之前是失败的），本修复让它重新通过。

Fixes #4