### PR TITLE
fix(ghostty): pin layer contentsScale on multi-display backing change

### DIFF
--- a/mux0/Ghostty/GhosttyTerminalView.swift
+++ b/mux0/Ghostty/GhosttyTerminalView.swift
@@ -303,6 +303,20 @@ final class GhosttyTerminalView: NSView, NSTextInputClient {
         let w = UInt32(pointSize.width * scale)
         let h = UInt32(pointSize.height * scale)
         guard w > 0, h > 0 else { return }
+        // Pin the layer's contentsScale to the window's backingScaleFactor so the
+        // Core Animation compositor doesn't apply its own scale on top of ghostty's
+        // already-px-correct render. Without this, dragging the window between a
+        // Retina (2x) and non-Retina (1x) screen leaves the compositor scaling the
+        // CAMetalLayer asymmetrically; the next layout pass (e.g. the first scroll
+        // re-pinning terminalView frame) then renders into the upper-left quadrant.
+        // Wrap in CATransaction with disabled actions so the change doesn't animate.
+        // Mirrors upstream ghostty/macos SurfaceView_AppKit.viewDidChangeBackingProperties.
+        if let window {
+            CATransaction.begin()
+            CATransaction.setDisableActions(true)
+            layer?.contentsScale = window.backingScaleFactor
+            CATransaction.commit()
+        }
         ghostty_surface_set_size(s, w, h)
         ghostty_surface_set_content_scale(s, scale, scale)
     }


### PR DESCRIPTION
## Summary

- 跨屏拖动 mux0 窗口（Retina ↔ 非 Retina 外接屏）后，第一次滚动会让终端内容缩到左上角约 1/4 区域。
- 根因：`syncSurfaceGeometry` 只通过 `ghostty_surface_set_size` / `set_content_scale` 同步了 ghostty 渲染管线，没同步 CAMetalLayer 自己的 `contentsScale`。Core Animation 合成器随后按 stale 的 contentsScale 把 layer 二次缩放，第一次滚动触发的 layout 抖动暴露出问题。
- 修复：在 `syncSurfaceGeometry` 里把 `layer?.contentsScale` 强制对齐到 `window.backingScaleFactor`，包在 `CATransaction.setDisableActions(true)` 里关掉隐式动画。对齐上游 `ghostty/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift` 中 `viewDidChangeBackingProperties` 的处理。

Fixes #20