### PR TITLE
fix(settings): font picker has no effect due to PostScript name / family name mismatch

### DIFF
--- a/mux0/Settings/Components/FontPickerView.swift
+++ b/mux0/Settings/Components/FontPickerView.swift
@@ -10,10 +10,15 @@ struct FontPickerView: View {
     @State private var isCustom: Bool = false
     @Environment(\.locale) private var locale
 
-    /// 系统等宽字体列表（首次访问缓存）。
+    /// 系统等宽字体族名列表（首次访问缓存）。
+    /// `availableFontNames(with:)` 返回 PostScript 名称（如 Menlo-Regular），
+    /// 但 ghostty 的 font-family 期望字体族名（如 Menlo），所以这里去重取 familyName。
     private static let systemMonospaceFonts: [String] = {
-        (NSFontManager.shared.availableFontNames(with: .fixedPitchFontMask) ?? [])
-            .sorted()
+        let names = NSFontManager.shared.availableFontNames(with: .fixedPitchFontMask) ?? []
+        let families = Set(names.compactMap { name -> String? in
+            NSFont(name: name, size: 12)?.familyName
+        })
+        return families.sorted()
     }()
 
     var body: some View {


### PR DESCRIPTION
## Problem

The font picker dropdown uses `NSFontManager.availableFontNames(with: .fixedPitchFontMask)`, which returns PostScript names (e.g. `Menlo-Regular`, `Courier-Bold`). However, ghostty's `font-family` config expects family names (e.g. `Menlo`).

After selecting a font from the dropdown, `font-family = Menlo-Regular` is written to the config. Ghostty can't find a font family named `Menlo-Regular`, silently falls back to the default — the terminal font doesn't change at all.

Additionally, multiple weights/variants of the same family appear as duplicate entries (`Menlo-Regular`, `Menlo-Bold`, `Menlo-Italic`…), making the list confusing.

## Fix

Extract `NSFont.familyName` from each PostScript name, deduplicate via `Set`, and sort. The picker now shows family names, and the value written to `font-family` matches what ghostty expects.