### PR TITLE
Agent session resume

### DIFF
--- a/Resources/agent-hooks/agent-hook.py
+++ b/Resources/agent-hooks/agent-hook.py
@@ -25,6 +25,10 @@ import pathlib
 
 SESSION_TTL_SEC = 3600
 SUMMARY_MAXLEN = 200
+# Session ids from claude/codex are UUID-shaped. Restrict the resume command
+# to this charset so a malformed payload can't inject shell metacharacters
+# into the persisted `initial_input`.
+SESSION_ID_RE = re.compile(r"\A[A-Za-z0-9_-]+\Z")
 
 
 def parse_payload() -> dict:
@@ -164,6 +168,19 @@ def _default_entry(agent: str, terminal_id: str) -> dict:
     }
 
 
+def resume_command_for(agent: str, session_id: str) -> str:
+    """Build the user-facing CLI command that resumes the given session.
+    Empty string if the session id is missing/malformed, or if we don't
+    have a stable resume invocation for the agent (e.g. opencode in v1)."""
+    if not session_id or not SESSION_ID_RE.match(session_id):
+        return ""
+    if agent == "claude":
+        return f"claude --resume {session_id}"
+    if agent == "codex":
+        return f"codex resume {session_id}"
+    return ""
+
+
 def dispatch(subcmd: str, agent: str, payload: dict,
              terminal_id: str, session_file: pathlib.Path, now: float) -> dict:
     """Apply subcommand to session file; return dict describing socket emit.
@@ -192,6 +209,12 @@ def dispatch(subcmd: str, agent: str, payload: dict,
         if tp:
             entry["transcriptPath"] = tp
         emit = {"event": "running", "at": now}
+        # Attach the resume command on every prompt so mux0 always tracks the
+        # most-recent session_id (a /clear or /resume mid-conversation rotates
+        # to a new id, and we want the latest one preserved for next launch).
+        resume = resume_command_for(agent, str(session_id))
+        if resume:
+            emit["resumeCommand"] = resume
 
     elif subcmd == "pretool":
         tool = payload.get("tool_name", "") or ""

--- a/Resources/agent-hooks/agent-hook.py
+++ b/Resources/agent-hooks/agent-hook.py
@@ -171,13 +171,21 @@ def _default_entry(agent: str, terminal_id: str) -> dict:
 def resume_command_for(agent: str, session_id: str) -> str:
     """Build the user-facing CLI command that resumes the given session.
     Empty string if the session id is missing/malformed, or if we don't
-    have a stable resume invocation for the agent (e.g. opencode in v1)."""
+    have a stable resume invocation for the agent.
+
+    Note: opencode does not actually flow through this Python hook (it has
+    its own JS plugin that emits resumeCommand directly), but we keep its
+    branch here so this function stays the single source of truth for the
+    CLI shape of every supported agent.
+    """
     if not session_id or not SESSION_ID_RE.match(session_id):
         return ""
     if agent == "claude":
         return f"claude --resume {session_id}"
     if agent == "codex":
         return f"codex resume {session_id}"
+    if agent == "opencode":
+        return f"opencode --session {session_id}"
     return ""
 
 

--- a/Resources/agent-hooks/opencode-plugin/mux0-status.js
+++ b/Resources/agent-hooks/opencode-plugin/mux0-status.js
@@ -41,6 +41,16 @@ function shortPath(p) {
     return parts.length > 3 ? parts.slice(-3).join("/") : parts.join("/");
 }
 
