### PR TITLE
fix(tabcontent): allow paste in rename inputs and stop terminal stealing focus

### DIFF
--- a/mux0/ContentView.swift
+++ b/mux0/ContentView.swift
@@ -362,10 +362,10 @@ extension Notification.Name {
     static let mux0FocusNextPane        = Notification.Name("mux0.focusNextPane")
     static let mux0FocusPrevPane        = Notification.Name("mux0.focusPrevPane")
 
-    // Edit menu → focused GhosttyTerminalView (routes to ghostty_surface_binding_action).
-    static let mux0Copy                 = Notification.Name("mux0.copy")
-    static let mux0Paste                = Notification.Name("mux0.paste")
-    static let mux0SelectAll            = Notification.Name("mux0.selectAll")
+    // 注：Edit > Copy / Paste / Select All 不走通知。⌘C/⌘V/⌘A 在 mux0App 的
+    // pasteboard CommandGroup 里通过 NSApp.sendAction(_:to:nil) 沿 responder
+    // chain 派发，命中 NSText（rename / 设置面板的 TextField）或终端
+    // GhosttyTerminalView 的同名 selector。
 
     // Settings
     static let mux0OpenSettings         = Notification.Name("mux0.openSettings")

--- a/mux0/Ghostty/GhosttyTerminalView.swift
+++ b/mux0/Ghostty/GhosttyTerminalView.swift
@@ -420,7 +420,35 @@ final class GhosttyTerminalView: NSView, NSTextInputClient {
 
     /// Select the entire scrollback contents.
     @discardableResult
-    func selectAll() -> Bool { runBindingAction("select_all") }
+    func selectAllRows() -> Bool { runBindingAction("select_all") }
+
+    // MARK: - Standard Edit-menu actions (responder chain entry points)
+    //
+    // mux0App 的 Edit > Copy/Paste/Select All 用 NSApp.sendAction(:to:nil) 沿
+    // responder chain 派发标准 selector。当终端是 first responder 时这三个
+    // 入口会被 AppKit 命中——把动作转发给 ghostty binding action，行为与之前
+    // 直接 post 通知的版本等价。
+    //
+    // 为什么不直接复用 `copySelection()` / `pasteClipboard()` 的名字：让方法名
+    // 区分 "selector 入口" 与 "纯函数实现"，避免别处误以为 `paste(_:)` 是
+    // 内部 API；同时可以在不破坏 binding-action 接口的前提下给 selector 单独
+    // 加 validation / logging。
+    //
+    // selectAll 必须用 `override`：NSResponder 已经声明了 `selectAll(_:)`，默认
+    // 实现会 forward 到下一个 responder 或 beep。ghostty 的滚动回放选择走的是
+    // binding action `select_all`，与 NSText 的"选中全部"语义一致。
+
+    @objc func paste(_ sender: Any?) {
+        _ = pasteClipboard()
+    }
+
+    @objc func copy(_ sender: Any?) {
+        _ = copySelection()
+    }
+
+    @objc override func selectAll(_ sender: Any?) {
+        _ = selectAllRows()
+    }
 
     // MARK: - Keyboard input
 

--- a/mux0/TabContent/TabContentView.swift
+++ b/mux0/TabContent/TabContentView.swift
@@ -52,6 +52,10 @@ final class TabContentView: NSView {
     /// Last layout snapshot per tab; used with SplitNode.sameStructure to decide whether
     /// the cached pane is still valid.
     private var tabPaneLayouts: [UUID: SplitNode] = [:]
+    /// 上次 activateTab 真正给该 tab 聚焦过的终端 id。用来识别同 tab 内
+    /// `tab.focusedTerminalId` 是否被外部（split/close/⌘⌥→/SplitPaneView.onFocus）
+    /// 改过，以便决定要不要重抓 first responder。详见 activateTab 末尾。
+    private var lastFocusedTerminalByTab: [UUID: UUID] = [:]
     /// The tab whose pane is currently installed as a subview.
     private var visibleTabId: UUID?
     private var keyMonitor: Any?
@@ -142,6 +146,7 @@ final class TabContentView: NSView {
             tabPanes[id]?.removeFromSuperview()
             tabPanes.removeValue(forKey: id)
             tabPaneLayouts.removeValue(forKey: id)
+            lastFocusedTerminalByTab.removeValue(forKey: id)
         }
 
         // Update tab bar with status dict
@@ -190,6 +195,8 @@ final class TabContentView: NSView {
 
         // Swap visible pane: detach whichever pane is currently installed, then make
         // sure `pane` is parented to self with the right frame.
+        let didSwitchTab = visibleTabId != tab.id
+        let didFocusedTerminalChange = lastFocusedTerminalByTab[tab.id] != tab.focusedTerminalId
         if let currentId = visibleTabId, currentId != tab.id {
             tabPanes[currentId]?.removeFromSuperview()
         }
@@ -204,8 +211,25 @@ final class TabContentView: NSView {
         }
         pane.applyTheme(theme)
 
-        // Restore focus
-        focusTerminal(tab.focusedTerminalId)
+        // 三类需要主动把 first responder 拽到终端的"用户行为驱动"路径：
+        //   1. 真切 tab（含首次安装：visibleTabId 旧值 nil → tab.id）
+        //   2. layout 结构变了（split / close 让 SplitPaneView 整棵被替换，
+        //      旧 GhosttyTerminalView 已 removeFromSuperview，window.firstResponder
+        //      若指向它会失效）
+        //   3. focusedTerminalId 变了（split 落到新 pane / close 退到兄弟 pane /
+        //      ⌘⌥→ 切窗格 / SplitPaneView.onFocus 程序焦点切换）—— 这种情况下
+        //      要么用户已经手动让目标 view 当 firstResponder（再调 makeFirstResponder
+        //      是 idempotent），要么 store 单方面切了 focus 我们必须跟上
+        //
+        // 其余场景（status / pwd / metadata / workspace 列表 / 设置面板状态等任一
+        // @Observable 变化触发的 SwiftUI 重渲）不会让上述三个值变化——保持当前
+        // first responder 不动，避免把侧栏 / 标签的内联 rename 字段（NSText 子类）
+        // 强行 resign，触发 controlTextDidEndEditing 把用户没编辑完的内容当成
+        // 确认提交并关掉 rename UI。
+        if didSwitchTab || !structureMatches || didFocusedTerminalChange {
+            focusTerminal(tab.focusedTerminalId)
+        }
+        lastFocusedTerminalByTab[tab.id] = tab.focusedTerminalId
     }
 
     private func buildSplitPane(for tab: TerminalTab) -> SplitPaneView {
@@ -338,13 +362,16 @@ final class TabContentView: NSView {
     // MARK: - Notification subscriptions
 
     private func subscribeNotifications() {
+        // 注：Edit > Copy / Paste / Select All 不在这里订阅。⌘C/⌘V/⌘A 由 mux0App 的
+        // pasteboard CommandGroup 通过 NSApp.sendAction(_:to:nil) 沿 responder chain
+        // 派发，由 NSText 子类（rename 字段 / 设置 TextField）或 GhosttyTerminalView
+        // 的同名 selector 直接处理。
         let names: [Notification.Name] = [
             .mux0NewTab, .mux0ClosePane,
             .mux0SplitVertical, .mux0SplitHorizontal,
             .mux0SelectNextTab, .mux0SelectPrevTab,
             .mux0SelectTabAtIndex,
             .mux0FocusNextPane, .mux0FocusPrevPane,
-            .mux0Copy, .mux0Paste, .mux0SelectAll,
         ]
         for name in names {
             NotificationCenter.default.addObserver(
@@ -366,9 +393,6 @@ final class TabContentView: NSView {
             if let idx = note.userInfo?["index"] as? Int { selectTab(at: idx) }
         case .mux0FocusNextPane:    focusAdjacentPane(forward: true)
         case .mux0FocusPrevPane:    focusAdjacentPane(forward: false)
-        case .mux0Copy:             focusedTerminalView()?.copySelection()
-        case .mux0Paste:            focusedTerminalView()?.pasteClipboard()
-        case .mux0SelectAll:        focusedTerminalView()?.selectAll()
         default: break
         }
     }

--- a/mux0/mux0App.swift
+++ b/mux0/mux0App.swift
@@ -61,13 +61,30 @@ struct mux0App: App {
             // ── Edit ──────────────────────────────────────────────────
             // Replace the default pasteboard group so we keep only the three items
             // that make sense for a terminal surface.
+            //
+            // 实现细节：闭包统一用 `NSApp.sendAction(_:to:nil)` 把动作沿 responder
+            // chain 派发，而不是直接 `post(.mux0Paste)`。这样：
+            //   · 当 first responder 是 NSText 子类（例如侧栏 / 标签的内联 rename
+            //     字段、设置面板里的 TextField 的 field editor）时，由 NSText
+            //     标准实现处理 —— rename 框里 ⌘V 真的会粘贴系统剪贴板。
+            //   · 否则链上下走到终端的 GhosttyTerminalView，它实现了同名 selector
+            //     转发给 ghostty binding action，行为与之前一致。
+            //
+            // 之前直接 post 通知会强制把动作打给当前焦点 pane，无视真正的 first
+            // responder，导致 NSTextField 的 paste: 永远收不到 ⌘V。
             CommandGroup(replacing: .pasteboard) {
-                Button(String(localized: L10n.Menu.copy.withLocale(LanguageStore.shared.locale))) { post(.mux0Copy) }
-                    .keyboardShortcut("c", modifiers: .command)
-                Button(String(localized: L10n.Menu.paste.withLocale(LanguageStore.shared.locale))) { post(.mux0Paste) }
-                    .keyboardShortcut("v", modifiers: .command)
-                Button(String(localized: L10n.Menu.selectAll.withLocale(LanguageStore.shared.locale))) { post(.mux0SelectAll) }
-                    .keyboardShortcut("a", modifiers: .command)
+                Button(String(localized: L10n.Menu.copy.withLocale(LanguageStore.shared.locale))) {
+                    NSApp.sendAction(#selector(NSText.copy(_:)), to: nil, from: nil)
+                }
+                .keyboardShortcut("c", modifiers: .command)
+                Button(String(localized: L10n.Menu.paste.withLocale(LanguageStore.shared.locale))) {
+                    NSApp.sendAction(#selector(NSText.paste(_:)), to: nil, from: nil)
+                }
+                .keyboardShortcut("v", modifiers: .command)
+                Button(String(localized: L10n.Menu.selectAll.withLocale(LanguageStore.shared.locale))) {
+                    NSApp.sendAction(#selector(NSText.selectAll(_:)), to: nil, from: nil)
+                }
+                .keyboardShortcut("a", modifiers: .command)
             }
 
             terminalCommands

--- a/mux0Tests/NotificationNamesTests.swift
+++ b/mux0Tests/NotificationNamesTests.swift
@@ -5,8 +5,9 @@ final class NotificationNamesTests: XCTestCase {
     func testNewMenuNotificationRawValues() {
         XCTAssertEqual(Notification.Name.mux0FocusNextPane.rawValue, "mux0.focusNextPane")
         XCTAssertEqual(Notification.Name.mux0FocusPrevPane.rawValue, "mux0.focusPrevPane")
-        XCTAssertEqual(Notification.Name.mux0Copy.rawValue,          "mux0.copy")
-        XCTAssertEqual(Notification.Name.mux0Paste.rawValue,         "mux0.paste")
-        XCTAssertEqual(Notification.Name.mux0SelectAll.rawValue,     "mux0.selectAll")
+        // 注：mux0Copy / mux0Paste / mux0SelectAll 已删除——⌘C/⌘V/⌘A 不再走通知，
+        // 改由 mux0App 的 pasteboard CommandGroup 通过 NSApp.sendAction(:to:nil)
+        // 沿 responder chain 派发标准 selector，命中 NSText（rename / 设置 TextField）
+        // 或终端 GhosttyTerminalView 的同名 selector。
     }
 }


### PR DESCRIPTION
## Summary

侧栏 / 标签的内联 rename 字段无法粘贴，且重命名时偶尔被终端"抢"走焦点导致 rename UI 提前关闭。

**根因**
1. `mux0App` 的 Edit > Copy/Paste/Select All 用 SwiftUI Button + `.keyboardShortcut` 直接 fire 闭包 `post(.mux0Paste)`，绕过 AppKit responder chain，⌘V 永远到不了 NSTextField 的 field editor。
2. `TabContentView.activateTab` 末尾**无条件** `makeFirstResponder(terminal)`，任意 `@Observable` store 变化（status / pwd / metadata 5s 轮询等）触发的 SwiftUI 重渲都会把侧栏 / 标签 rename 字段的 first responder 抢走，触发 `controlTextDidEndEditing` 把未编辑完的内容当成确认提交。

**修复**
- Edit 菜单三个 Button 闭包改用 `NSApp.sendAction(#selector(NSText.paste(_:)), to: nil, from: nil)` 沿 responder chain 派发；`GhosttyTerminalView` 实现 `paste/copy/selectAll(_:)` `@objc` selector 接管终端聚焦时的路径。
- `activateTab` 用三段闸门，只在"用户行为驱动"时主动聚焦终端：
  - `didSwitchTab`（含首次安装）
  - `!structureMatches`（split / close 重建了 SplitPaneView）
  - `didFocusedTerminalChange`（split 落新 pane / close 退兄弟 / ⌘⌥→ / pane 点击切换）

  其余 store 变化保持当前 first responder 不动。
- 删掉废弃的 `mux0Copy / mux0Paste / mux0SelectAll` 通知名 + 监听 + 单测断言。

Fixes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)