### PR TITLE
fix(ghostty): prevent clipboard overwrite on workspace/tab switch

### DIFF
--- a/mux0/Ghostty/GhosttyBridge.swift
+++ b/mux0/Ghostty/GhosttyBridge.swift
@@ -16,6 +16,11 @@ final class GhosttyBridge {
     /// and can only reach Swift state through the shared instance.
     var onPwdChanged: ((UUID, String) -> Void)?
 
+    /// When true, `writeClipboardCallback` skips writing to `NSPasteboard.general`.
+    /// Set by `GhosttyTerminalView.makeFrontmost` during workspace/tab switches to
+    /// prevent ghostty from syncing its internal selection into the system clipboard.
+    static var suppressClipboardWrites = false
+
     private init() {}
 
     /// Returns true on success. Call once from mux0App.init().
@@ -429,6 +434,7 @@ final class GhosttyBridge {
 
     // ghostty_runtime_write_clipboard_cb: (void*, ghostty_clipboard_e, const ghostty_clipboard_content_s*, size_t, bool) -> void
     private static let writeClipboardCallback: ghostty_runtime_write_clipboard_cb = { _, _, content, count, _ in
+        guard !GhosttyBridge.suppressClipboardWrites else { return }
         guard let content = content, count > 0 else { return }
 
         // Ghostty hands us the selection as multiple MIME-tagged entries (typically

--- a/mux0/Ghostty/GhosttyTerminalView.swift
+++ b/mux0/Ghostty/GhosttyTerminalView.swift
@@ -154,6 +154,14 @@ final class GhosttyTerminalView: NSView, NSTextInputClient {
         guard currentFrontmost !== front else { return }
         currentFrontmost = front
         let zeroMods = ghostty_input_mods_e(rawValue: 0)
+        // Suppress clipboard writes: switching tabs/workspaces calls
+        // ghostty_surface_set_focus etc. which may trigger ghostty to sync
+        // the current selection into the system clipboard. Setting this flag
+        // prevents writeClipboardCallback from touching NSPasteboard.general
+        // during the transition. The ghostty C API calls below are synchronous,
+        // so any clipboard callbacks fire before we clear the flag.
+        GhosttyBridge.suppressClipboardWrites = true
+        defer { GhosttyBridge.suppressClipboardWrites = false }
         for v in registry.allObjects {
             guard let s = v.surface else { continue }
             let isFront = (v === front)


### PR DESCRIPTION
Switching workspaces or tabs called makeFrontmost which triggers ghostty_surface_set_focus on all live surfaces, causing libghostty to sync its internal selection into NSPasteboard.general. Add a suppressClipboardWrites flag that writeClipboardCallback checks during the synchronous transition.