+// OpenCode session ids are alphanumeric with underscores/dashes (`ses_xxx`
+// in current versions). Restrict the resume command to this charset so a
+// malformed payload can't inject shell metacharacters into the persisted
+// `initial_input`.
+const SESSION_ID_RE = /^[A-Za-z0-9_-]+$/;
+function resumeCommandFor(sessionID) {
+    if (!sessionID || !SESSION_ID_RE.test(sessionID)) return null;
+    return `opencode --session ${sessionID}`;
+}
+
 function describeOpencodeTool(tool, input) {
     if (!input || typeof input !== "object") return tool || "";
     const t = tool || "";
@@ -86,18 +96,39 @@ export const Mux0StatusPlugin = async (_input) => ({
         }
     },
 
-    "tool.execute.before": async (args) => {
-        turn.tool = args?.tool;
+    // chat.message fires when the user sends a message — opencode's
+    // equivalent of UserPromptSubmit. We attach resumeCommand here so the
+    // session id is captured even on prompts that don't trigger any tool
+    // calls (e.g. a quick chat answer with no Edit/Bash/Read).
+    "chat.message": async (input, _output) => {
         if (!turn.startedAt) turn.startedAt = Date.now() / 1000;
-        const detail = describeOpencodeTool(args?.tool, args?.input);
-        emit({ event: "running", toolDetail: detail || undefined });
+        const resumeCommand = resumeCommandFor(input?.sessionID);
+        const payload = { event: "running" };
+        if (resumeCommand) payload.resumeCommand = resumeCommand;
+        emit(payload);
     },
 
-    "tool.execute.after": async (args) => {
-        // args.error present if tool threw; args.result.status === "error"
-        // for tools that report failure in-band.
-        const hadErr = !!(args?.error)
-            || (args?.result?.status === "error");
+    // Plugin runtime calls these hooks with two args:
+    //   (input, output) where input has { tool, sessionID, callID, ... }.
+    // Tool args live on output.args (before) and output.{title,output,metadata}
+    // (after). See packages/plugin/src/index.ts in sst/opencode.
+    "tool.execute.before": async (input, output) => {
+        turn.tool = input?.tool;
+        if (!turn.startedAt) turn.startedAt = Date.now() / 1000;
+        const detail = describeOpencodeTool(input?.tool, output?.args);
+        const resumeCommand = resumeCommandFor(input?.sessionID);
+        const payload = { event: "running" };
+        if (detail) payload.toolDetail = detail;
+        if (resumeCommand) payload.resumeCommand = resumeCommand;
+        emit(payload);
+    },
+
+    "tool.execute.after": async (_input, output) => {
+        // Tools may report failure in `output.metadata.error` /
+        // `output.metadata.status`, or by throwing (which surfaces as
+        // session.error rather than reaching this hook).
+        const hadErr = !!(output?.metadata?.error)
+            || (output?.metadata?.status === "error");
         if (hadErr) turn.hadError = true;
         // No socket emit — icon only flips at session.idle / session.status{type=idle}.
     },

--- a/Resources/agent-hooks/tests/test_agent_hook.py
+++ b/Resources/agent-hooks/tests/test_agent_hook.py
@@ -176,7 +176,11 @@ def test_dispatch_prompt_then_stop_clean_turn(tmp_path, monkeypatch):
 
     prompt_payload = {"session_id": "s1", "transcript_path": str(transcript)}
     emit1 = agent_hook.dispatch("prompt", "claude", prompt_payload, "term1", sf, now)
-    assert emit1 == {"event": "running", "at": now}
+    assert emit1 == {
+        "event": "running",
+        "at": now,
+        "resumeCommand": "claude --resume s1",
+    }
 
     stop_payload = {"session_id": "s1"}
     emit2 = agent_hook.dispatch("stop", "claude", stop_payload, "term1", sf, now + 10)
@@ -275,3 +279,65 @@ def test_dispatch_posttool_running_emit_preserves_sticky_error(tmp_path):
     stop_emit = agent_hook.dispatch("stop", "claude",
                                      {"session_id": "s7"}, "term7", sf, now + 2)
     assert stop_emit["exitCode"] == 1
+
+
+# ---------- resume_command_for ----------
+
+def test_resume_command_for_claude():
+    assert agent_hook.resume_command_for("claude", "abc") == "claude --resume abc"
+
+
+def test_resume_command_for_codex():
+    assert agent_hook.resume_command_for("codex", "xyz") == "codex resume xyz"
+
+
+def test_resume_command_for_unknown_agent():
+    # OpenCode (and any future agent) returns empty until we know its CLI shape.
+    assert agent_hook.resume_command_for("opencode", "xyz") == ""
+
+
+def test_resume_command_for_empty_session():
+    assert agent_hook.resume_command_for("claude", "") == ""
+
+
+def test_resume_command_for_rejects_shell_metacharacters():
+    # Session id is persisted into `initial_input` for next-launch auto-exec.
+    # Any character outside [A-Za-z0-9_-] must abort the build so the shell
+    # can't be tricked into executing extra commands. Real claude/codex
+    # session ids are UUID-shaped, so this never rejects a legitimate id.
+    bad = ["abc; touch /tmp/pwn", "abc def", "abc`whoami`", "abc$(id)",
+           "abc&", "abc|cat", "abc\nrm", "../etc/passwd", "a/b"]
+    for value in bad:
+        assert agent_hook.resume_command_for("claude", value) == "", value
+        assert agent_hook.resume_command_for("codex", value) == "", value
+
+
+def test_resume_command_for_accepts_uuid_shapes():
+    # Real-world session ids: hex UUIDs (with or without dashes), short
+    # alphanumeric tags, underscore-separated. All must round-trip.
+    good = ["550e8400-e29b-41d4-a716-446655440000",
+            "550e8400e29b41d4a716446655440000",
+            "abc_DEF-123",
+            "xyz"]
+    for value in good:
+        assert agent_hook.resume_command_for("claude", value) == \
+               f"claude --resume {value}"
+
+
+def test_dispatch_codex_prompt_emits_resume_command(tmp_path):
+    sf = tmp_path / "sessions.json"
+    emit = agent_hook.dispatch("prompt", "codex",
+                                {"session_id": "cdx-1"}, "term-c", sf, 5_000_000.0)
+    assert emit["resumeCommand"] == "codex resume cdx-1"
+
+
+def test_dispatch_pretool_does_not_emit_resume_command(tmp_path):
+    # Only `prompt` should attach resumeCommand, to avoid spamming the socket
+    # with the same value on every tool invocation.
+    sf = tmp_path / "sessions.json"
+    agent_hook.dispatch("prompt", "claude", {"session_id": "s9"}, "t9", sf, 6_000_000.0)
+    emit = agent_hook.dispatch("pretool", "claude",
+                                {"session_id": "s9", "tool_name": "Bash",
+                                 "tool_input": {"command": "ls"}},
+                                "t9", sf, 6_000_001.0)
+    assert "resumeCommand" not in emit

--- a/Resources/agent-hooks/tests/test_agent_hook.py
+++ b/Resources/agent-hooks/tests/test_agent_hook.py
@@ -291,9 +291,14 @@ def test_resume_command_for_codex():
     assert agent_hook.resume_command_for("codex", "xyz") == "codex resume xyz"
 
 
+def test_resume_command_for_opencode():
+    assert agent_hook.resume_command_for("opencode", "ses_abc") == \
+           "opencode --session ses_abc"
+
+
 def test_resume_command_for_unknown_agent():
-    # OpenCode (and any future agent) returns empty until we know its CLI shape.
-    assert agent_hook.resume_command_for("opencode", "xyz") == ""
+    # Any future agent returns empty until we know its CLI shape.
+    assert agent_hook.resume_command_for("aider", "xyz") == ""
 
 
 def test_resume_command_for_empty_session():

--- a/docs/agent-hooks.md
+++ b/docs/agent-hooks.md
@@ -7,7 +7,7 @@ mux0 通过注入到各 AI CLI 的生命周期钩子，把 `running` / `idle` / 
 ## IPC
 
 - 传输：Unix domain socket，路径为 `~/Library/Caches/mux0/hooks-<bundle-hash>.sock`（`<bundle-hash>` = SHA256(`Bundle.main.bundlePath`) 前 8 位十六进制）。按 bundle 路径分命名空间是为了让 `/Applications/mux0.app` 和 Xcode DerivedData 里的 Debug 构建互不抢占 socket——后起的实例 `bind()` 前会 `unlink` 掉同路径的旧 sockfile，会把前一实例踢下线。路径由 `GhosttyBridge.initialize()` 写进 `MUX0_HOOK_SOCK`，终端进程通过 env 继承
-- 消息格式：每行一个 JSON，`{"terminalId": "...", "event": "running|idle|needsInput|finished", "agent": "claude|opencode|codex", "at": <epoch>, "exitCode": <int>?, "toolDetail": <string>?, "summary": <string>?}`。`exitCode` 仅在 `event=finished` 时携带（shell = 真实 `$?`；agent = 0/1 哨兵）；`toolDetail` 仅在 agent 的 `event=running` 时携带（如 "Edit Models/Foo.swift"）；`summary` 仅在 agent 的 `event=finished` 时携带（transcript 最后一条 assistant 消息，≤200 chars）。
+- 消息格式：每行一个 JSON，`{"terminalId": "...", "event": "running|idle|needsInput|finished", "agent": "claude|opencode|codex", "at": <epoch>, "exitCode": <int>?, "toolDetail": <string>?, "summary": <string>?, "resumeCommand": <string>?}`。`exitCode` 仅在 `event=finished` 时携带（shell = 真实 `$?`；agent = 0/1 哨兵）；`toolDetail` 仅在 agent 的 `event=running` 时携带（如 "Edit Models/Foo.swift"）；`summary` 仅在 agent 的 `event=finished` 时携带（transcript 最后一条 assistant 消息，≤200 chars）；`resumeCommand` 仅在 Claude/Codex 的 prompt 触发的 `event=running` 时携带（恢复当前 session 的 CLI，如 `claude --resume <session_id>` / `codex resume <session_id>`，OpenCode 暂未支持）。
 - 监听端：`HookSocketListener`（DispatchSourceRead，accept 循环）
 
 ## Agent Turn 成败检测
@@ -21,6 +21,22 @@ Agent turn 没有真实的 exit code，但 Claude Code / Codex 的 `PostToolUse`
 **Turn summary**（Claude 独有）：`Stop` 从 `transcript_path` 读取 JSONL 最后一条 `role: "assistant"` 的 text 字段，剥掉 `<thinking>...</thinking>` 块，截到 200 chars，放进 `summary`。Codex 同理（schema 一致）。OpenCode 的 summary 在 v1 里留空（它没有等价的 transcript path 参数；后续 spec 可补）。
 
 **Tool detail**（全部 agent）：`PreToolUse` / `tool.execute.before` 时，派发脚本/插件会根据 `tool_name` + `tool_input` 生成一个紧凑的人类可读标签（"Edit Models/Foo.swift"、"Bash: ls"），作为 `running` 事件的 `toolDetail`。Swift 端把它拼到 tooltip 的第二行。
+
+## Resume command 持久化
+
+每次 `UserPromptSubmit` 触发时，`agent-hook.py` 把当前 session 对应的恢复 CLI（Claude → `claude --resume <session_id>`；Codex → `codex resume <session_id>`）放进 `running` 事件的 `resumeCommand` 字段。`HookDispatcher` 接到后调用 `WorkspaceStore.recordResumeCommand(terminalId:command:)` **直接**写到对应 workspace 的 `pendingPrefills[terminalId]` 并同步持久化到 UserDefaults——保留**最新**那一条（用户 `/clear` 或 `/resume` 切到新 session 时旧 id 立即被覆盖）。
+
+不依赖 `NSApplication.willTerminateNotification` 做"退出时提升"——⌘Q / 关窗 / 强退 / 崩溃路径下 willTerminate 触发与否不可靠，每次 hook 收到时立刻 save 才是稳定的持久化点。
+
+下次启动 surface 时，`TabContentView.terminalViewFor` 通过 `consumePendingPrefill(terminalId:)` 读取该值，作为 `GhosttyTerminalView.command` 传入——优先级高于 workspace `defaultCommand`。
+
+读取**不**清空：pendingPrefills 持久保留"最近一次的恢复命令"，只在下一次新 prompt 触发 `recordResumeCommand` 时被覆盖。这保证"重启 → 自动恢复 → 没发任何 prompt → 再重启"仍然能恢复同一会话；代价是用户手动退出 agent 之后该字段会变 stale，下次重启仍会自动 `claude --resume <id>`，不过 claude/codex 都接受任意旧 session id（只是恢复一段久远对话），不会报错。
+
+**注入路径**：与 `defaultCommand` 完全相同——`WorkspaceDefaultCommand.startupInput(for:)` 在尾部加 `\n`，由 `GhosttyBridge.newSurface` 通过 ghostty 的 `surfCfg.initial_input` 喂入 PTY，shell 启动后 readline 读到立即执行。
+
+`initial_input` 在 shell 启动之前会先把字节绘制到 surface 一次（PTY echo 路径之外的渲染层副作用），但 Claude / Codex 的 TUI 启动后立即切换到 alternate screen buffer，整屏接管后顶部那行幽灵 echo 被自动覆盖，用户实际感知不到。早期尝试过用 `ghostty_surface_text` 在 OSC 7 之后延时注入避开这一行，也尝试过用 env var + zsh shim eval 完全绕过 PTY，最终还是回到这个方案——简单、不依赖 shell 类型、与现有 `defaultCommand` 路径同构。
+
+**v1 限制**：OpenCode 因为没有稳定的 `--resume <id>` CLI 形态，`resume_command_for("opencode", ...)` 返回空串，插件不发该字段。后续如果 opencode 加上 stable resume 语法，只需扩展 `resume_command_for` 即可。
 
 ## 各 Agent 的信号来源
 

--- a/docs/agent-hooks.md
+++ b/docs/agent-hooks.md
@@ -24,19 +24,27 @@ Agent turn 没有真实的 exit code，但 Claude Code / Codex 的 `PostToolUse`
 
 ## Resume command 持久化
 
-每次 `UserPromptSubmit` 触发时，`agent-hook.py` 把当前 session 对应的恢复 CLI（Claude → `claude --resume <session_id>`；Codex → `codex resume <session_id>`）放进 `running` 事件的 `resumeCommand` 字段。`HookDispatcher` 接到后调用 `WorkspaceStore.recordResumeCommand(terminalId:command:)` **直接**写到对应 workspace 的 `pendingPrefills[terminalId]` 并同步持久化到 UserDefaults——保留**最新**那一条（用户 `/clear` 或 `/resume` 切到新 session 时旧 id 立即被覆盖）。
+每次 `UserPromptSubmit` 触发时，`agent-hook.py` 把当前 session 对应的恢复 CLI（Claude → `claude --resume <session_id>`；Codex → `codex resume <session_id>`）放进 `running` 事件的 `resumeCommand` 字段。`HookDispatcher` 接到后**双重 gate**：必须同时满足该 agent 的状态通知 toggle (`mux0-agent-status-<agent>`) 与恢复 toggle (`mux0-agent-resume-<agent>`) 都为 `true`，才会调用 `WorkspaceStore.recordResumeCommand(terminalId:command:)` 写到对应 workspace 的 `pendingPrefills[terminalId]` 并同步持久化——保留**最新**那一条（`/clear` / `/resume` 切到新 session 时旧 id 立即被覆盖）。
+
+恢复 toggle 默认 OFF。Settings → Agents 把 toggle 拆成 "Notifications"（控制状态图标）与 "Resume on Launch"（控制本节）两个分组：用户必须显式打开 Resume 行 mux0 才会在磁盘上保留 session id。
 
 不依赖 `NSApplication.willTerminateNotification` 做"退出时提升"——⌘Q / 关窗 / 强退 / 崩溃路径下 willTerminate 触发与否不可靠，每次 hook 收到时立刻 save 才是稳定的持久化点。
 
-下次启动 surface 时，`TabContentView.terminalViewFor` 通过 `consumePendingPrefill(terminalId:)` 读取该值，作为 `GhosttyTerminalView.command` 传入——优先级高于 workspace `defaultCommand`。
+下次启动 surface 时，`TabContentView.resolvedStartupCommand(forTerminal:)` 通过 `consumePendingPrefill(terminalId:)` 读取该值，再走一遍 **读端 gate**：用 `HookMessage.Agent.fromResumeCommand` 按 prefix 反推 agent，看 `mux0-agent-resume-<agent>` 是否仍为 `true`，否则降级到 workspace `defaultCommand`。读端 gate 必要——它兜住"老版本写盘 / 用户在另一台机器同步了 UserDefaults / toggle 切换时机异常"导致的 stale 旧值。
 
 读取**不**清空：pendingPrefills 持久保留"最近一次的恢复命令"，只在下一次新 prompt 触发 `recordResumeCommand` 时被覆盖。这保证"重启 → 自动恢复 → 没发任何 prompt → 再重启"仍然能恢复同一会话；代价是用户手动退出 agent 之后该字段会变 stale，下次重启仍会自动 `claude --resume <id>`，不过 claude/codex 都接受任意旧 session id（只是恢复一段久远对话），不会报错。
+
+**关 toggle 的副作用**：用户在 Settings 把某个 agent 的 Resume 从 ON 切到 OFF 时，`AgentResumeToggleRow` 的 setter 立刻调 `WorkspaceStore.clearResumePrefills(forAgent:)`——按 prefix（`claude ` / `codex `）扫描所有 workspace 的 pendingPrefills，把该 agent 的旧值清掉。下一次启动就回到裸 shell（或 `defaultCommand`），不会再 auto-resume。
+
+**关闭 tab / pane 的副作用**：`closeTerminal` 删该 terminal 的 prefill 一项；`removeTab` 把整 tab 内所有 leaf 的 prefill 全删——避免已死 UUID 的恢复命令永远赖在 UserDefaults 里。
 
 **注入路径**：与 `defaultCommand` 完全相同——`WorkspaceDefaultCommand.startupInput(for:)` 在尾部加 `\n`，由 `GhosttyBridge.newSurface` 通过 ghostty 的 `surfCfg.initial_input` 喂入 PTY，shell 启动后 readline 读到立即执行。
 
 `initial_input` 在 shell 启动之前会先把字节绘制到 surface 一次（PTY echo 路径之外的渲染层副作用），但 Claude / Codex 的 TUI 启动后立即切换到 alternate screen buffer，整屏接管后顶部那行幽灵 echo 被自动覆盖，用户实际感知不到。早期尝试过用 `ghostty_surface_text` 在 OSC 7 之后延时注入避开这一行，也尝试过用 env var + zsh shim eval 完全绕过 PTY，最终还是回到这个方案——简单、不依赖 shell 类型、与现有 `defaultCommand` 路径同构。
 
-**v1 限制**：OpenCode 因为没有稳定的 `--resume <id>` CLI 形态，`resume_command_for("opencode", ...)` 返回空串，插件不发该字段。后续如果 opencode 加上 stable resume 语法，只需扩展 `resume_command_for` 即可。
+**Session id 校验**：`resume_command_for` 在拼 CLI 之前用 `[A-Za-z0-9_-]+` 白名单检查 session_id；不匹配直接返回空串，hook 不发 `resumeCommand`。这是防御层——agent 端的 session id 都是 UUID 形态，但万一被恶意 / 畸形 payload 污染（含空格、`;`、反引号等 shell 元字符），下次启动作为 `initial_input` 喂给 shell 时不会变成命令注入。
+
+**OpenCode 的 sessionID 来源**：OpenCode 不走 Python hook，由 `Resources/agent-hooks/opencode-plugin/mux0-status.js` 直接 emit 到同一个 Unix socket。`tool.execute.before` 钩子的 `input.sessionID` 就是当前 session id；plugin 拼成 `opencode --session <sessionID>` 放进 `resumeCommand`，跟 claude/codex 路径同构。`session.created` / `session.idle` 等纯 event 钩子拿不到 sessionID，所以 resume 是绑定在 tool 调用边界上的——一个 turn 通常会调多个 tool，每次都附 resumeCommand，mux0 端的 equality guard 自动 dedup 写盘。`agent-hook.py` 的 `resume_command_for` 同时也保留了 opencode 分支，作为 CLI 形态的 single source of truth（即便 Python 端永远不会被 opencode 调用）。
 
 ## 各 Agent 的信号来源
 

--- a/docs/settings-reference.md
+++ b/docs/settings-reference.md
@@ -62,7 +62,11 @@ mux0 的设置面板分成六个 tab：**Appearance（外观）**、**Font（字
 
 ## 5. Agents
 
-控制哪些 code agent 会在 sidebar / tab 上显示状态图标。三个 agent 独立开关，默认全部关闭。至少打开一个时，图标列才会出现在 UI 上。
+设置面板分成两个分组：**Notifications** 控制状态图标；**Resume on Launch** 控制下次启动时是否自动恢复上次的 agent 会话。两个分组下的开关互相独立，默认全部关闭。底部 **Reset** 一次性清掉本 tab 的全部 key。
+
+### 5.1 Notifications
+
+控制哪些 code agent 会在 sidebar / tab 上显示状态图标。至少打开一个时，图标列才会出现在 UI 上。
 
 | 设置项 | config key | 默认值 | 说明 |
 |---|---|---|---|
@@ -70,11 +74,23 @@ mux0 的设置面板分成六个 tab：**Appearance（外观）**、**Font（字
 | Codex | `mux0-agent-status-codex` | `false` | 同上，对应 Codex wrapper。Codex 需要用户在 `~/.codex/config.toml` 中显式打开 `[features] codex_hooks = true`，否则只有 turn 完成事件，见 `docs/agent-hooks.md#codex-的特殊规则`。 |
 | OpenCode | `mux0-agent-status-opencode` | `false` | 同上，对应 OpenCode 插件。 |
 
-**扩展性**：将来新增 code agent 时，`HookMessage.Agent` 枚举加一个 case，Settings → Agents 分组里会自动多出一行 Toggle（managed keys + 行列表均由 `.allCases` 派生）。
+### 5.2 Resume on Launch
+
+启用后，每次 `UserPromptSubmit` 都会把 `claude --resume <id>` / `codex resume <id>` 持久化到对应 terminal 的 `pendingPrefills`；下次启动该 terminal 时自动把这条命令塞进 shell 执行（优先级高于侧边栏 `defaultCommand`）。详见 `docs/agent-hooks.md#resume-command-持久化`。
+
+| 设置项 | config key | 默认值 | 说明 |
+|---|---|---|---|
+| Claude Code | `mux0-agent-resume-claude` | `false` | 开启后，每次 `UserPromptSubmit` 都把 `claude --resume <session_id>` 落盘；关闭时 `HookDispatcher` 直接丢弃 `resumeCommand` 字段，且立刻调 `WorkspaceStore.clearResumePrefills(forAgent: .claude)` 把已存的 claude 命令全清空。 |
+| OpenCode | `mux0-agent-resume-opencode` | `false` | 同上，对应 OpenCode（命令形态 `opencode --session <id>`）。session id 由 `mux0-status.js` plugin 在 `tool.execute.before` 的 `input.sessionID` 拿到，每次 tool 调用都附；mux0 端 equality guard 自动 dedup。 |
+| Codex | `mux0-agent-resume-codex` | `false` | 同上，对应 Codex。需要先开 5.1 里的 Codex 通知开关（hook 才会跑）。 |
+
+**扩展性**：将来新增 code agent 时，`HookMessage.Agent` 枚举加一个 case；Notifications 分组自动多出一行 Toggle（managed keys + 行列表均由 `.allCases` 派生）。Resume 分组里所有 `supportsResume` 返回 true 的 agent 都会渲染，所以新 agent 默认 supportsResume = false，等到把 wrapper 端的 `resume_command_for` / plugin 接好且 `Agent.supportsResume` 改成 true = 自动出现在 UI。
 
 **行为细节**：
-- 开关全部关闭 → sidebar / tab 的状态图标列整列折叠（等同于该功能被禁用）。
-- 某 agent 开关 ON → OFF：已落盘到 `TerminalStatusStore` 的状态会残留（不再收到后续事件也无法自动清理）；新事件被丢弃。这是已知边缘场景。
+- Notifications 全关 → sidebar / tab 的状态图标列整列折叠（等同于该功能被禁用）。
+- Notifications 某 agent 开关 ON → OFF：已落盘到 `TerminalStatusStore` 的状态会残留（不再收到后续事件也无法自动清理）；新事件被丢弃。这是已知边缘场景。
+- Resume ON → OFF 立刻按 prefix（`claude ` / `codex `）扫所有 workspace 的 pendingPrefills，把对应 agent 的旧值清空——保证关 toggle 的下一次启动不会再 auto-resume。
+- 关闭一个跑过 agent 的 tab / pane 时，`closeTerminal` / `removeTab` 会同步把对应 terminalId 的 pendingPrefill 一起删掉，避免 UserDefaults 里堆积已死 UUID 的命令。
 - 老 key `mux0-status-indicators`：2026-04 之前存在的主开关。从代码中移除；如果仍保留在你的 mux0 config 文件里，mux0 不再读取，手动删除即可。
 
 ---

--- a/mux0.xcodeproj/project.pbxproj
+++ b/mux0.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		6AA362AD3255878AD318860E /* TerminalStatusIconViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC8D978AA26C3DD97EF58200 /* TerminalStatusIconViewTests.swift */; };
 		6EF0E2148355BAE5EEE90A2A /* SettingsConfigStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B3D7EB9C3386BAF73077239 /* SettingsConfigStore.swift */; };
 		710F3420134F2A1296D1CA1F /* BoundControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B95FF6C4289EE3D48831A08 /* BoundControls.swift */; };
+		724E2546197F4E6FD8F95B65 /* DraggedSnapshotShadow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531109F006EA4DC2299C7FC2 /* DraggedSnapshotShadow.swift */; };
 		749811FA06D8580CF545268A /* TextLinkButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2794897A7761B77AEFEC405F /* TextLinkButton.swift */; };
 		764C52B851F870CEAD204A76 /* SettingsResetRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6828870E05C9747F55C30BEE /* SettingsResetRow.swift */; };
 		7BB3ED2855848925E919A2EE /* AgentsSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98AEAE23A5BABC68B717A3C5 /* AgentsSectionView.swift */; };
@@ -122,6 +123,7 @@
 		4AB9513EB0F425DDEDAFA246 /* L10nSmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = L10nSmokeTests.swift; sourceTree = "<group>"; };
 		4BE3C12A39B918898C929585 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		500DC5FBA84EA82E83A79C79 /* PlaceholderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceholderTests.swift; sourceTree = "<group>"; };
+		531109F006EA4DC2299C7FC2 /* DraggedSnapshotShadow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraggedSnapshotShadow.swift; sourceTree = "<group>"; };
 		5DEC02C6A3912B9FFA44F2E2 /* SurfaceScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceScrollView.swift; sourceTree = "<group>"; };
 		6172CA48D21FC80F732CB23A /* HookSocketListenerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookSocketListenerTests.swift; sourceTree = "<group>"; };
 		65EACD3F08D21F717F82A9A0 /* ThemedTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemedTextField.swift; sourceTree = "<group>"; };
@@ -233,6 +235,7 @@
 			children = (
 				EFFA7A6778F19840BCAE2246 /* AppTheme.swift */,
 				EE58F1D0F1F79A6A03712FD9 /* DesignTokens.swift */,
+				531109F006EA4DC2299C7FC2 /* DraggedSnapshotShadow.swift */,
 				F58750DF02302B3749F21937 /* GhosttyConfigReader.swift */,
 				0052317F2679AB0572F50932 /* IconButton.swift */,
 				0B75BC1D38F67C220D3F82A8 /* TerminalStatusIconView.swift */,
@@ -610,6 +613,7 @@
 				710F3420134F2A1296D1CA1F /* BoundControls.swift in Sources */,
 				BE855766F2E7E0E965AE4335 /* ContentView.swift in Sources */,
 				D1FCB41AE29A916D0B66F0B7 /* DesignTokens.swift in Sources */,
+				724E2546197F4E6FD8F95B65 /* DraggedSnapshotShadow.swift in Sources */,
 				9688B5112BE4CAA8A86ACC76 /* FontPickerView.swift in Sources */,
 				50E89BB982BD02982F6B9B47 /* FontSectionView.swift in Sources */,
 				2BB1606A5799193109DE274C /* GhosttyBridge.swift in Sources */,

--- a/mux0/Bridge/TabBridge.swift
+++ b/mux0/Bridge/TabBridge.swift
@@ -5,6 +5,7 @@ struct TabBridge: NSViewRepresentable {
     @Bindable var store: WorkspaceStore
     @Bindable var statusStore: TerminalStatusStore
     @Bindable var pwdStore: TerminalPwdStore
+    @Bindable var settings: SettingsConfigStore
     var theme: AppTheme
     /// ghostty `background-opacity`，用来给 AppKit layer 背景（canvas / sidebar strip）
     /// 加 alpha —— 不动 theme token 本身，避免派生出的 border/text 色也被乘透。
@@ -22,6 +23,7 @@ struct TabBridge: NSViewRepresentable {
         let view = TabContentView(frame: .zero)
         view.store = store
         view.pwdStore = pwdStore
+        view.settingsStore = settings
         view.applyTheme(theme, backgroundOpacity: backgroundOpacity, locale: locale)
         if let ws = store.selectedWorkspace {
             view.loadWorkspace(ws,
@@ -35,6 +37,7 @@ struct TabBridge: NSViewRepresentable {
         _ = languageTick
         nsView.store = store
         nsView.pwdStore = pwdStore
+        nsView.settingsStore = settings
         nsView.applyTheme(theme, backgroundOpacity: backgroundOpacity, locale: locale)
         if let ws = store.selectedWorkspace {
             nsView.loadWorkspace(ws,

--- a/mux0/ContentView.swift
+++ b/mux0/ContentView.swift
@@ -170,10 +170,12 @@ struct ContentView: View {
                     let listener = try HookSocketListener(path: path)
                     let store = self.statusStore
                     let settingsStoreRef = self.settingsStore
+                    let workspaceStoreRef = self.store
                     listener.onMessage = { msg in
                         HookDispatcher.dispatch(msg,
                                                 settings: settingsStoreRef,
-                                                store: store)
+                                                store: store,
+                                                workspaceStore: workspaceStoreRef)
                     }
                     try listener.start()
                     hookListener = listener

--- a/mux0/ContentView.swift
+++ b/mux0/ContentView.swift
@@ -91,6 +91,24 @@ struct ContentView: View {
                 }
                 .background(Color(themeManager.theme.canvas).opacity(contentBg))
                 .clipShape(RoundedRectangle(cornerRadius: cardRadius, style: .continuous))
+                .overlay {
+                    // 浅边框：颜色取 theme.border，alpha 随 contentShadowIntensity 线性缩放。
+                    // 强度 = 0 时彻底不画（避免在透明背景上叠出 0 alpha 描边的 hairline 噪点）。
+                    let intensity = themeManager.contentShadowIntensity
+                    if intensity > 0 {
+                        RoundedRectangle(cornerRadius: cardRadius, style: .continuous)
+                            .strokeBorder(
+                                Color(themeManager.theme.border).opacity(Double(intensity) * 0.6),
+                                lineWidth: DT.Stroke.hairline
+                            )
+                    }
+                }
+                .shadow(
+                    color: .black.opacity(Double(themeManager.contentShadowIntensity) * 0.18),
+                    radius: 6 + themeManager.contentShadowIntensity * 6,
+                    x: 0,
+                    y: 2
+                )
                 .padding(.top, trafficLightInset)
                 .padding(.leading, sidebarCollapsed ? cardInset : 0)
                 .padding(.trailing, cardInset)
@@ -235,7 +253,9 @@ struct ContentView: View {
         let blur = CGFloat(blurRaw.flatMap { Double($0) } ?? 0)
         let contentRaw = settingsStore.get("mux0-content-opacity")
         let content = CGFloat(contentRaw.flatMap { Double($0) } ?? 1.0)
-        themeManager.applyWindowEffects(opacity: opacity, blurRadius: blur, contentOpacity: content)
+        let shadowRaw = settingsStore.get("mux0-content-shadow")
+        let shadow = CGFloat(shadowRaw.flatMap { Double($0) } ?? 0)
+        themeManager.applyWindowEffects(opacity: opacity, blurRadius: blur, contentOpacity: content, contentShadow: shadow)
     }
 
     private var sidebarToggleButton: some View {

--- a/mux0/ContentView.swift
+++ b/mux0/ContentView.swift
@@ -71,6 +71,7 @@ struct ContentView: View {
                         store: store,
                         statusStore: statusStore,
                         pwdStore: pwdStore,
+                        settings: settingsStore,
                         theme: themeManager.theme,
                         backgroundOpacity: contentBg,
                         showStatusIndicators: showStatusIndicators,
@@ -84,6 +85,7 @@ struct ContentView: View {
                             theme: themeManager.theme,
                             settings: settingsStore,
                             updateStore: updateStore,
+                            workspaceStore: store,
                             initialSection: pendingSettingsSection,
                             onClose: { showSettings = false }
                         )
@@ -300,4 +302,12 @@ extension Notification.Name {
     // Settings
     static let mux0OpenSettings         = Notification.Name("mux0.openSettings")
     static let mux0EditConfigFile       = Notification.Name("mux0.editConfigFile")
+
+    /// Posted by the Agents → Notifications → Codex toggle when the user
+    /// flips it ON, so the section view can present its experimental-flag
+    /// alert. Routed via NotificationCenter (instead of an `onTurnOn`
+    /// parameter) so every row in the ForEach has an identical view
+    /// signature — Form(.grouped) splits a row out into its own card if
+    /// any neighbour differs.
+    static let mux0CodexHookAlert       = Notification.Name("mux0.codexHookAlert")
 }

--- a/mux0/Ghostty/GhosttyBridge.swift
+++ b/mux0/Ghostty/GhosttyBridge.swift
@@ -237,6 +237,15 @@ final class GhosttyBridge {
         defer { Self.envLock.unlock() }
 
         setenv("MUX0_TERMINAL_ID", terminalId.uuidString, 1)
+        // When the caller hasn't provided a working directory (e.g. a freshly
+        // created terminal whose pwdStore has no record yet), fall back to
+        // $HOME instead of letting ghostty inherit the spawning process's
+        // cwd. macOS Launch Services starts an .app with cwd = `/`, which
+        // breaks tools that refuse to run from a non-readable directory
+        // (Homebrew prints "current working directory must be readable to
+        // <user> to run brew", which then aborts a typical .zshrc midway and
+        // leaves $NVM_DIR / $PATH unset).
+        let resolvedWorkingDirectory = workingDirectory ?? NSHomeDirectory()
         let initialInput = WorkspaceDefaultCommand.startupInput(for: command)
 
         var surfCfg = ghostty_surface_config_new()
@@ -256,26 +265,16 @@ final class GhosttyBridge {
         // commands as initial shell input instead of Ghostty's `command` field:
         // if an SSH command exits quickly, the user lands back in their shell
         // rather than Ghostty treating the surface's main process as failed.
-        if let wd = workingDirectory, let input = initialInput {
-            return wd.withCString { wdPtr in
-                input.withCString { inputPtr in
-                    surfCfg.working_directory = wdPtr
-                    surfCfg.initial_input = inputPtr
-                    return ghostty_surface_new(appHandle, &surfCfg)
-                }
-            }
-        } else if let wd = workingDirectory {
-            return wd.withCString { ptr in
-                surfCfg.working_directory = ptr
+        return resolvedWorkingDirectory.withCString { wdPtr in
+            surfCfg.working_directory = wdPtr
+            guard let input = initialInput else {
                 return ghostty_surface_new(appHandle, &surfCfg)
             }
-        } else if let input = initialInput {
-            return input.withCString { ptr in
-                surfCfg.initial_input = ptr
+            return input.withCString { inputPtr in
+                surfCfg.initial_input = inputPtr
                 return ghostty_surface_new(appHandle, &surfCfg)
             }
         }
-        return ghostty_surface_new(appHandle, &surfCfg)
     }
 
     // MARK: - Window effects

--- a/mux0/Ghostty/GhosttyTerminalView.swift
+++ b/mux0/Ghostty/GhosttyTerminalView.swift
@@ -35,9 +35,9 @@ final class GhosttyTerminalView: NSView, NSTextInputClient {
     /// callbacks (e.g. COMMAND_FINISHED) back to TerminalStatusStore.
     var terminalId: UUID?
 
-    /// The workspace-level default command to type into the initial shell when this
-    /// surface is created. Set by TabContentView before the view enters a window.
-    /// Only used on first surface creation (viewDidMoveToWindow when surface == nil).
+    /// Shell command to auto-execute on first surface creation. Set by
+    /// TabContentView before the view enters a window; consumed once when
+    /// `surface == nil` in `viewDidMoveToWindow`.
     var command: String?
 
     // MARK: - Scrollbar state (consumed by SurfaceScrollView)

--- a/mux0/Localization/L10n.swift
+++ b/mux0/Localization/L10n.swift
@@ -102,6 +102,7 @@ enum L10n {
         static let backgroundOpacity    = LocalizedStringResource("settings.appearance.backgroundOpacity")
         static let backgroundBlur       = LocalizedStringResource("settings.appearance.backgroundBlur")
         static let contentOpacity       = LocalizedStringResource("settings.appearance.contentOpacity")
+        static let contentShadow        = LocalizedStringResource("settings.appearance.contentShadow")
         static let windowPaddingX       = LocalizedStringResource("settings.appearance.windowPaddingX")
         static let windowPaddingY       = LocalizedStringResource("settings.appearance.windowPaddingY")
         static let cursorStyle          = LocalizedStringResource("settings.appearance.cursorStyle")

--- a/mux0/Localization/L10n.swift
+++ b/mux0/Localization/L10n.swift
@@ -151,13 +151,17 @@ enum L10n {
             static let defaultPlaceholder  = LocalizedStringResource("settings.shell.defaultPlaceholder")
         }
         enum Agents {
-            static let claude            = LocalizedStringResource("settings.agents.claude")
-            static let codex             = LocalizedStringResource("settings.agents.codex")
-            static let opencode          = LocalizedStringResource("settings.agents.opencode")
-            static let betaBadge         = LocalizedStringResource("settings.agents.betaBadge")
-            static let codexAlertTitle   = LocalizedStringResource("settings.agents.codexAlertTitle")
-            static let codexAlertMessage = LocalizedStringResource("settings.agents.codexAlertMessage")
-            static let codexAlertOK      = LocalizedStringResource("settings.agents.codexAlertOK")
+            static let claude              = LocalizedStringResource("settings.agents.claude")
+            static let codex               = LocalizedStringResource("settings.agents.codex")
+            static let opencode            = LocalizedStringResource("settings.agents.opencode")
+            static let betaBadge           = LocalizedStringResource("settings.agents.betaBadge")
+            static let codexAlertTitle     = LocalizedStringResource("settings.agents.codexAlertTitle")
+            static let codexAlertMessage   = LocalizedStringResource("settings.agents.codexAlertMessage")
+            static let codexAlertOK        = LocalizedStringResource("settings.agents.codexAlertOK")
+            static let notificationsTitle  = LocalizedStringResource("settings.agents.notificationsTitle")
+            static let notificationsFooter = LocalizedStringResource("settings.agents.notificationsFooter")
+            static let resumeTitle         = LocalizedStringResource("settings.agents.resumeTitle")
+            static let resumeFooter        = LocalizedStringResource("settings.agents.resumeFooter")
         }
         enum Update {
             // Labels on the left column of the Form rows.

--- a/mux0/Localization/Localizable.xcstrings
+++ b/mux0/Localization/Localizable.xcstrings
@@ -155,6 +155,13 @@
         "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "内容不透明度" } }
       }
     },
+    "settings.appearance.contentShadow" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Content Shadow" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "内容阴影" } }
+      }
+    },
     "settings.appearance.cursorBlink" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/mux0/Localization/Localizable.xcstrings
+++ b/mux0/Localization/Localizable.xcstrings
@@ -372,6 +372,34 @@
         "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "OpenCode" } }
       }
     },
+    "settings.agents.notificationsTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Notifications" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "通知" } }
+      }
+    },
+    "settings.agents.notificationsFooter" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Show running / idle / finished status icons next to tabs that run the selected agents." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "在跑这些 agent 的 tab 旁显示运行 / 闲置 / 完成的状态图标。" } }
+      }
+    },
+    "settings.agents.resumeTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Resume on Launch" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "启动时恢复会话" } }
+      }
+    },
+    "settings.agents.resumeFooter" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "On next launch, auto-run `claude --resume <id>` / `codex resume <id>` to land back in the most recent session. Off by default. Turning a row off also drops any saved session id." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "下次启动时自动执行 `claude --resume <id>` / `codex resume <id>`，回到最近一次的会话。默认关闭。关闭某一行同时会清除已保存的会话 id。" } }
+      }
+    },
     "settings.section.agents" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/mux0/Models/HookDispatcher.swift
+++ b/mux0/Models/HookDispatcher.swift
@@ -15,8 +15,12 @@ import Foundation
 enum HookDispatcher {
     static func dispatch(_ msg: HookMessage,
                          settings: SettingsConfigStore,
-                         store: TerminalStatusStore) {
+                         store: TerminalStatusStore,
+                         workspaceStore: WorkspaceStore? = nil) {
         guard settings.get(msg.agent.settingsKey) == "true" else { return }
+        if let cmd = msg.resumeCommand, let ws = workspaceStore {
+            ws.recordResumeCommand(terminalId: msg.terminalId, command: cmd)
+        }
         switch msg.event {
         case .running:
             store.setRunning(terminalId: msg.terminalId,

--- a/mux0/Models/HookDispatcher.swift
+++ b/mux0/Models/HookDispatcher.swift
@@ -17,10 +17,14 @@ enum HookDispatcher {
                          settings: SettingsConfigStore,
                          store: TerminalStatusStore,
                          workspaceStore: WorkspaceStore? = nil) {
-        guard settings.get(msg.agent.settingsKey) == "true" else { return }
-        if let cmd = msg.resumeCommand, let ws = workspaceStore {
+        // Resume is gated independently from the status (notifications)
+        // toggle: a user who only wants auto-resume but doesn't want the
+        // running/idle icons should still get their session id persisted.
+        if let cmd = msg.resumeCommand, let ws = workspaceStore,
+           settings.get(msg.agent.resumeSettingsKey) == "true" {
             ws.recordResumeCommand(terminalId: msg.terminalId, command: cmd)
         }
+        guard settings.get(msg.agent.settingsKey) == "true" else { return }
         switch msg.event {
         case .running:
             store.setRunning(terminalId: msg.terminalId,

--- a/mux0/Models/HookMessage.swift
+++ b/mux0/Models/HookMessage.swift
@@ -35,6 +35,11 @@ struct HookMessage: Decodable, Equatable {
     /// Optional finished-state summary (e.g. last assistant message, ≤200 chars).
     /// Present when Claude/Codex Stop reads transcript; nil otherwise.
     let summary: String?
+    /// Optional resume command (e.g. `claude --resume <session_id>`,
+    /// `codex resume <session_id>`). Emitted on the `running` events
+    /// triggered by `UserPromptSubmit`; mux0 records the most-recent value
+    /// per terminal and replays it as the next-launch shell input.
+    let resumeCommand: String?
 
     var timestamp: Date { Date(timeIntervalSince1970: at) }
 }

--- a/mux0/Models/HookMessage.swift
+++ b/mux0/Models/HookMessage.swift
@@ -19,6 +19,25 @@ struct HookMessage: Decodable, Equatable {
 
         /// Config key used by Settings → Agents and by the listener filter.
         var settingsKey: String { "mux0-agent-status-\(rawValue)" }
+
+        /// Config key controlling whether mux0 records and replays this
+        /// agent's `--resume <id>` shell command on next launch.
+        var resumeSettingsKey: String { "mux0-agent-resume-\(rawValue)" }
+
+        /// True when the hook surface for this agent emits a stable
+        /// `resumeCommand` (claude/codex via `agent-hook.py`, opencode via
+        /// the `mux0-status.js` plugin). Used to render the Resume toggle
+        /// row only for supported agents.
+        var supportsResume: Bool { true }
+
+        /// Identify which agent owns a stored resume command by its leading
+        /// CLI token. Returns nil for malformed strings.
+        static func fromResumeCommand(_ command: String) -> Agent? {
+            if command.hasPrefix("claude ")   { return .claude }
+            if command.hasPrefix("codex ")    { return .codex }
+            if command.hasPrefix("opencode ") { return .opencode }
+            return nil
+        }
     }
 
     let terminalId: UUID

--- a/mux0/Models/Workspace.swift
+++ b/mux0/Models/Workspace.swift
@@ -147,6 +147,12 @@ struct Workspace: Codable, Identifiable, Equatable {
     var tabs: [TerminalTab]
     var selectedTabId: UUID?
     var defaultCommand: String?
+    /// Per-terminal one-shot command (key = terminalId.uuidString) to inject
+    /// as the next surface's `initial_input`. Persisted synchronously on
+    /// each agent `resumeCommand` so the latest session id survives
+    /// ⌘Q / force-quit / crash without relying on `willTerminate`.
+    /// Non-destructive read; overwritten only by the next prompt.
+    var pendingPrefills: [String: String] = [:]
 
     init(id: UUID = UUID(), name: String, defaultCommand: String? = nil) {
         self.id = id
@@ -159,9 +165,35 @@ struct Workspace: Codable, Identifiable, Equatable {
     var selectedTab: TerminalTab? {
         tabs.first { $0.id == selectedTabId }
     }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, name, tabs, selectedTabId, defaultCommand, pendingPrefills
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try c.decode(UUID.self, forKey: .id)
+        self.name = try c.decode(String.self, forKey: .name)
+        self.tabs = try c.decode([TerminalTab].self, forKey: .tabs)
+        self.selectedTabId = try c.decodeIfPresent(UUID.self, forKey: .selectedTabId)
+        self.defaultCommand = try c.decodeIfPresent(String.self, forKey: .defaultCommand)
+        self.pendingPrefills = (try? c.decode([String: String].self, forKey: .pendingPrefills)) ?? [:]
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(id, forKey: .id)
+        try c.encode(name, forKey: .name)
+        try c.encode(tabs, forKey: .tabs)
+        try c.encodeIfPresent(selectedTabId, forKey: .selectedTabId)
+        try c.encodeIfPresent(defaultCommand, forKey: .defaultCommand)
+        try c.encode(pendingPrefills, forKey: .pendingPrefills)
+    }
 }
 
 enum WorkspaceDefaultCommand {
+    /// Build the auto-executing `initial_input` payload for a new ghostty
+    /// surface. Trailing `\n` makes the shell run it immediately.
     static func startupInput(for command: String?) -> String? {
         let trimmed = command?.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let trimmed, !trimmed.isEmpty else { return nil }

--- a/mux0/Models/WorkspaceStore.swift
+++ b/mux0/Models/WorkspaceStore.swift
@@ -113,6 +113,11 @@ final class WorkspaceStore {
         guard let wsIdx = wsIndex(workspaceId) else { return }
         // Find the index before removal so we can select the adjacent tab
         let closedIdx = workspaces[wsIdx].tabs.firstIndex(where: { $0.id == id })
+        if let tIdx = closedIdx {
+            for tid in workspaces[wsIdx].tabs[tIdx].layout.allTerminalIds() {
+                workspaces[wsIdx].pendingPrefills.removeValue(forKey: tid.uuidString)
+            }
+        }
         workspaces[wsIdx].tabs.removeAll { $0.id == id }
         if workspaces[wsIdx].tabs.isEmpty {
             let replacement = makeNewTab(index: 1)
@@ -166,6 +171,7 @@ final class WorkspaceStore {
         let tab = workspaces[wsIdx].tabs[tIdx]
         if let newLayout = tab.layout.removing(terminalId: terminalId) {
             workspaces[wsIdx].tabs[tIdx].layout = newLayout
+            workspaces[wsIdx].pendingPrefills.removeValue(forKey: terminalId.uuidString)
             if tab.focusedTerminalId == terminalId {
                 // Safe: newLayout is non-nil so it contains at least one terminal
                 workspaces[wsIdx].tabs[tIdx].focusedTerminalId =
@@ -205,6 +211,35 @@ final class WorkspaceStore {
               let tIdx = tabIndex(tabId, in: wsIdx) else { return }
         workspaces[wsIdx].tabs[tIdx].layout = layout
         save()
+    }
+
+    // MARK: - Agent resume / prefill
+
+    private func wsIndexContaining(terminalId: UUID) -> Int? {
+        workspaces.firstIndex { ws in
+            ws.tabs.contains { $0.layout.allTerminalIds().contains(terminalId) }
+        }
+    }
+
+    /// Persist the latest agent resume command for `terminalId`. Synchronous
+    /// save — the value must survive force-quit / crash with no termination
+    /// hook. No-op when unchanged.
+    func recordResumeCommand(terminalId: UUID, command: String) {
+        let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              let wsIdx = wsIndexContaining(terminalId: terminalId) else { return }
+        let key = terminalId.uuidString
+        guard workspaces[wsIdx].pendingPrefills[key] != trimmed else { return }
+        workspaces[wsIdx].pendingPrefills[key] = trimmed
+        save()
+    }
+
+    /// Non-destructive read: a relaunch that lands back inside the agent and
+    /// quits without typing a new prompt should still resume the same session
+    /// next time. Only the next `recordResumeCommand` overwrites.
+    func consumePendingPrefill(terminalId: UUID) -> String? {
+        guard let wsIdx = wsIndexContaining(terminalId: terminalId) else { return nil }
+        return workspaces[wsIdx].pendingPrefills[terminalId.uuidString]
     }
 
     // MARK: - Helpers

--- a/mux0/Models/WorkspaceStore.swift
+++ b/mux0/Models/WorkspaceStore.swift
@@ -242,6 +242,24 @@ final class WorkspaceStore {
         return workspaces[wsIdx].pendingPrefills[terminalId.uuidString]
     }
 
+    /// Drop every stored resume command for the given agent. Called when the
+    /// user turns the Resume toggle off, so the change takes effect on next
+    /// launch instead of waiting for the stale entry to be overwritten.
+    func clearResumePrefills(forAgent agent: HookMessage.Agent) {
+        guard agent.supportsResume else { return }
+        var changed = false
+        for i in workspaces.indices {
+            let kept = workspaces[i].pendingPrefills.filter {
+                HookMessage.Agent.fromResumeCommand($0.value) != agent
+            }
+            if kept.count != workspaces[i].pendingPrefills.count {
+                workspaces[i].pendingPrefills = kept
+                changed = true
+            }
+        }
+        if changed { save() }
+    }
+
     // MARK: - Helpers
 
     private func makeNewTab(index: Int) -> TerminalTab {

--- a/mux0/Settings/Components/SettingsResetRow.swift
+++ b/mux0/Settings/Components/SettingsResetRow.swift
@@ -7,6 +7,11 @@ import SwiftUI
 struct SettingsResetRow: View {
     let settings: SettingsConfigStore
     let keys: [String]
+    /// Sections that own state outside `SettingsConfigStore` (e.g. Agents'
+    /// per-terminal `pendingPrefills` in `WorkspaceStore`) pass a closure
+    /// here so the destructive reset clears that state too — otherwise the
+    /// row would only delete the config keys and leave related state stale.
+    var additionalAction: () -> Void = { }
 
     @State private var confirmingReset = false
     @Environment(\.locale) private var locale
@@ -28,6 +33,7 @@ struct SettingsResetRow: View {
                 for key in keys {
                     settings.set(key, nil)
                 }
+                additionalAction()
             }
             Button(String(localized: (L10n.Settings.resetCancel).withLocale(locale)), role: .cancel) { }
         } message: {

--- a/mux0/Settings/Sections/AgentsSectionView.swift
+++ b/mux0/Settings/Sections/AgentsSectionView.swift
@@ -55,7 +55,20 @@ struct AgentsSectionView: View {
                     .foregroundColor(Color(theme.textTertiary))
             }
 
-            SettingsResetRow(settings: settings, keys: Self.managedKeys)
+            SettingsResetRow(
+                settings: settings,
+                keys: Self.managedKeys,
+                additionalAction: {
+                    // pendingPrefills are read non-destructively, so wiping
+                    // the resume toggle keys alone would leave them in
+                    // place and replay on the next launch when the user
+                    // re-enables Resume. Mirror the per-row OFF transition
+                    // here for every resume-capable agent.
+                    for agent in HookMessage.Agent.allCases where agent.supportsResume {
+                        workspaceStore.clearResumePrefills(forAgent: agent)
+                    }
+                }
+            )
         }
         .formStyle(.grouped)
         .scrollContentBackground(.hidden)

--- a/mux0/Settings/Sections/AgentsSectionView.swift
+++ b/mux0/Settings/Sections/AgentsSectionView.swift
@@ -3,10 +3,16 @@ import SwiftUI
 struct AgentsSectionView: View {
     let theme: AppTheme
     let settings: SettingsConfigStore
+    let workspaceStore: WorkspaceStore
 
-    /// All config keys this section manages. Data-driven from `HookMessage.Agent.allCases`
-    /// so adding a new agent (enum case) auto-registers it with the reset button.
-    private static let managedKeys: [String] = HookMessage.Agent.allCases.map(\.settingsKey)
+    /// Every config key this section manages — both notification toggles
+    /// (all agents) and resume toggles (claude/codex only). Used by the
+    /// "Restore Defaults" reset row to clear them in one shot.
+    private static let managedKeys: [String] = {
+        let status = HookMessage.Agent.allCases.map(\.settingsKey)
+        let resume = HookMessage.Agent.allCases.filter(\.supportsResume).map(\.resumeSettingsKey)
+        return status + resume
+    }()
 
     /// Codex hooks are gated behind an experimental flag (`[features].codex_hooks = true`
     /// in `~/.codex/config.toml`). The wrapper can't flip it for the user — the flag
@@ -16,14 +22,39 @@ struct AgentsSectionView: View {
 
     var body: some View {
         Form {
-            ForEach(HookMessage.Agent.allCases) { agent in
-                AgentToggleRow(
-                    theme: theme,
-                    settings: settings,
-                    agent: agent,
-                    onTurnOn: agent == .codex ? { showingCodexAlert = true } : nil
-                )
+            // ForEach + Section under Form(.grouped) on macOS 26.4 has a
+            // layout quirk: the 3rd ForEach row gets ejected from the
+            // section card (the first two render with shared rounded
+            // background, the third loses it). Listing rows explicitly
+            // sidesteps it. Same expansion rule applies to future agents
+            // — the array literal stays the single source of truth.
+            Section {
+                AgentToggleRow(theme: theme, settings: settings, agent: .claude)
+                AgentToggleRow(theme: theme, settings: settings, agent: .opencode)
+                AgentToggleRow(theme: theme, settings: settings, agent: .codex)
+            } header: {
+                Text(L10n.Settings.Agents.notificationsTitle)
+            } footer: {
+                Text(L10n.Settings.Agents.notificationsFooter)
+                    .font(Font(DT.Font.small))
+                    .foregroundColor(Color(theme.textTertiary))
             }
+
+            Section {
+                AgentResumeToggleRow(theme: theme, settings: settings,
+                                     workspaceStore: workspaceStore, agent: .claude)
+                AgentResumeToggleRow(theme: theme, settings: settings,
+                                     workspaceStore: workspaceStore, agent: .opencode)
+                AgentResumeToggleRow(theme: theme, settings: settings,
+                                     workspaceStore: workspaceStore, agent: .codex)
+            } header: {
+                Text(L10n.Settings.Agents.resumeTitle)
+            } footer: {
+                Text(L10n.Settings.Agents.resumeFooter)
+                    .font(Font(DT.Font.small))
+                    .foregroundColor(Color(theme.textTertiary))
+            }
+
             SettingsResetRow(settings: settings, keys: Self.managedKeys)
         }
         .formStyle(.grouped)
@@ -36,17 +67,21 @@ struct AgentsSectionView: View {
         } message: {
             Text(L10n.Settings.Agents.codexAlertMessage)
         }
+        .onReceive(NotificationCenter.default.publisher(for: .mux0CodexHookAlert)) { _ in
+            showingCodexAlert = true
+        }
     }
 }
 
-/// One row per agent: label + BETA badge + trailing toggle.
-/// When `onTurnOn` is provided, it fires once on each false→true transition
-/// (used by Codex to surface the experimental-flag alert).
+/// Notifications row: per-agent label + BETA badge + status toggle.
+/// All rows share an identical view signature — Codex's experimental-flag
+/// alert is fired via NotificationCenter from inside the binding setter so
+/// the row struct doesn't need a per-agent callback parameter (which would
+/// cause Form(.grouped) to split that row out into its own card).
 private struct AgentToggleRow: View {
     let theme: AppTheme
     let settings: SettingsConfigStore
     let agent: HookMessage.Agent
-    let onTurnOn: (() -> Void)?
 
     var body: some View {
         LabeledContent {
@@ -70,7 +105,45 @@ private struct AgentToggleRow: View {
             set: { newValue in
                 let wasOn = settings.get(agent.settingsKey)?.lowercased() == "true"
                 settings.set(agent.settingsKey, newValue ? "true" : nil)
-                if newValue && !wasOn { onTurnOn?() }
+                if newValue && !wasOn && agent == .codex {
+                    NotificationCenter.default.post(name: .mux0CodexHookAlert, object: nil)
+                }
+            }
+        )
+    }
+}
+
+/// Resume row: same shape as the notifications row, but the off-transition
+/// also drops every saved resume command for this agent so the change takes
+/// effect at the very next launch.
+private struct AgentResumeToggleRow: View {
+    let theme: AppTheme
+    let settings: SettingsConfigStore
+    let workspaceStore: WorkspaceStore
+    let agent: HookMessage.Agent
+
+    var body: some View {
+        LabeledContent {
+            Toggle("", isOn: binding)
+                .labelsHidden()
+                .toggleStyle(.switch)
+        } label: {
+            HStack(spacing: DT.Space.sm) {
+                Text(agent.label)
+                BetaBadge(theme: theme)
+            }
+        }
+    }
+
+    private var binding: Binding<Bool> {
+        Binding(
+            get: {
+                guard let raw = settings.get(agent.resumeSettingsKey) else { return false }
+                return raw.lowercased() == "true"
+            },
+            set: { newValue in
+                settings.set(agent.resumeSettingsKey, newValue ? "true" : nil)
+                if !newValue { workspaceStore.clearResumePrefills(forAgent: agent) }
             }
         )
     }

--- a/mux0/Settings/Sections/AppearanceSectionView.swift
+++ b/mux0/Settings/Sections/AppearanceSectionView.swift
@@ -12,6 +12,7 @@ struct AppearanceSectionView: View {
         "background-opacity",
         "background-blur-radius",
         "mux0-content-opacity",
+        "mux0-content-shadow",
         "window-padding-x",
         "window-padding-y",
         "cursor-style",
@@ -48,6 +49,15 @@ struct AppearanceSectionView: View {
                 range: 0.0...1.0,
                 step: 0.05,
                 label: L10n.Settings.contentOpacity
+            )
+
+            BoundSlider(
+                settings: settings,
+                key: "mux0-content-shadow",
+                defaultValue: 0,
+                range: 0.0...1.0,
+                step: 0.05,
+                label: L10n.Settings.contentShadow
             )
 
             BoundStepper(

--- a/mux0/Settings/SettingsView.swift
+++ b/mux0/Settings/SettingsView.swift
@@ -4,6 +4,7 @@ struct SettingsView: View {
     let theme: AppTheme
     let settings: SettingsConfigStore
     let updateStore: UpdateStore
+    let workspaceStore: WorkspaceStore
     let onClose: () -> Void
 
     @Environment(ThemeManager.self) private var themeManager
@@ -14,12 +15,14 @@ struct SettingsView: View {
         theme: AppTheme,
         settings: SettingsConfigStore,
         updateStore: UpdateStore,
+        workspaceStore: WorkspaceStore,
         initialSection: SettingsSection? = nil,
         onClose: @escaping () -> Void
     ) {
         self.theme = theme
         self.settings = settings
         self.updateStore = updateStore
+        self.workspaceStore = workspaceStore
         self.onClose = onClose
         _section = State(initialValue: initialSection ?? .appearance)
     }
@@ -69,7 +72,7 @@ struct SettingsView: View {
         case .font:       FontSectionView(theme: theme, settings: settings)
         case .terminal:   TerminalSectionView(theme: theme, settings: settings)
         case .shell:      ShellSectionView(theme: theme, settings: settings)
-        case .agents:     AgentsSectionView(theme: theme, settings: settings)
+        case .agents:     AgentsSectionView(theme: theme, settings: settings, workspaceStore: workspaceStore)
         case .update:     UpdateSectionView(theme: theme, updateStore: updateStore)
         }
     }

--- a/mux0/Sidebar/WorkspaceListView.swift
+++ b/mux0/Sidebar/WorkspaceListView.swift
@@ -682,18 +682,23 @@ private final class WorkspaceRowItemView: NSView, NSTextFieldDelegate, NSDraggin
         let pbItem = NSPasteboardItem()
         pbItem.setString(workspaceId.uuidString, forType: .mux0Workspace)
 
+        let (ghost, frame) = snapshotForDragging()
         let draggingItem = NSDraggingItem(pasteboardWriter: pbItem)
-        draggingItem.setDraggingFrame(bounds, contents: snapshotForDragging())
+        draggingItem.setDraggingFrame(frame, contents: ghost)
 
         beginDraggingSession(with: [draggingItem], event: event, source: self)
     }
 
-    private func snapshotForDragging() -> NSImage {
-        guard let rep = bitmapImageRepForCachingDisplay(in: bounds) else { return NSImage() }
+    private func snapshotForDragging() -> (image: NSImage, frame: NSRect) {
+        guard let rep = bitmapImageRepForCachingDisplay(in: bounds) else {
+            return (NSImage(), bounds)
+        }
         cacheDisplay(in: bounds, to: rep)
-        let image = NSImage(size: bounds.size)
-        image.addRepresentation(rep)
-        return image
+        let raw = NSImage(size: bounds.size)
+        raw.addRepresentation(rep)
+        return DraggedSnapshotShadow.compose(content: raw,
+                                             contentSize: bounds.size,
+                                             cornerRadius: DT.Radius.row)
     }
 
     // NSDraggingSource

--- a/mux0/TabContent/TabBarView.swift
+++ b/mux0/TabContent/TabBarView.swift
@@ -565,19 +565,23 @@ private final class TabItemView: NSView, NSTextFieldDelegate, NSDraggingSource {
         let pbItem = NSPasteboardItem()
         pbItem.setString(tabId.uuidString, forType: .mux0Tab)
 
+        let (ghost, frame) = snapshotForDragging()
         let draggingItem = NSDraggingItem(pasteboardWriter: pbItem)
-        let snapshot = snapshotForDragging()
-        draggingItem.setDraggingFrame(bounds, contents: snapshot)
+        draggingItem.setDraggingFrame(frame, contents: ghost)
 
         beginDraggingSession(with: [draggingItem], event: event, source: self)
     }
 
-    private func snapshotForDragging() -> NSImage {
-        guard let rep = bitmapImageRepForCachingDisplay(in: bounds) else { return NSImage() }
+    private func snapshotForDragging() -> (image: NSImage, frame: NSRect) {
+        guard let rep = bitmapImageRepForCachingDisplay(in: bounds) else {
+            return (NSImage(), bounds)
+        }
         cacheDisplay(in: bounds, to: rep)
-        let image = NSImage(size: bounds.size)
-        image.addRepresentation(rep)
-        return image
+        let raw = NSImage(size: bounds.size)
+        raw.addRepresentation(rep)
+        return DraggedSnapshotShadow.compose(content: raw,
+                                             contentSize: bounds.size,
+                                             cornerRadius: TabBarView.pillRadius)
     }
 
     // NSDraggingSource

--- a/mux0/TabContent/TabContentView.swift
+++ b/mux0/TabContent/TabContentView.swift
@@ -234,7 +234,8 @@ final class TabContentView: NSView {
         let tv = GhosttyTerminalView(frame: .zero)
         tv.terminalId = id
         tv.pwdStoreRef = pwdStore
-        tv.command = store?.selectedWorkspace?.defaultCommand
+        tv.command = store?.consumePendingPrefill(terminalId: id)
+            ?? store?.selectedWorkspace?.defaultCommand
         terminalViews[id] = tv
         return tv
     }

--- a/mux0/TabContent/TabContentView.swift
+++ b/mux0/TabContent/TabContentView.swift
@@ -22,6 +22,9 @@ import AppKit
 final class TabContentView: NSView {
     var store: WorkspaceStore?
     var pwdStore: TerminalPwdStore?
+    /// Used only by `terminalViewFor` to gate consumption of pending agent
+    /// resume commands against the user's Settings → Agents → Resume toggle.
+    var settingsStore: SettingsConfigStore?
 
     private var theme: AppTheme = .systemFallback(isDark: true)
     /// Mirror of ghostty `background-opacity`. Applied to paneContainer's layer so
@@ -234,10 +237,25 @@ final class TabContentView: NSView {
         let tv = GhosttyTerminalView(frame: .zero)
         tv.terminalId = id
         tv.pwdStoreRef = pwdStore
-        tv.command = store?.consumePendingPrefill(terminalId: id)
-            ?? store?.selectedWorkspace?.defaultCommand
+        tv.command = resolvedStartupCommand(forTerminal: id)
         terminalViews[id] = tv
         return tv
+    }
+
+    /// Pick the shell command to auto-execute on a fresh surface. Source order:
+    ///   1. Pending agent resume command (`claude --resume <id>` /
+    ///      `codex resume <id>`) — only when the matching agent's Resume
+    ///      toggle in Settings is ON. Default OFF means stale UserDefaults
+    ///      entries from earlier runs (or before the toggle existed) are
+    ///      ignored, not replayed.
+    ///   2. Workspace-level `defaultCommand`.
+    private func resolvedStartupCommand(forTerminal id: UUID) -> String? {
+        if let pending = store?.consumePendingPrefill(terminalId: id),
+           let agent = HookMessage.Agent.fromResumeCommand(pending),
+           settingsStore?.get(agent.resumeSettingsKey) == "true" {
+            return pending
+        }
+        return store?.selectedWorkspace?.defaultCommand
     }
 
     private func focusTerminal(_ id: UUID) {

--- a/mux0/Theme/DraggedSnapshotShadow.swift
+++ b/mux0/Theme/DraggedSnapshotShadow.swift
@@ -1,0 +1,85 @@
+import AppKit
+
+/// Composes a "smooth shadow" stack under a row/tab snapshot for use as
+/// the dragging ghost. Approach follows Josh Comeau's layered-shadow
+/// recipe (https://www.joshwcomeau.com/css/designing-shadows/): four
+/// stacked shadows with very low individual alpha (≈0.05) and
+/// exponentially-doubling offset / blur. The effect: a soft natural
+/// falloff that reads as "lifted" without the muddy, concentrated edge
+/// that single-layer or Material-style stacks leave on translucent
+/// macOS surfaces.
+///
+/// Returned image is `padding`-pt larger on every side than the source
+/// snapshot. The accompanying frame is offset by `-padding` on x/y, so
+/// callers pass it directly to `NSDraggingItem.setDraggingFrame(_:contents:)`
+/// and the cursor stays anchored to the same point on the original row.
+enum DraggedSnapshotShadow {
+    /// Per-side padding reserved for the shadow halo. Sized so the
+    /// largest layer (offset 8pt + blur 8pt) doesn't clip at the image
+    /// edge — the visible reach of an NSShadow is ~1.5σ of its blur.
+    static let padding: CGFloat = 20
+
+    /// Four-layer smooth-shadow stack. Each pass is barely visible
+    /// alone; only the accumulation reads as shadow. Doubling
+    /// offset/blur produces a naturally-decaying falloff curve.
+    /// AppKit's NSShadow uses an unflipped coordinate space, so a
+    /// visually-down CSS offset becomes a negative `shadowOffset.height`.
+    private static let layers: [(dy: CGFloat, blur: CGFloat, alpha: CGFloat)] = [
+        (-1, 1, 0.05),
+        (-2, 2, 0.05),
+        (-4, 4, 0.05),
+        (-8, 8, 0.05),
+    ]
+
+    static func compose(content snapshot: NSImage,
+                        contentSize: NSSize,
+                        cornerRadius: CGFloat) -> (image: NSImage, frame: NSRect) {
+        let outerSize = NSSize(width: contentSize.width + padding * 2,
+                                height: contentSize.height + padding * 2)
+        let cardRect = NSRect(x: padding, y: padding,
+                              width: contentSize.width,
+                              height: contentSize.height)
+        let path = NSBezierPath(roundedRect: cardRect,
+                                 xRadius: cornerRadius,
+                                 yRadius: cornerRadius)
+
+        let composed = NSImage(size: outerSize)
+        composed.lockFocus()
+        defer { composed.unlockFocus() }
+
+        // Each layer: fill `path` with opaque black under an NSShadow.
+        // After the loop the card region is fully opaque black; we punch
+        // it back out below so the snapshot's anti-aliased edges blend
+        // cleanly with the surrounding shadow halo.
+        for layer in layers {
+            NSGraphicsContext.saveGraphicsState()
+            let shadow = NSShadow()
+            shadow.shadowOffset = NSSize(width: 0, height: layer.dy)
+            shadow.shadowBlurRadius = layer.blur
+            shadow.shadowColor = NSColor.black.withAlphaComponent(layer.alpha)
+            shadow.set()
+            NSColor.black.set()
+            path.fill()
+            NSGraphicsContext.restoreGraphicsState()
+        }
+
+        if let cgctx = NSGraphicsContext.current?.cgContext {
+            cgctx.saveGState()
+            cgctx.setBlendMode(.clear)
+            path.fill()
+            cgctx.restoreGState()
+        }
+
+        // Clip the snapshot to the rounded card so any non-rounded
+        // pixels in the source bitmap get masked into the same shape
+        // the shadow was drawn for.
+        NSGraphicsContext.saveGraphicsState()
+        path.addClip()
+        snapshot.draw(in: cardRect)
+        NSGraphicsContext.restoreGraphicsState()
+
+        let frame = NSRect(x: -padding, y: -padding,
+                           width: outerSize.width, height: outerSize.height)
+        return (composed, frame)
+    }
+}

--- a/mux0/Theme/ThemeManager.swift
+++ b/mux0/Theme/ThemeManager.swift
@@ -30,6 +30,12 @@ final class ThemeManager {
     /// 画"中间内容"底色的视图都读它，以保证两档设置的组合效果一致。
     var contentEffectiveOpacity: CGFloat { backgroundOpacity * contentOpacity }
 
+    /// mux0 自定义 `mux0-content-shadow`，值域 0…1。控制中央内容卡片的浅边框
+    /// 与浅阴影强度——0 完全不画边框/阴影，1 为最强（仍保持"轻量"感）。
+    /// 边框颜色取 theme.border，alpha 随该值线性缩放；阴影是黑色，opacity 与
+    /// radius 也随该值缩放。
+    private(set) var contentShadowIntensity: CGFloat = 0
+
     init() {
         // 初始化时直接尝试解析 ghostty config (不需要 libghostty)
         let isDark = NSApp?.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
@@ -91,13 +97,15 @@ final class ThemeManager {
 
     /// 推入最新的 window effects。clamp 后只在值真的变化时赋值，避免无谓的
     /// @Observable 通知让 SwiftUI 重建视图树。
-    func applyWindowEffects(opacity: CGFloat, blurRadius: CGFloat, contentOpacity: CGFloat = 1.0) {
+    func applyWindowEffects(opacity: CGFloat, blurRadius: CGFloat, contentOpacity: CGFloat = 1.0, contentShadow: CGFloat = 0) {
         let clampedOpacity = max(0, min(1, opacity))
         let clampedBlur = max(0, min(100, blurRadius))
         let clampedContent = max(0, min(1, contentOpacity))
+        let clampedShadow = max(0, min(1, contentShadow))
         if backgroundOpacity != clampedOpacity { backgroundOpacity = clampedOpacity }
         if backgroundBlurRadius != clampedBlur { backgroundBlurRadius = clampedBlur }
         if self.contentOpacity != clampedContent { self.contentOpacity = clampedContent }
+        if contentShadowIntensity != clampedShadow { contentShadowIntensity = clampedShadow }
     }
 
     // MARK: - ghostty config color → NSColor

--- a/mux0Tests/HookDispatcherTests.swift
+++ b/mux0Tests/HookDispatcherTests.swift
@@ -235,4 +235,73 @@ final class HookDispatcherTests: XCTestCase {
             XCTFail("claude ON should forward")
         }
     }
+
+    // MARK: - Resume command gating
+
+    private func makeMsgWithResume(agent: HookMessage.Agent,
+                                   resume: String) -> HookMessage {
+        let json = """
+        {"terminalId":"\(tid.uuidString)","event":"running","agent":"\(agent.rawValue)","at":1,"resumeCommand":"\(resume)"}
+        """
+        return try! JSONDecoder().decode(HookMessage.self, from: json.data(using: .utf8)!)
+    }
+
+    func testDispatchSkipsResumeCommandWhenResumeToggleOff() {
+        // Status toggle ON, resume toggle absent (= OFF). Status fires, but
+        // the resume command must NOT be persisted.
+        settings.set(HookMessage.Agent.claude.settingsKey, "true")
+        settings.save()
+        let wsStore = WorkspaceStore(persistenceKey: "test-\(UUID())")
+        wsStore.createWorkspace(name: "p")
+        let term = wsStore.workspaces[0].tabs[0].layout.allTerminalIds()[0]
+        let msg = HookMessage(terminalId: term, event: .running, agent: .claude,
+                              at: 1, exitCode: nil, toolDetail: nil,
+                              summary: nil, resumeCommand: "claude --resume abc")
+
+        HookDispatcher.dispatch(msg, settings: settings, store: store,
+                                workspaceStore: wsStore)
+
+        XCTAssertTrue(wsStore.workspaces[0].pendingPrefills.isEmpty,
+                      "resume toggle off → no resume command persisted")
+    }
+
+    func testDispatchRecordsResumeCommandEvenWhenStatusToggleOff() {
+        // Resume gating is independent of the notifications gate — a user
+        // who only enabled "Resume on Launch" but kept "Notifications" off
+        // must still get the session id persisted.
+        settings.set(HookMessage.Agent.claude.resumeSettingsKey, "true")
+        settings.save()
+        let wsStore = WorkspaceStore(persistenceKey: "test-\(UUID())")
+        wsStore.createWorkspace(name: "p")
+        let term = wsStore.workspaces[0].tabs[0].layout.allTerminalIds()[0]
+        let msg = HookMessage(terminalId: term, event: .running, agent: .claude,
+                              at: 1, exitCode: nil, toolDetail: nil,
+                              summary: nil, resumeCommand: "claude --resume abc")
+
+        HookDispatcher.dispatch(msg, settings: settings, store: store,
+                                workspaceStore: wsStore)
+
+        XCTAssertEqual(wsStore.workspaces[0].pendingPrefills[term.uuidString],
+                       "claude --resume abc")
+        // Notifications gate still applied to the status update itself.
+        XCTAssertEqual(store.status(for: term), .neverRan)
+    }
+
+    func testDispatchRecordsResumeCommandWhenResumeToggleOn() {
+        settings.set(HookMessage.Agent.claude.settingsKey, "true")
+        settings.set(HookMessage.Agent.claude.resumeSettingsKey, "true")
+        settings.save()
+        let wsStore = WorkspaceStore(persistenceKey: "test-\(UUID())")
+        wsStore.createWorkspace(name: "p")
+        let term = wsStore.workspaces[0].tabs[0].layout.allTerminalIds()[0]
+        let msg = HookMessage(terminalId: term, event: .running, agent: .claude,
+                              at: 1, exitCode: nil, toolDetail: nil,
+                              summary: nil, resumeCommand: "claude --resume abc")
+
+        HookDispatcher.dispatch(msg, settings: settings, store: store,
+                                workspaceStore: wsStore)
+
+        XCTAssertEqual(wsStore.workspaces[0].pendingPrefills[term.uuidString],
+                       "claude --resume abc")
+    }
 }

--- a/mux0Tests/HookMessageTests.swift
+++ b/mux0Tests/HookMessageTests.swift
@@ -69,6 +69,18 @@ final class HookMessageTests: XCTestCase {
         XCTAssertFalse(raws.contains("shell"))
     }
 
+    func testDecodeRunningWithResumeCommand() throws {
+        let json = #"{"terminalId":"550E8400-E29B-41D4-A716-446655440000","event":"running","agent":"claude","at":1713500000.0,"resumeCommand":"claude --resume abc-123"}"#.data(using: .utf8)!
+        let msg = try JSONDecoder().decode(HookMessage.self, from: json)
+        XCTAssertEqual(msg.resumeCommand, "claude --resume abc-123")
+    }
+
+    func testDecodeRunningWithoutResumeCommand() throws {
+        let json = #"{"terminalId":"550E8400-E29B-41D4-A716-446655440000","event":"running","agent":"claude","at":1}"#.data(using: .utf8)!
+        let msg = try JSONDecoder().decode(HookMessage.self, from: json)
+        XCTAssertNil(msg.resumeCommand)
+    }
+
     func testAgentSettingsKeyFormat() {
         XCTAssertEqual(HookMessage.Agent.claude.settingsKey,   "mux0-agent-status-claude")
         XCTAssertEqual(HookMessage.Agent.codex.settingsKey,    "mux0-agent-status-codex")

--- a/mux0Tests/WorkspaceStoreTests.swift
+++ b/mux0Tests/WorkspaceStoreTests.swift
@@ -454,4 +454,151 @@ final class WorkspaceStoreTests: XCTestCase {
             XCTFail("new workspace's first tab must be a single terminal leaf")
         }
     }
+
+    // MARK: - Agent resume / prefill
+
+    /// Helper: return the (single) terminalId of the (single) tab in the
+    /// (single) workspace of a freshly-built store.
+    private func firstTerminalId(_ store: WorkspaceStore) -> UUID {
+        store.workspaces[0].tabs[0].layout.allTerminalIds()[0]
+    }
+
+    func testRecordResumeCommandWritesIntoPendingPrefills() {
+        let store = WorkspaceStore(persistenceKey: "test-\(UUID())")
+        store.createWorkspace(name: "p")
+        let term = firstTerminalId(store)
+
+        store.recordResumeCommand(terminalId: term, command: "claude --resume abc")
+
+        XCTAssertEqual(store.workspaces[0].pendingPrefills[term.uuidString],
+                       "claude --resume abc")
+    }
+
+    func testRecordResumeCommandTrimsWhitespace() {
+        let store = WorkspaceStore(persistenceKey: "test-\(UUID())")
+        store.createWorkspace(name: "p")
+        let term = firstTerminalId(store)
+
+        store.recordResumeCommand(terminalId: term, command: "  codex resume xyz  \n")
+
+        XCTAssertEqual(store.workspaces[0].pendingPrefills[term.uuidString],
+                       "codex resume xyz")
+    }
+
+    func testRecordResumeCommandUnknownTerminalNoOp() {
+        let store = WorkspaceStore(persistenceKey: "test-\(UUID())")
+        store.createWorkspace(name: "p")
+
+        store.recordResumeCommand(terminalId: UUID(), command: "claude --resume nope")
+
+        XCTAssertTrue(store.workspaces[0].pendingPrefills.isEmpty)
+    }
+
+    func testRecordResumeCommandEmptyValueIgnored() {
+        let store = WorkspaceStore(persistenceKey: "test-\(UUID())")
+        store.createWorkspace(name: "p")
+        let term = firstTerminalId(store)
+
+        store.recordResumeCommand(terminalId: term, command: "   ")
+
+        XCTAssertTrue(store.workspaces[0].pendingPrefills.isEmpty)
+    }
+
+    func testRecordResumeCommandLatestValueWins() {
+        // A second prompt within the same session (e.g. after /clear or
+        // /resume) emits a new resumeCommand — pendingPrefills must reflect
+        // the newest value, since that's the session id the user is
+        // actively working in and would want to resume on next launch.
+        let store = WorkspaceStore(persistenceKey: "test-\(UUID())")
+        store.createWorkspace(name: "p")
+        let term = firstTerminalId(store)
+
+        store.recordResumeCommand(terminalId: term, command: "claude --resume old")
+        store.recordResumeCommand(terminalId: term, command: "claude --resume new")
+
+        XCTAssertEqual(store.workspaces[0].pendingPrefills[term.uuidString],
+                       "claude --resume new")
+    }
+
+    func testConsumePendingPrefillReadsButDoesNotClear() {
+        // pendingPrefills must survive a "relaunch + no new prompt"
+        // scenario, so consume reads non-destructively. Only the next
+        // recordResumeCommand call overwrites it.
+        let store = WorkspaceStore(persistenceKey: "test-\(UUID())")
+        store.createWorkspace(name: "p")
+        let term = firstTerminalId(store)
+        store.recordResumeCommand(terminalId: term, command: "claude --resume abc")
+
+        let first = store.consumePendingPrefill(terminalId: term)
+        let second = store.consumePendingPrefill(terminalId: term)
+
+        XCTAssertEqual(first, "claude --resume abc")
+        XCTAssertEqual(second, "claude --resume abc")
+        XCTAssertEqual(store.workspaces[0].pendingPrefills[term.uuidString],
+                       "claude --resume abc")
+    }
+
+    func testConsumePendingPrefillUnknownTerminalReturnsNil() {
+        let store = WorkspaceStore(persistenceKey: "test-\(UUID())")
+        store.createWorkspace(name: "p")
+        XCTAssertNil(store.consumePendingPrefill(terminalId: UUID()))
+    }
+
+    func testWorkspaceCodableRoundTripPreservesPendingPrefill() throws {
+        let store = WorkspaceStore(persistenceKey: "test-\(UUID())")
+        store.createWorkspace(name: "p")
+        let term = firstTerminalId(store)
+        store.recordResumeCommand(terminalId: term, command: "claude --resume rt")
+
+        let data = try JSONEncoder().encode(store.workspaces)
+        let decoded = try JSONDecoder().decode([Workspace].self, from: data)
+
+        XCTAssertEqual(decoded[0].pendingPrefills[term.uuidString], "claude --resume rt")
+    }
+
+    func testCloseTerminalDropsItsPendingPrefill() {
+        // Splitting yields a 2-leaf tab; after recording resume on each leaf
+        // and closing one, only the survivor's entry must remain — otherwise
+        // pendingPrefills accumulates orphan terminalId keys forever.
+        let store = WorkspaceStore(persistenceKey: "test-\(UUID())")
+        store.createWorkspace(name: "p")
+        let wsId = store.workspaces[0].id
+        let tabId = store.workspaces[0].tabs[0].id
+        let term1 = firstTerminalId(store)
+        guard let term2 = store.splitTerminal(id: term1, in: wsId, tabId: tabId,
+                                              direction: .vertical) else {
+            return XCTFail("split failed")
+        }
+        store.recordResumeCommand(terminalId: term1, command: "claude --resume one")
+        store.recordResumeCommand(terminalId: term2, command: "claude --resume two")
+
+        store.closeTerminal(id: term1, in: wsId, tabId: tabId)
+
+        XCTAssertNil(store.workspaces[0].pendingPrefills[term1.uuidString])
+        XCTAssertEqual(store.workspaces[0].pendingPrefills[term2.uuidString],
+                       "claude --resume two")
+    }
+
+    func testRemoveTabDropsAllItsTerminalsPendingPrefills() {
+        let store = WorkspaceStore(persistenceKey: "test-\(UUID())")
+        store.createWorkspace(name: "p")
+        let wsId = store.workspaces[0].id
+        let tab1Id = store.workspaces[0].tabs[0].id
+        let term1 = firstTerminalId(store)
+        guard let term2 = store.splitTerminal(id: term1, in: wsId, tabId: tab1Id,
+                                              direction: .vertical) else {
+            return XCTFail("split failed")
+        }
+        guard let extra = store.addTab(to: wsId) else { return XCTFail("addTab failed") }
+        store.recordResumeCommand(terminalId: term1, command: "claude --resume one")
+        store.recordResumeCommand(terminalId: term2, command: "claude --resume two")
+        store.recordResumeCommand(terminalId: extra.terminalId, command: "claude --resume three")
+
+        store.removeTab(id: tab1Id, from: wsId)
+
+        XCTAssertNil(store.workspaces[0].pendingPrefills[term1.uuidString])
+        XCTAssertNil(store.workspaces[0].pendingPrefills[term2.uuidString])
+        XCTAssertEqual(store.workspaces[0].pendingPrefills[extra.terminalId.uuidString],
+                       "claude --resume three")
+    }
 }

--- a/mux0Tests/WorkspaceStoreTests.swift
+++ b/mux0Tests/WorkspaceStoreTests.swift
@@ -579,6 +579,52 @@ final class WorkspaceStoreTests: XCTestCase {
                        "claude --resume two")
     }
 
+    func testClearResumePrefillsForClaudeKeepsCodexEntries() {
+        // Clearing one agent's stored resume commands must not touch the
+        // other's — users may turn off claude's auto-resume while still
+        // wanting codex's to fire.
+        let store = WorkspaceStore(persistenceKey: "test-\(UUID())")
+        store.createWorkspace(name: "p")
+        let wsId = store.workspaces[0].id
+        let tabId = store.workspaces[0].tabs[0].id
+        let term1 = firstTerminalId(store)
+        guard let term2 = store.splitTerminal(id: term1, in: wsId, tabId: tabId,
+                                              direction: .vertical) else {
+            return XCTFail("split failed")
+        }
+        store.recordResumeCommand(terminalId: term1, command: "claude --resume one")
+        store.recordResumeCommand(terminalId: term2, command: "codex resume two")
+
+        store.clearResumePrefills(forAgent: .claude)
+
+        XCTAssertNil(store.workspaces[0].pendingPrefills[term1.uuidString])
+        XCTAssertEqual(store.workspaces[0].pendingPrefills[term2.uuidString],
+                       "codex resume two")
+    }
+
+    func testClearResumePrefillsForOpencodeKeepsClaude() {
+        // OpenCode has its own resume CLI (`opencode --session <id>`). The
+        // clear-by-agent helper must drop ONLY opencode entries, leaving
+        // claude/codex stored values alone.
+        let store = WorkspaceStore(persistenceKey: "test-\(UUID())")
+        store.createWorkspace(name: "p")
+        let wsId = store.workspaces[0].id
+        let tabId = store.workspaces[0].tabs[0].id
+        let term1 = firstTerminalId(store)
+        guard let term2 = store.splitTerminal(id: term1, in: wsId, tabId: tabId,
+                                              direction: .vertical) else {
+            return XCTFail("split failed")
+        }
+        store.recordResumeCommand(terminalId: term1, command: "claude --resume keep")
+        store.recordResumeCommand(terminalId: term2, command: "opencode --session drop")
+
+        store.clearResumePrefills(forAgent: .opencode)
+
+        XCTAssertEqual(store.workspaces[0].pendingPrefills[term1.uuidString],
+                       "claude --resume keep")
+        XCTAssertNil(store.workspaces[0].pendingPrefills[term2.uuidString])
+    }
+
     func testRemoveTabDropsAllItsTerminalsPendingPrefills() {
         let store = WorkspaceStore(persistenceKey: "test-\(UUID())")
         store.createWorkspace(name: "p")


### PR DESCRIPTION
## Summary
- Persist each agent's resume command from the hook stream and replay it as the next-launch shell input (Claude / Codex / OpenCode)
- Settings → Agents split into Notifications and Resume on Launch sections; default OFF; gates independent of each other
- Layered drop shadow on sidebar / tab drag ghosts
- Content shadow setting in Appearance