### PR TITLE
feat(tabcontent): resume agent session on quick-action tab restart

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,8 @@ mux0/
 │   ├── TabBarView.swift       — NSView，水平标签条（新建/关闭/重命名/拖拽）
 │   ├── TabContentView.swift   — NSView，承载当前 workspace 的 tabs，管理 SplitPaneView 缓存
 │   ├── SplitPaneView.swift    — 递归 NSSplitView 渲染 SplitNode，drag divider + 键盘焦点导航
+│   ├── StartupCommandResolver.swift — 纯静态解析器，按 Quick Action / agent
+│   │   resume / workspace default 顺序决定每个新 surface 的 initial command
 │   ├── SurfaceScrollView.swift — NSScrollView 包装 GhosttyTerminalView，提供原生 overlay 滚动条（消费 ghostty SCROLLBAR/CELL_SIZE action，拖拽回写 `scroll_to_row:N`）
 │   └── PasteboardTypes.swift  — .mux0Tab UTI 常量
 ├── Ghostty/

--- a/docs/agent-hooks.md
+++ b/docs/agent-hooks.md
@@ -30,7 +30,7 @@ Agent turn 没有真实的 exit code，但 Claude Code / Codex 的 `PostToolUse`
 
 不依赖 `NSApplication.willTerminateNotification` 做"退出时提升"——⌘Q / 关窗 / 强退 / 崩溃路径下 willTerminate 触发与否不可靠，每次 hook 收到时立刻 save 才是稳定的持久化点。
 
-下次启动 surface 时，`TabContentView.resolvedStartupCommand(forTerminal:)` 通过 `consumePendingPrefill(terminalId:)` 读取该值，再走一遍 **读端 gate**：用 `HookMessage.Agent.fromResumeCommand` 按 prefix 反推 agent，看 `mux0-agent-resume-<agent>` 是否仍为 `true`，否则降级到 workspace `defaultCommand`。读端 gate 必要——它兜住"老版本写盘 / 用户在另一台机器同步了 UserDefaults / toggle 切换时机异常"导致的 stale 旧值。
+下次启动 surface 时，`TabContentView.resolvedStartupCommand(forTerminal:)` 通过 `consumePendingPrefill(terminalId:)` 读取该值，再走一遍 **读端 gate**：用 `HookMessage.Agent.fromResumeCommand` 按 prefix 反推 agent，看 `mux0-agent-resume-<agent>` 是否仍为 `true`，否则降级到 workspace `defaultCommand`。读端 gate 必要——它兜住"老版本写盘 / 用户在另一台机器同步了 UserDefaults / toggle 切换时机异常"导致的 stale 旧值。Quick Action 启动的 tab（侧边栏右上角 claude / codex / opencode 按钮）也走这条路径——`tab.quickActionId` 命中 builtin agent 且对应 Resume toggle 为 ON 时，注入 `pendingPrefills` 而不是裸命令；prefill 与 agent 类型不匹配时降级到 Quick Action 的原命令。
 
 读取**不**清空：pendingPrefills 持久保留"最近一次的恢复命令"，只在下一次新 prompt 触发 `recordResumeCommand` 时被覆盖。这保证"重启 → 自动恢复 → 没发任何 prompt → 再重启"仍然能恢复同一会话；代价是用户手动退出 agent 之后该字段会变 stale，下次重启仍会自动 `claude --resume <id>`，不过 claude/codex 都接受任意旧 session id（只是恢复一段久远对话），不会报错。
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -188,9 +188,9 @@ WorkspaceStore 的每个 Tab 可关联一个**快捷操作 ID**（`TerminalTab.q
 
 **`QuickActionsStore`** 是 enabled 列表（按显示顺序排）+ 内置命令覆盖（per-id）+ 自定义条目数组的单一真理源，全部通过 `SettingsConfigStore` 持久化（3 个键：`mux0-quickactions-enabled` / `mux0-quickactions-builtin-command-<id>` / `mux0-quickactions-custom`）。`@Observable`，UI 直接订阅。
 
-**命令注入路径：** Tab 第一个终端启动时（`id == tab.layout.allTerminalIds().first`），`TabContentView.resolvedStartupCommand(forTerminal:)` 检测 `tab.quickActionId` 非空 → 调 `quickActionsStore.command(for: id)`：内置 = override 或默认（`gitui` / `claude` / `codex` / `opencode`），自定义 = 用户输入命令。返回值作为 `initial_input` + `\n` 喂给 ghostty surface，shell 启动后立即执行。Split 出的次级 pane 不会再跑（它不是 layout 第一个终端）。
+**命令注入路径：** Tab 第一个终端启动时（`id == tab.layout.allTerminalIds().first`），`TabContentView.resolvedStartupCommand(forTerminal:)` 委托给 `StartupCommandResolver.resolve` 检测 `tab.quickActionId` 非空 → 调 `quickActionsStore.command(for: id)`：内置 = override 或默认（`gitui` / `claude` / `codex` / `opencode`），自定义 = 用户输入命令。返回值作为 `initial_input` + `\n` 喂给 ghostty surface，shell 启动后立即执行。Split 出的次级 pane 不会再跑（它不是 layout 第一个终端）。例外：若 `quickActionId` 是 builtin agent（claude / codex / opencode）、对应 Resume toggle 为 ON、且 `pendingPrefills[terminalId]` 是匹配 agent 的 `<agent> --resume <id>`，则注入该 prefill 而**非** `quickActionsStore.command(...)` —— 用户对 builtin 命令的 override 在 resume 路径下被故意绕过，恢复 session 比保留 flag 更优先。详见 `StartupCommandResolver.resolve` 的 (0a) 分支与 `docs/agent-hooks.md` 的 Resume command 持久化章节。
 
-**重启恢复：** Tab 数据序列化到 UserDefaults，重启后 `tab.quickActionId` 还在 → 同一注入路径自动重新跑命令（gitui 重新打开、claude 重新连接……）。Surface 不序列化，重启后是新 ghostty surface。
+**重启恢复：** Tab 数据序列化到 UserDefaults，重启后 `tab.quickActionId` 还在 → 同一注入路径自动重新跑命令（gitui 重新打开；claude / codex / opencode 在 Resume toggle 开启且有匹配 prefill 时改注入 `<agent> --resume <id>` 续接上一会话，否则跑默认命令）。Surface 不序列化，重启后是新 ghostty surface。
 
 **图标：** `BuiltinQuickAction.iconSource` 三种来源——SF Symbol（gitui 用 `arrow.triangle.branch`）、Asset Catalog（claude / codex / opencode 用 lobe-icons SVG，`template-rendering-intent: template`）、首字母（自定义）。三种统一通过 `QuickActionIconView` 渲染，跟随 theme token tint。
 

--- a/docs/superpowers/plans/2026-05-07-keyboard-shortcuts-tab-workspace.md
+++ b/docs/superpowers/plans/2026-05-07-keyboard-shortcuts-tab-workspace.md
@@ -1,0 +1,584 @@
+# Tab / Workspace 切换快捷键 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 给 mux0 加入 `Cmd+1-9` 切 workspace、`Cmd+Option+1-9` 切 tab、`Ctrl+Tab`/`Ctrl+Shift+Tab` 循环 tab 三组键盘快捷键。
+
+**Architecture:** 沿用现有"SwiftUI Commands → Notification → @Observable store"模式。新加 `mux0SelectWorkspaceAtIndex` notification 由 `SidebarView` 接收并落到 `WorkspaceStore.select(id:)`。`Ctrl+Tab` 用 NSEvent local monitor 实现（与现有 `⌘⌥↑/↓` 同方式），不进菜单，避免菜单 blink。
+
+**Tech Stack:** Swift 6, SwiftUI Commands, AppKit NSEvent monitor, Xcode String Catalog (xcstrings)
+
+**Spec:** `docs/superpowers/specs/2026-05-07-keyboard-shortcuts-tab-workspace-design.md`
+
+---
+
+## File Map
+
+| 文件 | 改动 |
+|------|------|
+| `mux0/Localization/Localizable.xcstrings` | 加 `"menu.selectWorkspace %lld"` 中英翻译 |
+| `mux0/Localization/L10n.swift` | 加 `Menu.selectWorkspaceN(_:)` helper |
+| `mux0Tests/L10nSmokeTests.swift` | 把新 key 加入 `allKeys` |
+| `mux0/ContentView.swift` | `extension Notification.Name` 加 `mux0SelectWorkspaceAtIndex` |
+| `mux0Tests/NotificationNamesTests.swift` | 加 raw value 断言 |
+| `mux0/Sidebar/SidebarView.swift` | 加 `.onReceive(.mux0SelectWorkspaceAtIndex)` 处理 |
+| `mux0Tests/WorkspaceStoreTests.swift` | 加 `select(id:)` 越界 / 未知 id 的回归测试 |
+| `mux0/mux0App.swift` | 新 `workspaceCommands` 挂 File 菜单；Terminal 菜单 `selectTabN` modifier 改 `[.command, .option]` |
+| `mux0/TabContent/TabContentView.swift` | `installKeyMonitor()` 加 `Ctrl+Tab` / `Ctrl+Shift+Tab` 分支 |
+
+---
+
+## Task 1: 加入 "Select Workspace" i18n key（中英 + smoke test）
+
+**Files:**
+- Modify: `mux0/Localization/Localizable.xcstrings`
+- Modify: `mux0/Localization/L10n.swift:226-247`
+- Modify: `mux0Tests/L10nSmokeTests.swift:32`
+
+- [ ] **Step 1: 把 "menu.selectWorkspace %lld" 加进 L10nSmokeTests.allKeys（先写测试）**
+
+打开 `mux0Tests/L10nSmokeTests.swift`，在 `allKeys` 数组的 `// Menu` 区段里、`"menu.selectTab %lld"` 这行**后面**插入一行：
+
+```swift
+        "menu.selectTab %lld",
+        "menu.selectWorkspace %lld",   // ← 新增
+        "menu.settings",
+```
+
+保持字母升序（selectTab → selectWorkspace → settings）。
+
+- [ ] **Step 2: 跑 smoke test 看到失败**
+
+```bash
+xcodebuild test -project mux0.xcodeproj -scheme mux0Tests -only-testing:mux0Tests/L10nSmokeTests
+```
+
+预期：`testAllKeysResolveInEnBundle` 和 `testAllKeysResolveInZhHansBundle` 失败，错误信息包含 `Missing en translation for: menu.selectWorkspace %lld` 等。
+
+- [ ] **Step 3: 在 xcstrings 加翻译**
+
+打开 `mux0/Localization/Localizable.xcstrings`。文件是 JSON，找到现有 `"menu.selectTab %lld"` 这一段（约第 102 行）：
+
+```json
+    "menu.selectTab %lld" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Select Tab %lld" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "切换到第 %lld 个 Tab" } }
+      }
+    },
+```
+
+在它**下方**（紧跟 `,` 之后、下一个 key 之前）插入：
+
+```json
+    "menu.selectWorkspace %lld" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Select Workspace %lld" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "切换到第 %lld 个工作区" } }
+      }
+    },
+```
+
+按 catalog 内字母升序，新条目应位于 `menu.selectTab %lld` 之后、`menu.settings` 之前。
+
+- [ ] **Step 4: 在 L10n.swift 加 selectWorkspaceN helper**
+
+打开 `mux0/Localization/L10n.swift`，找到 `enum Menu` 末尾的 `selectTabN`（约第 244 行）：
+
+```swift
+        /// `%lld` will be formatted at call site in mux0App.
+        static func selectTabN(_ n: Int) -> LocalizedStringResource {
+            LocalizedStringResource("menu.selectTab \(n)")
+        }
+    }
+```
+
+在 `selectTabN` 紧后、`}` 之前追加：
+
+```swift
+        /// `%lld` will be formatted at call site in mux0App.
+        static func selectWorkspaceN(_ n: Int) -> LocalizedStringResource {
+            LocalizedStringResource("menu.selectWorkspace \(n)")
+        }
+```
+
+整段变成：
+
+```swift
+        /// `%lld` will be formatted at call site in mux0App.
+        static func selectTabN(_ n: Int) -> LocalizedStringResource {
+            LocalizedStringResource("menu.selectTab \(n)")
+        }
+        /// `%lld` will be formatted at call site in mux0App.
+        static func selectWorkspaceN(_ n: Int) -> LocalizedStringResource {
+            LocalizedStringResource("menu.selectWorkspace \(n)")
+        }
+    }
+```
+
+- [ ] **Step 5: 跑 smoke test 看到通过**
+
+```bash
+xcodebuild test -project mux0.xcodeproj -scheme mux0Tests -only-testing:mux0Tests/L10nSmokeTests
+```
+
+预期：全部 testcase PASS。
+
+- [ ] **Step 6: 提交**
+
+```bash
+git add mux0/Localization/Localizable.xcstrings \
+        mux0/Localization/L10n.swift \
+        mux0Tests/L10nSmokeTests.swift
+git commit -m "i18n(menu): add 'Select Workspace N' string for Cmd+1-9 menu items
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: 加入 `mux0SelectWorkspaceAtIndex` notification
+
+**Files:**
+- Modify: `mux0/ContentView.swift:351-381`
+- Modify: `mux0Tests/NotificationNamesTests.swift`
+
+- [ ] **Step 1: 在 NotificationNamesTests 增加 raw value 断言（先写测试）**
+
+打开 `mux0Tests/NotificationNamesTests.swift`，把整个 `testNewMenuNotificationRawValues` 改为：
+
+```swift
+    func testNewMenuNotificationRawValues() {
+        XCTAssertEqual(Notification.Name.mux0FocusNextPane.rawValue, "mux0.focusNextPane")
+        XCTAssertEqual(Notification.Name.mux0FocusPrevPane.rawValue, "mux0.focusPrevPane")
+        XCTAssertEqual(Notification.Name.mux0SelectWorkspaceAtIndex.rawValue,
+                       "mux0.selectWorkspaceAtIndex")
+        // 注：mux0Copy / mux0Paste / mux0SelectAll 已删除——⌘C/⌘V/⌘A 不再走通知，
+        // 改由 mux0App 的 pasteboard CommandGroup 通过 NSApp.sendAction(:to:nil)
+        // 沿 responder chain 派发标准 selector，命中 NSText（rename / 设置 TextField）
+        // 或终端 GhosttyTerminalView 的同名 selector。
+    }
+```
+
+- [ ] **Step 2: 跑 test 看到编译失败**
+
+```bash
+xcodebuild test -project mux0.xcodeproj -scheme mux0Tests -only-testing:mux0Tests/NotificationNamesTests
+```
+
+预期：编译失败，错误是 `Type 'Notification.Name' has no member 'mux0SelectWorkspaceAtIndex'`。
+
+- [ ] **Step 3: 在 ContentView 的 Notification.Name extension 加新名字**
+
+打开 `mux0/ContentView.swift`，找到 `extension Notification.Name` 块（约第 351 行）。在 `mux0SelectTabAtIndex` 后面插入一行：
+
+```swift
+    static let mux0SelectNextTab        = Notification.Name("mux0.selectNextTab")
+    static let mux0SelectPrevTab        = Notification.Name("mux0.selectPrevTab")
+    static let mux0SelectTabAtIndex     = Notification.Name("mux0.selectTabAtIndex")
+    static let mux0SelectWorkspaceAtIndex = Notification.Name("mux0.selectWorkspaceAtIndex")
+```
+
+- [ ] **Step 4: 跑 test 看到通过**
+
+```bash
+xcodebuild test -project mux0.xcodeproj -scheme mux0Tests -only-testing:mux0Tests/NotificationNamesTests
+```
+
+预期：PASS。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add mux0/ContentView.swift mux0Tests/NotificationNamesTests.swift
+git commit -m "feat(bridge): add mux0SelectWorkspaceAtIndex notification
+
+Pre-wires the channel for the Cmd+1-9 workspace-switch shortcut.
+Receiver in SidebarView arrives in the next commit.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: SidebarView 接收 `mux0SelectWorkspaceAtIndex` + WorkspaceStore 边界回归测试
+
+**Files:**
+- Modify: `mux0/Sidebar/SidebarView.swift:71-73`
+- Modify: `mux0Tests/WorkspaceStoreTests.swift`
+
+- [ ] **Step 1: 给 WorkspaceStore.select(id:) 写边界回归测试（先写测试）**
+
+打开 `mux0Tests/WorkspaceStoreTests.swift`，找到 `func testSelectWorkspace()`（约第 18 行）。在它**正下方**插入两条新测试：
+
+```swift
+    func testSelectWorkspace_unknownIdIsNoop() {
+        let store = WorkspaceStore(persistenceKey: "test-\(UUID())")
+        store.createWorkspace(name: "alpha")
+        let alphaId = store.workspaces[0].id
+        let unknownId = UUID()
+        store.select(id: unknownId)
+        XCTAssertEqual(store.selectedId, alphaId,
+                       "Selecting an unknown workspace id should not change selectedId")
+    }
+
+    func testSelectWorkspace_sameIdIsNoop() {
+        let store = WorkspaceStore(persistenceKey: "test-\(UUID())")
+        store.createWorkspace(name: "alpha")
+        let alphaId = store.workspaces[0].id
+        store.select(id: alphaId)  // already selected
+        XCTAssertEqual(store.selectedId, alphaId)
+    }
+```
+
+- [ ] **Step 2: 跑测试看到通过（行为已存在）**
+
+```bash
+xcodebuild test -project mux0.xcodeproj -scheme mux0Tests -only-testing:mux0Tests/WorkspaceStoreTests
+```
+
+预期：PASS。两条新测试都不应该 fail —— `WorkspaceStore.select(id:)` 已有 `guard contains` 防御。这步是"锁定行为"防止未来回归。
+
+- [ ] **Step 3: 在 SidebarView 加 onReceive 处理**
+
+打开 `mux0/Sidebar/SidebarView.swift`，找到现有 `.onReceive(NotificationCenter.default.publisher(for: .mux0BeginCreateWorkspace))`（约第 71 行）：
+
+```swift
+        .onReceive(NotificationCenter.default.publisher(for: .mux0BeginCreateWorkspace)) { _ in
+            createWorkspaceWithDefaultName()
+        }
+```
+
+在它**正下方**插入：
+
+```swift
+        .onReceive(NotificationCenter.default.publisher(for: .mux0SelectWorkspaceAtIndex)) { note in
+            guard let idx = note.userInfo?["index"] as? Int,
+                  idx >= 0, idx < store.workspaces.count else { return }
+            store.select(id: store.workspaces[idx].id)
+        }
+```
+
+> 防御性地双重保险（这里 `idx < count` + `WorkspaceStore.select` 内部 `guard contains`）—— `select` 已有保护，但 `userInfo` 是 `Any?`，外层校验让 store 层调用更干净。
+
+- [ ] **Step 4: 跑 build 看编译通过**
+
+```bash
+xcodebuild -project mux0.xcodeproj -scheme mux0 -configuration Debug build 2>&1 | tail -5
+```
+
+预期：`** BUILD SUCCEEDED **`。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add mux0/Sidebar/SidebarView.swift mux0Tests/WorkspaceStoreTests.swift
+git commit -m "feat(sidebar): route mux0SelectWorkspaceAtIndex to WorkspaceStore.select
+
+Adds regression tests locking down WorkspaceStore.select(id:) behavior
+for unknown-id and same-id cases.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: 改菜单 — File 菜单加 `Cmd+1-9` 切 workspace；Terminal 菜单切 tab 改成 `Cmd+Opt+1-9`
+
+**Files:**
+- Modify: `mux0/mux0App.swift:21-92` (body), `mux0/mux0App.swift:108-158` (terminalCommands)
+
+- [ ] **Step 1: 在 mux0App.swift 新增 `workspaceCommands` `@CommandsBuilder`**
+
+打开 `mux0/mux0App.swift`，找到 `@CommandsBuilder private var terminalCommands: some Commands {` 这一行（约第 108 行）。在 `terminalCommands` **正上方**插入新的 builder：
+
+```swift
+    @CommandsBuilder private var workspaceCommands: some Commands {
+        // 把 Cmd+1-9 绑成「切第 N 个 workspace」放在 File 菜单的 New Workspace 后面。
+        // 旧的「Cmd+1-9 切第 N 个 Tab」被降级到 Cmd+Opt+1-9（见 terminalCommands 末尾）。
+        // workspace 数量 < N 时由 SidebarView.onReceive 静默忽略，不弹 alert / 不 beep。
+        CommandGroup(after: .newItem) {
+            Divider()
+            ForEach(1...9, id: \.self) { idx in
+                Button(String(localized: L10n.Menu.selectWorkspaceN(idx)
+                                  .withLocale(LanguageStore.shared.locale))) {
+                    NotificationCenter.default.post(
+                        name: .mux0SelectWorkspaceAtIndex,
+                        object: nil,
+                        userInfo: ["index": idx - 1])
+                }
+                .keyboardShortcut(KeyEquivalent(Character(String(idx))), modifiers: .command)
+            }
+        }
+    }
+
+```
+
+- [ ] **Step 2: 把 `workspaceCommands` 挂进 body 的 `.commands` 块**
+
+仍在 `mux0App.swift`，找到 body 里的 `.commands { ... }`（约第 37-91 行）。在末尾 `terminalCommands` 之前/之后插入 `workspaceCommands` —— 推荐在 `terminalCommands` 上方（这样 .commands 闭包内的物理顺序与最终菜单顺序一致：File → Edit → Terminal）：
+
+把这一段：
+
+```swift
+            terminalCommands
+        }
+    }
+```
+
+改成：
+
+```swift
+            workspaceCommands
+            terminalCommands
+        }
+    }
+```
+
+> SwiftUI `@CommandsBuilder` 闭包的 tuple 上限是 10 个；当前 body 加 workspaceCommands 后是 6 个 `Commands`，仍在限内。
+
+- [ ] **Step 3: 把 Terminal 菜单的 `selectTabN` 改 modifier 到 `[.command, .option]`**
+
+仍在 `mux0App.swift`，找到 `terminalCommands` 末尾的 ForEach（约第 148-156 行）：
+
+```swift
+            ForEach(1...9, id: \.self) { idx in
+                Button(String(localized: L10n.Menu.selectTabN(idx).withLocale(LanguageStore.shared.locale))) {
+                    NotificationCenter.default.post(
+                        name: .mux0SelectTabAtIndex,
+                        object: nil,
+                        userInfo: ["index": idx - 1])
+                }
+                .keyboardShortcut(KeyEquivalent(Character(String(idx))), modifiers: .command)
+            }
+```
+
+把 `modifiers: .command` 改成 `modifiers: [.command, .option]`：
+
+```swift
+            ForEach(1...9, id: \.self) { idx in
+                Button(String(localized: L10n.Menu.selectTabN(idx).withLocale(LanguageStore.shared.locale))) {
+                    NotificationCenter.default.post(
+                        name: .mux0SelectTabAtIndex,
+                        object: nil,
+                        userInfo: ["index": idx - 1])
+                }
+                .keyboardShortcut(KeyEquivalent(Character(String(idx))), modifiers: [.command, .option])
+            }
+```
+
+- [ ] **Step 4: 跑 build**
+
+```bash
+xcodebuild -project mux0.xcodeproj -scheme mux0 -configuration Debug build 2>&1 | tail -10
+```
+
+预期：`** BUILD SUCCEEDED **`。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add mux0/mux0App.swift
+git commit -m "feat(menu): bind Cmd+1-9 to workspaces; move tab index to Cmd+Opt+1-9
+
+- New File-menu items 'Select Workspace 1…9' bound to Cmd+1…Cmd+9.
+- Existing Terminal-menu 'Select Tab N' moved from Cmd+N to Cmd+Opt+N.
+- Routes through mux0SelectWorkspaceAtIndex notification → SidebarView →
+  WorkspaceStore.select(id:); workspace count < N silently ignored.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: TabContentView 的 keyMonitor 加 `Ctrl+Tab` / `Ctrl+Shift+Tab`
+
+**Files:**
+- Modify: `mux0/TabContent/TabContentView.swift:483-498`
+
+- [ ] **Step 1: 改写 installKeyMonitor 加新分支**
+
+打开 `mux0/TabContent/TabContentView.swift`，找到 `private func installKeyMonitor()`（约第 483 行）。当前实现：
+
+```swift
+    private func installKeyMonitor() {
+        // ⌘⌥→ and ⌘⌥← are now menu items (Terminal → Focus Next/Previous Pane),
+        // so SwiftUI dispatches those via .mux0FocusNextPane / .mux0FocusPrevPane.
+        // The monitor remains only for the ↑/↓ aliases — intentional hidden duplicates
+        // not shown in the menu, kept because they're a common pane-nav habit.
+        keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard let self,
+                  event.modifierFlags.intersection([.command, .option]) == [.command, .option]
+            else { return event }
+            switch event.keyCode {
+            case 125: self.focusAdjacentPane(forward: true);  return nil  // ↓
+            case 126: self.focusAdjacentPane(forward: false); return nil  // ↑
+            default: return event
+            }
+        }
+    }
+```
+
+整段替换为：
+
+```swift
+    private func installKeyMonitor() {
+        // 处理两组 menu 不可见的 hidden duplicate 快捷键：
+        // - ⌘⌥↑/↓ 是 Terminal → Focus Next/Previous Pane 的别名（菜单展示
+        //   ⌘⌥→/← 给水平 pane 直觉；↑/↓ 是常见 pane-nav 习惯）
+        // - Ctrl+Tab / Ctrl+Shift+Tab 是 Terminal → Select Next/Previous Tab
+        //   (⌘⇧]/[) 的浏览器/iTerm 风格别名
+        keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard let self else { return event }
+
+            // 只看 ⌘⌃⌥⇧ 这四位，忽略 .numericPad / .function / .capsLock 等
+            let interesting: NSEvent.ModifierFlags = [.command, .control, .option, .shift]
+            let mods = event.modifierFlags.intersection(interesting)
+
+            // ⌘⌥↑/↓ — pane 切焦点
+            if mods == [.command, .option] {
+                switch event.keyCode {
+                case 125: self.focusAdjacentPane(forward: true);  return nil  // ↓
+                case 126: self.focusAdjacentPane(forward: false); return nil  // ↑
+                default: break
+                }
+            }
+
+            // Ctrl+Tab / Ctrl+Shift+Tab — tab 循环（keyCode 48 = Tab）
+            if event.keyCode == 48 {
+                if mods == [.control] {
+                    self.cycleTab(forward: true);  return nil
+                }
+                if mods == [.control, .shift] {
+                    self.cycleTab(forward: false); return nil
+                }
+            }
+
+            return event
+        }
+    }
+```
+
+- [ ] **Step 2: 跑 build**
+
+```bash
+xcodebuild -project mux0.xcodeproj -scheme mux0 -configuration Debug build 2>&1 | tail -10
+```
+
+预期：`** BUILD SUCCEEDED **`。
+
+- [ ] **Step 3: 跑全套 model 层测试确认没回归**
+
+```bash
+xcodebuild test -project mux0.xcodeproj -scheme mux0Tests 2>&1 | tail -20
+```
+
+预期：所有 testcase PASS。
+
+- [ ] **Step 4: 提交**
+
+```bash
+git add mux0/TabContent/TabContentView.swift
+git commit -m "feat(tabcontent): add Ctrl+Tab / Ctrl+Shift+Tab tab cycling
+
+NSEvent local monitor branches for browser/iTerm-style tab nav,
+sharing TabContentView.cycleTab(forward:) with the Cmd+Shift+]/[
+menu shortcut. Hidden from the menu (matching the existing ⌘⌥↑/↓
+pane-nav alias) so the menu shows only one canonical shortcut.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: 文档漂移检查 + 手动验证
+
+**Files:**
+- Run: `./scripts/check-doc-drift.sh`
+- Manual smoke test
+
+- [ ] **Step 1: 跑文档漂移检查**
+
+```bash
+./scripts/check-doc-drift.sh
+```
+
+预期：脚本通过（本次没新增/删除/重命名 Swift 文件，目录结构未变；landing 版本号未动）。
+
+如果 fail，根据脚本输出修复（不应该 fail —— 本次仅修改文件内容）。
+
+- [ ] **Step 2: 启动应用做手动验证**
+
+> ⚠️ 按照 CLAUDE.md "Agent Permissions"：**不要主动 `open` / `killall` mux0.app**。这一步把验证清单交给用户做。
+
+输出验证清单到本任务的 plan 输出里：
+
+```
+请手动验证以下场景（每条勾上后回报）：
+
+① 多 workspace 时（先在侧栏新建至少 3 个 workspace）：
+   - [ ] 按 Cmd+1 → 切到第 1 个 workspace
+   - [ ] 按 Cmd+2 → 切到第 2 个
+   - [ ] 按 Cmd+3 → 切到第 3 个
+
+② workspace 数 < N 时：
+   - [ ] 只有 2 个 workspace 时按 Cmd+5 → 当前 workspace 不变，无 alert / 无 beep
+
+③ 当前 workspace 多 tab 时：
+   - [ ] 按 Cmd+Opt+1 → 切到第 1 个 tab
+   - [ ] 按 Cmd+Opt+2 → 切到第 2 个
+
+④ Ctrl+Tab：
+   - [ ] 多 tab 时按 Ctrl+Tab → 顺时针下一个 tab
+   - [ ] 按 Ctrl+Shift+Tab → 逆时针上一个 tab
+   - [ ] 单 tab 时按 Ctrl+Tab → 无变化 / 无 beep
+
+⑤ 终端 first responder 时：
+   - [ ] 在终端跑 `vim`，按 Ctrl+Tab → mux0 切 tab，shell 不收到 \t
+   - [ ] 切回原 tab 后 vim 状态保留
+
+⑥ 菜单显示：
+   - [ ] File 菜单底部能看到 "Select Workspace 1" … "Select Workspace 9"，
+        快捷键显示 ⌘1 … ⌘9
+   - [ ] Terminal 菜单的 "Select Tab 1" … "Select Tab 9" 显示 ⌘⌥1 … ⌘⌥9
+
+⑦ 中英语言切换：
+   - [ ] Settings → Appearance → Language 切到中文 → File 菜单显示 "切换到第 1 个工作区" 等
+   - [ ] 切回 English → 显示 "Select Workspace 1" 等
+```
+
+- [ ] **Step 3: （用户回报全绿后）开 PR**
+
+按记忆中的 `feedback_no_auto_git_push` 偏好：**不要自动 push** —— 让用户显式触发：
+
+输出建议命令给用户执行：
+
+```bash
+# 当前在 master 分支，本地有 6 个 commit。建议切到 feature 分支再 push：
+git checkout -b agent/keyboard-shortcuts-tab-workspace
+git push -u origin agent/keyboard-shortcuts-tab-workspace
+gh pr create --base master \
+    --title "feat: keyboard shortcuts for tab/workspace switching" \
+    --body "Summary: bind Cmd+1-9 to workspaces, move tab index to Cmd+Opt+1-9, add Ctrl+Tab/Ctrl+Shift+Tab tab cycling.
+
+Spec: docs/superpowers/specs/2026-05-07-keyboard-shortcuts-tab-workspace-design.md"
+```
+
+> 按记忆 `feedback_pr_body_no_test_plan`，PR body 不含默认 test plan 模板，只放 Summary + spec 引用。
+
+---
+
+## Self-Review Checklist (作者自查，不分发)
+
+- ✅ Spec 覆盖：
+  - `Cmd+1-9 → workspace` 由 Task 1（i18n）+ Task 2（notification）+ Task 3（路由）+ Task 4（菜单）覆盖
+  - `Cmd+Opt+1-9 → tab` 由 Task 4（modifier 改动）覆盖
+  - `Ctrl+Tab / Ctrl+Shift+Tab` 由 Task 5 覆盖
+  - 边界（workspace 数 < N、未知 id）由 Task 3 单测 + Task 6 手测覆盖
+  - i18n 中英 by Task 1
+- ✅ 无 placeholder：每个 step 都有完整代码块或具体命令
+- ✅ 类型一致：`mux0SelectWorkspaceAtIndex` 在 NotificationNamesTests / ContentView / SidebarView / mux0App 四处用同一名字；`L10n.Menu.selectWorkspaceN` 函数签名 `(_ n: Int) -> LocalizedStringResource` 在 L10n.swift 定义、mux0App 调用一致
+- ✅ frequent commit：6 个 task 每个一次 commit
+- ✅ 测试设计：i18n 走 smoke test (Task 1)、notification name 走 raw value test (Task 2)、store 边界走单测 (Task 3)、UI 行为走手测 (Task 6)

--- a/docs/superpowers/plans/2026-05-08-quick-action-agent-resume.md
+++ b/docs/superpowers/plans/2026-05-08-quick-action-agent-resume.md
@@ -1,0 +1,555 @@
+# Quick Action Agent Resume Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let Quick Action tabs (claude / codex / opencode) participate in agent session resume on next launch instead of always running the bare command.
+
+**Architecture:** Refactor the inline `resolvedStartupCommand(forTerminal:)` logic in `TabContent/TabContentView.swift` into a pure static `StartupCommandResolver.resolve(...)` helper, then add a new "0a" branch that returns the stored resume prefill when the tab's `quickActionId` matches a builtin agent and that agent's Resume toggle is enabled.
+
+**Tech Stack:** Swift 5.9, AppKit, XCTest. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-05-08-quick-action-agent-resume-design.md`
+
+---
+
+## File Map
+
+| File | Role |
+|------|------|
+| `mux0/TabContent/StartupCommandResolver.swift` (new) | Pure static resolver — deterministic, no I/O. Holds the precedence logic (Quick Action → resume → default) so it can be unit-tested independently of NSView / WorkspaceStore / SettingsConfigStore. |
+| `mux0/TabContent/TabContentView.swift` (modify, ~5 lines) | `resolvedStartupCommand(forTerminal:)` becomes a thin call site: gathers tab/workspace/store state and forwards to `StartupCommandResolver.resolve`. |
+| `mux0Tests/StartupCommandResolverTests.swift` (new) | Unit tests for every branch in the resolver. |
+| `docs/agent-hooks.md` (modify, 1 line) | Note that Quick Action tabs now participate in resume. |
+
+`project.yml`'s `mux0` source group is `path: mux0` (recursive); the new resolver file is auto-picked up. `mux0Tests` is `sources: [mux0Tests]` flat — keep test files at the top level of `mux0Tests/`. **No `xcodegen generate` needed** for adding files inside these existing globs.
+
+---
+
+## Task 1: Extract pure resolver, no behavior change
+
+**Files:**
+- Create: `mux0/TabContent/StartupCommandResolver.swift`
+- Modify: `mux0/TabContent/TabContentView.swift:291-312` (the `resolvedStartupCommand` method)
+- Test: `mux0Tests/StartupCommandResolverTests.swift`
+
+This task introduces the helper file with logic that is **byte-for-byte equivalent** to today's behavior. The "Quick Action eats the prefill" bug is preserved here on purpose — Task 2 fixes it under failing tests. Doing the refactor first under green tests gives us a safety net.
+
+- [ ] **Step 1: Create `mux0/TabContent/StartupCommandResolver.swift` with the current logic**
+
+```swift
+import Foundation
+
+/// Pure resolver for the shell command auto-injected into a freshly created
+/// ghostty surface. Mirrors the precedence rules previously inlined in
+/// `TabContentView.resolvedStartupCommand(forTerminal:)`.
+///
+/// Source order:
+///   0. Quick action tab's first terminal — return
+///      `"<quickActionCommand>\n"` (built-in default or user override).
+///   1. Pending agent resume command (`claude --resume <id>` /
+///      `codex resume <id>` / `opencode --session <id>`) — only when the
+///      matching agent's Resume toggle is on. Default OFF means stale
+///      UserDefaults entries are ignored, not replayed.
+///   2. Workspace-level `defaultCommand`.
+///
+/// Inputs are passed explicitly (rather than wiring up real stores) so the
+/// resolver can be unit-tested without bringing up an NSView, WorkspaceStore,
+/// SettingsConfigStore, or QuickActionsStore.
+enum StartupCommandResolver {
+    static func resolve(
+        terminalId: UUID,
+        tab: TerminalTab?,
+        workspaceDefaultCommand: String?,
+        quickActionCommand: (QuickActionId) -> String?,
+        isResumeEnabled: (HookMessage.Agent) -> Bool,
+        pendingPrefill: String?
+    ) -> String? {
+        // (0) Quick action tab's first terminal.
+        if let tab,
+           let actionId = tab.quickActionId,
+           terminalId == tab.layout.allTerminalIds().first,
+           let cmd = quickActionCommand(actionId) {
+            return "\(cmd)\n"
+        }
+
+        // (1) Agent resume.
+        if let pending = pendingPrefill,
+           let agent = HookMessage.Agent.fromResumeCommand(pending),
+           isResumeEnabled(agent) {
+            return pending
+        }
+
+        // (2) Workspace default command.
+        return workspaceDefaultCommand
+    }
+}
+```
+
+- [ ] **Step 2: Replace the body of `TabContentView.resolvedStartupCommand(forTerminal:)` with a delegating call**
+
+Find the existing implementation in `mux0/TabContent/TabContentView.swift` (around line 291). Keep its doc comment block. Replace its body so it forwards to the resolver. The selected workspace, tab, and pending prefill come from the existing `store` reference; agent toggles come from `settingsStore`.
+
+```swift
+private func resolvedStartupCommand(forTerminal id: UUID) -> String? {
+    let workspace = store?.selectedWorkspace
+    let tab = workspace?.tabs.first { $0.layout.allTerminalIds().contains(id) }
+    let pendingPrefill = store?.consumePendingPrefill(terminalId: id)
+    return StartupCommandResolver.resolve(
+        terminalId: id,
+        tab: tab,
+        workspaceDefaultCommand: workspace?.defaultCommand,
+        quickActionCommand: { [quickActionsStore] actionId in
+            quickActionsStore?.command(for: actionId)
+        },
+        isResumeEnabled: { [settingsStore] agent in
+            settingsStore?.get(agent.resumeSettingsKey) == "true"
+        },
+        pendingPrefill: pendingPrefill
+    )
+}
+```
+
+Note: keep the existing doc comment block (`/// Pick the shell command...`) directly above this method — only the body changes.
+
+- [ ] **Step 3: Build to confirm no compilation regressions**
+
+```bash
+xcodebuild -project mux0.xcodeproj -scheme mux0 -configuration Debug build
+```
+
+Expected: `** BUILD SUCCEEDED **`. If you get an "ambiguous use of `allTerminalIds()`" or similar, double-check that the resolver file imports only `Foundation` (the model types are in the same target).
+
+- [ ] **Step 4: Create `mux0Tests/StartupCommandResolverTests.swift` with tests pinning current behavior**
+
+These tests cover **branches that should NOT change** in Task 2. We deliberately do not test the "Quick Action claude with toggle on + prefill" case here — that's the broken behavior Task 2 will flip.
+
+```swift
+import XCTest
+@testable import mux0
+
+final class StartupCommandResolverTests: XCTestCase {
+    // MARK: - Quick Action branch (unchanged after Task 2)
+
+    func testQuickActionGitui_returnsNakedCommand() {
+        let term = UUID()
+        let tab = TerminalTab(title: "T", terminalId: term, quickActionId: "gitui")
+        let result = StartupCommandResolver.resolve(
+            terminalId: term,
+            tab: tab,
+            workspaceDefaultCommand: "should-not-fire",
+            quickActionCommand: { _ in "gitui" },
+            isResumeEnabled: { _ in true },
+            pendingPrefill: "claude --resume abc"  // ignored: gitui isn't an agent
+        )
+        XCTAssertEqual(result, "gitui\n")
+    }
+
+    func testQuickActionClaude_noPrefill_returnsNakedClaude() {
+        let term = UUID()
+        let tab = TerminalTab(title: "T", terminalId: term, quickActionId: "claude")
+        let result = StartupCommandResolver.resolve(
+            terminalId: term,
+            tab: tab,
+            workspaceDefaultCommand: nil,
+            quickActionCommand: { _ in "claude" },
+            isResumeEnabled: { _ in true },
+            pendingPrefill: nil
+        )
+        XCTAssertEqual(result, "claude\n")
+    }
+
+    func testQuickActionClaude_toggleOff_returnsNakedClaude() {
+        let term = UUID()
+        let tab = TerminalTab(title: "T", terminalId: term, quickActionId: "claude")
+        let result = StartupCommandResolver.resolve(
+            terminalId: term,
+            tab: tab,
+            workspaceDefaultCommand: nil,
+            quickActionCommand: { _ in "claude" },
+            isResumeEnabled: { _ in false },
+            pendingPrefill: "claude --resume abc"
+        )
+        XCTAssertEqual(result, "claude\n")
+    }
+
+    // MARK: - Naked terminal Agent resume branch (must not regress)
+
+    func testNakedTerminal_resumeOn_returnsPrefill() {
+        let term = UUID()
+        let tab = TerminalTab(title: "T", terminalId: term, quickActionId: nil)
+        let result = StartupCommandResolver.resolve(
+            terminalId: term,
+            tab: tab,
+            workspaceDefaultCommand: "default-cmd",
+            quickActionCommand: { _ in nil },
+            isResumeEnabled: { _ in true },
+            pendingPrefill: "claude --resume abc"
+        )
+        XCTAssertEqual(result, "claude --resume abc")
+    }
+
+    func testNakedTerminal_resumeOff_returnsDefaultCommand() {
+        let term = UUID()
+        let tab = TerminalTab(title: "T", terminalId: term, quickActionId: nil)
+        let result = StartupCommandResolver.resolve(
+            terminalId: term,
+            tab: tab,
+            workspaceDefaultCommand: "default-cmd",
+            quickActionCommand: { _ in nil },
+            isResumeEnabled: { _ in false },
+            pendingPrefill: "claude --resume abc"
+        )
+        XCTAssertEqual(result, "default-cmd")
+    }
+
+    func testNakedTerminal_noPrefill_returnsDefaultCommand() {
+        let term = UUID()
+        let tab = TerminalTab(title: "T", terminalId: term, quickActionId: nil)
+        let result = StartupCommandResolver.resolve(
+            terminalId: term,
+            tab: tab,
+            workspaceDefaultCommand: "default-cmd",
+            quickActionCommand: { _ in nil },
+            isResumeEnabled: { _ in true },
+            pendingPrefill: nil
+        )
+        XCTAssertEqual(result, "default-cmd")
+    }
+
+    func testNakedTerminal_noPrefill_noDefault_returnsNil() {
+        let term = UUID()
+        let tab = TerminalTab(title: "T", terminalId: term, quickActionId: nil)
+        let result = StartupCommandResolver.resolve(
+            terminalId: term,
+            tab: tab,
+            workspaceDefaultCommand: nil,
+            quickActionCommand: { _ in nil },
+            isResumeEnabled: { _ in true },
+            pendingPrefill: nil
+        )
+        XCTAssertNil(result)
+    }
+
+    // MARK: - Quick Action tab, non-first pane (split sibling)
+
+    func testQuickActionTab_secondPane_fallsThroughToDefault() {
+        let firstTerm = UUID()
+        let secondTerm = UUID()
+        // SplitNode.split is positional: (UUID, SplitDirection, CGFloat,
+        // SplitNode, SplitNode).
+        let layout: SplitNode = .split(
+            UUID(),
+            .horizontal,
+            0.5,
+            .terminal(firstTerm),
+            .terminal(secondTerm)
+        )
+        var tab = TerminalTab(title: "T", terminalId: firstTerm, quickActionId: "claude")
+        tab.layout = layout
+        // resolve for the SECOND terminal — not the first leaf.
+        let result = StartupCommandResolver.resolve(
+            terminalId: secondTerm,
+            tab: tab,
+            workspaceDefaultCommand: "default-cmd",
+            quickActionCommand: { _ in "claude" },
+            isResumeEnabled: { _ in true },
+            pendingPrefill: nil
+        )
+        XCTAssertEqual(result, "default-cmd")
+    }
+}
+```
+
+- [ ] **Step 5: Run the new tests + full test suite**
+
+```bash
+xcodebuild test -project mux0.xcodeproj -scheme mux0Tests -only-testing:mux0Tests/StartupCommandResolverTests
+```
+
+Expected: 7/7 pass.
+
+```bash
+xcodebuild test -project mux0.xcodeproj -scheme mux0Tests
+```
+
+Expected: full suite green. The refactor must not break anything else.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mux0/TabContent/StartupCommandResolver.swift \
+        mux0/TabContent/TabContentView.swift \
+        mux0Tests/StartupCommandResolverTests.swift
+git commit -m "refactor(tabcontent): extract StartupCommandResolver
+
+Move the source-order precedence (quick action / agent resume / workspace
+default) out of TabContentView into a pure static helper so it can be
+exercised by unit tests without an NSView. Behavior unchanged.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Add resume-aware branch (0a) for Quick Action agent tabs
+
+**Files:**
+- Modify: `mux0/TabContent/StartupCommandResolver.swift`
+- Test: `mux0Tests/StartupCommandResolverTests.swift`
+
+This task introduces the new behavior: a Quick Action tab whose `quickActionId` matches a builtin agent (`"claude"` / `"codex"` / `"opencode"`) returns the stored resume prefill when the toggle is on and the prefill's leading agent token matches.
+
+- [ ] **Step 1: Add failing tests for the new behavior**
+
+Append these to `StartupCommandResolverTests.swift` (above the existing `// MARK: - Quick Action tab, non-first pane` mark or in a new `// MARK: - Quick Action resume (Task 2)` block — placement is cosmetic).
+
+```swift
+    // MARK: - Quick Action resume (Task 2)
+
+    func testQuickActionClaude_resumeOn_matchingPrefill_returnsPrefill() {
+        let term = UUID()
+        let tab = TerminalTab(title: "T", terminalId: term, quickActionId: "claude")
+        let result = StartupCommandResolver.resolve(
+            terminalId: term,
+            tab: tab,
+            workspaceDefaultCommand: nil,
+            quickActionCommand: { _ in "claude" },
+            isResumeEnabled: { $0 == .claude },
+            pendingPrefill: "claude --resume abc-123"
+        )
+        XCTAssertEqual(result, "claude --resume abc-123")
+    }
+
+    func testQuickActionClaude_resumeOn_mismatchedPrefill_returnsNakedClaude() {
+        let term = UUID()
+        let tab = TerminalTab(title: "T", terminalId: term, quickActionId: "claude")
+        let result = StartupCommandResolver.resolve(
+            terminalId: term,
+            tab: tab,
+            workspaceDefaultCommand: nil,
+            quickActionCommand: { _ in "claude" },
+            isResumeEnabled: { _ in true },
+            // prefill belongs to a DIFFERENT agent — must not be replayed.
+            pendingPrefill: "codex resume xyz-789"
+        )
+        XCTAssertEqual(result, "claude\n")
+    }
+
+    func testQuickActionClaude_overrideCommand_resumeOn_returnsPrefill() {
+        // User changed the builtin claude command to `claude --debug` AND
+        // turned the Resume toggle on. Spec: resume wins, ignore override.
+        let term = UUID()
+        let tab = TerminalTab(title: "T", terminalId: term, quickActionId: "claude")
+        let result = StartupCommandResolver.resolve(
+            terminalId: term,
+            tab: tab,
+            workspaceDefaultCommand: nil,
+            quickActionCommand: { _ in "claude --debug" },
+            isResumeEnabled: { $0 == .claude },
+            pendingPrefill: "claude --resume abc-123"
+        )
+        XCTAssertEqual(result, "claude --resume abc-123")
+    }
+
+    func testQuickActionCustomUUID_claudePrefill_returnsCustomCommand() {
+        // Custom Quick Action id is a UUID string — `Agent(rawValue:)` fails,
+        // so the resume branch must NOT fire for it.
+        let term = UUID()
+        let customId = UUID().uuidString
+        let tab = TerminalTab(title: "T", terminalId: term, quickActionId: customId)
+        let result = StartupCommandResolver.resolve(
+            terminalId: term,
+            tab: tab,
+            workspaceDefaultCommand: nil,
+            quickActionCommand: { _ in "my-script.sh" },
+            isResumeEnabled: { _ in true },
+            pendingPrefill: "claude --resume abc-123"
+        )
+        XCTAssertEqual(result, "my-script.sh\n")
+    }
+
+    func testQuickActionCodex_resumeOn_returnsCodexResumePrefill() {
+        // Codex uses `codex resume <id>` (no double-dash). Verify both
+        // builtin agents work, not just claude.
+        let term = UUID()
+        let tab = TerminalTab(title: "T", terminalId: term, quickActionId: "codex")
+        let result = StartupCommandResolver.resolve(
+            terminalId: term,
+            tab: tab,
+            workspaceDefaultCommand: nil,
+            quickActionCommand: { _ in "codex" },
+            isResumeEnabled: { $0 == .codex },
+            pendingPrefill: "codex resume xyz-789"
+        )
+        XCTAssertEqual(result, "codex resume xyz-789")
+    }
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+```bash
+xcodebuild test -project mux0.xcodeproj -scheme mux0Tests -only-testing:mux0Tests/StartupCommandResolverTests
+```
+
+Expected: 5 new tests fail (each currently returns the bare quick-action command instead of the prefill, except the custom-UUID test which already passes for the right reason — count it as a confirmation, not a regression). The 7 tests from Task 1 still pass.
+
+If you want to be precise, run them individually:
+
+```bash
+xcodebuild test -project mux0.xcodeproj -scheme mux0Tests \
+  -only-testing:mux0Tests/StartupCommandResolverTests/testQuickActionClaude_resumeOn_matchingPrefill_returnsPrefill
+```
+
+- [ ] **Step 3: Add the (0a) branch to the resolver**
+
+Edit `mux0/TabContent/StartupCommandResolver.swift`. Replace the entire `resolve(...)` body with the version below (the change is the new `if let agent = HookMessage.Agent...` block inserted **inside** the existing Quick Action `if`, before the `quickActionCommand` lookup):
+
+```swift
+    static func resolve(
+        terminalId: UUID,
+        tab: TerminalTab?,
+        workspaceDefaultCommand: String?,
+        quickActionCommand: (QuickActionId) -> String?,
+        isResumeEnabled: (HookMessage.Agent) -> Bool,
+        pendingPrefill: String?
+    ) -> String? {
+        // (0) Quick action tab's first terminal.
+        if let tab,
+           let actionId = tab.quickActionId,
+           terminalId == tab.layout.allTerminalIds().first {
+
+            // (0a) If this Quick Action is a builtin agent, the agent's
+            //      Resume toggle is on, AND we have a stored prefill whose
+            //      leading CLI token matches the same agent → replay that
+            //      `<agent> --resume <id>` instead of the bare command.
+            //      The agent equality guard prevents a stale prefill written
+            //      by a different agent from being replayed here.
+            if let agent = HookMessage.Agent(rawValue: actionId),
+               isResumeEnabled(agent),
+               let pending = pendingPrefill,
+               HookMessage.Agent.fromResumeCommand(pending) == agent {
+                return pending
+            }
+
+            // (0b) Fallback: original Quick Action command (built-in default
+            //      or user override).
+            if let cmd = quickActionCommand(actionId) {
+                return "\(cmd)\n"
+            }
+        }
+
+        // (1) Agent resume — naked terminal path.
+        if let pending = pendingPrefill,
+           let agent = HookMessage.Agent.fromResumeCommand(pending),
+           isResumeEnabled(agent) {
+            return pending
+        }
+
+        // (2) Workspace default command.
+        return workspaceDefaultCommand
+    }
+```
+
+- [ ] **Step 4: Re-run the resolver tests**
+
+```bash
+xcodebuild test -project mux0.xcodeproj -scheme mux0Tests -only-testing:mux0Tests/StartupCommandResolverTests
+```
+
+Expected: 12/12 pass (7 from Task 1 + 5 from Task 2).
+
+- [ ] **Step 5: Run the full test suite to catch any regressions**
+
+```bash
+xcodebuild test -project mux0.xcodeproj -scheme mux0Tests
+```
+
+Expected: full suite green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mux0/TabContent/StartupCommandResolver.swift \
+        mux0Tests/StartupCommandResolverTests.swift
+git commit -m "feat(tabcontent): resume agent session on quick-action tab restart
+
+Quick Action tabs (claude / codex / opencode) now replay the stored
+resume command on next launch when the matching Agent Resume toggle is
+on, instead of always running the bare CLI. The agent identity is
+double-checked: the prefill's leading token must match the tab's
+quickActionId, otherwise we fall back to the original Quick Action
+command.
+
+Builtin command overrides (e.g. user changed 'claude' to 'claude
+--debug') are intentionally bypassed when resuming — the resume command
+is the agent's own canonical CLI form, and a user who toggled Resume on
+expects continuity over flag preservation.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Document the new behavior in agent-hooks.md
+
+**Files:**
+- Modify: `docs/agent-hooks.md` (the "Resume command 持久化" section)
+
+- [ ] **Step 1: Update the resume-section paragraph that mentions `TabContentView.resolvedStartupCommand`**
+
+Find the paragraph in `docs/agent-hooks.md` that begins with:
+
+> 下次启动 surface 时，`TabContentView.resolvedStartupCommand(forTerminal:)` 通过 `consumePendingPrefill(terminalId:)` 读取该值...
+
+Append a new sentence at the end of that paragraph:
+
+> Quick Action 启动的 tab（侧边栏右上角 claude / codex / opencode 按钮）也走这条路径——`tab.quickActionId` 命中 builtin agent 且对应 Resume toggle 为 ON 时，注入 `pendingPrefills` 而不是裸命令；prefill 与 agent 类型不匹配时降级到 Quick Action 的原命令。
+
+- [ ] **Step 2: Verify the doc-drift check still passes**
+
+```bash
+./scripts/check-doc-drift.sh
+```
+
+Expected: passes (we added a Swift file inside `mux0/TabContent/`, but that directory is already enumerated in CLAUDE.md's Directory Structure under `TabContent/`; no new top-level entry is required for an internal helper file).
+
+If the script complains that `StartupCommandResolver.swift` is missing from CLAUDE.md or `docs/architecture.md`, add a single bullet under the existing `TabContent/` block in CLAUDE.md:
+
+```
+│   ├── StartupCommandResolver.swift — pure static helper for resolving
+│   │   the auto-injected initial command (quick action / agent resume /
+│   │   workspace default) per surface launch
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/agent-hooks.md
+# Also include CLAUDE.md if Step 2 required an update.
+git commit -m "docs(agent-hooks): note quick-action tab resume path
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Final Verification
+
+- [ ] **Step 1: Confirm clean working tree on the right branch**
+
+```bash
+git status
+git log --oneline master..HEAD
+```
+
+Expected: branch `agent/quickaction-agent-resume`, working tree clean, three new commits (refactor → feat → docs) on top of master plus the spec commit.
+
+- [ ] **Step 2: One last full test run**
+
+```bash
+xcodebuild test -project mux0.xcodeproj -scheme mux0Tests
+```
+
+Expected: full suite green. Done. Report back to the user.
+
+**Do not push.** Per the user's saved feedback (`feedback_no_auto_git_push.md`), local commits are fine but pushing requires per-push consent. Surface the diff and the verification results, and let the user decide.

--- a/docs/superpowers/specs/2026-05-07-keyboard-shortcuts-tab-workspace-design.md
+++ b/docs/superpowers/specs/2026-05-07-keyboard-shortcuts-tab-workspace-design.md
@@ -1,0 +1,273 @@
+# Tab / Workspace 切换快捷键 —— Design
+
+## Context
+
+mux0 当前的 tab/workspace 导航快捷键集中在 Terminal 菜单：
+
+- `⌘T` 新建 tab、`⌘W` 关闭 pane、`⌘D`/`⌘⇧D` 拆分
+- `⌘⌥→/←` 在 pane 之间切焦点、`⌘⇧]/[` 在 tab 之间循环
+- `⌘1…⌘9` 直接选当前 workspace 的第 N 个 tab
+
+但**没有给 workspace 留键盘入口**——用户只能用鼠标点击侧栏切 workspace。Workspace 是 mux0 的顶层导航单元（每个 workspace 是一组独立的 tabs），这种"必须离手到鼠标"的体验跟终端 app 的 keyboard-first 定位不符。
+
+同时用户反馈 `Ctrl+Tab` / `Ctrl+Shift+Tab` 是浏览器 / iTerm2 / Warp 通用的"切换 tab"按键习惯，希望在 mux0 里也能用。
+
+本次改动加入：
+
+1. **`Cmd+1…Cmd+9`** 切换到第 1…9 个 workspace（取代当前的"切到第 N 个 tab"绑定）
+2. **`Cmd+Option+1…Cmd+Option+9`** 接管旧的"切到第 N 个 tab"
+3. **`Ctrl+Tab` / `Ctrl+Shift+Tab`** 作为 `⌘⇧]/[` 的等价快捷键，循环切 tab
+
+## Goals
+
+- `Cmd+1-9` 直达 workspace；workspace 不足 N 时静默忽略
+- `Cmd+Option+1-9` 仍然能直达当前 workspace 的第 N 个 tab（不丢功能，只是降一档）
+- `Ctrl+Tab` / `Ctrl+Shift+Tab` 跟 `⌘⇧]/[` 行为完全一致：当前 workspace 内顺序循环，复用现有 `cycleTab(forward:)`
+- 菜单里给 `Cmd+1-9` 切 workspace 留下可发现入口（File 菜单底部）
+- 保留 `Cmd+Option+1-9` 的菜单项（沿用现有 ForEach，只改 modifier）
+- `Ctrl+Tab` 不进菜单，跟 `⌘⌥↑/↓` 一样作为"intentional hidden duplicate"
+
+## Non-Goals
+
+- 不实现 `Cmd+Shift+T` 重开关闭的 tab（用户明确放弃）
+- 不实现三指左右滑动切 tab（用户明确放弃）
+- 不做 MRU（most-recently-used）顺序——`Ctrl+Tab` 也是 sequential，跟 `⌘⇧]/[` 同一个 `cycleTab` 实现
+- 不为 `Cmd+1-9` 加 workspace 数量大于 9 时的"More…"或翻页菜单——超过 9 个的 workspace 只能鼠标点击或拖拽
+- 不为 `Cmd+1-9` 在 workspace 数 < N 时弹 alert 或 beep；静默忽略
+- 不开"Workspace"顶层菜单——`Cmd+1-9` 切 workspace 复用 File 菜单（"Workspace" 与 "New Workspace" 都是 workspace 级命令，归 File 一致）
+- 不改 `⌘⌥→/←` / `⌘⇧]/[` / `⌘⌥↑/↓` 等现有绑定
+
+## Architecture
+
+```
+[mux0App.swift @main]
+   ├─ File menu
+   │    ├─ New Workspace            ⌘N    → post(.mux0BeginCreateWorkspace)
+   │    └─ Select Workspace 1…9     ⌘1…⌘9 → post(.mux0SelectWorkspaceAtIndex, idx)   ← 新增
+   │
+   └─ Terminal menu
+        ├─ … (existing items)
+        └─ Select Tab 1…9           ⌘⌥1…⌘⌥9 → post(.mux0SelectTabAtIndex, idx)       ← 改 modifier
+
+[ContentView.swift Notification.Name]
+   └─ + mux0SelectWorkspaceAtIndex                                                    ← 新增
+
+[Sidebar/SidebarView.swift]
+   └─ .onReceive(.mux0SelectWorkspaceAtIndex) { idx in                                ← 新增
+        if idx < store.workspaces.count {
+            store.select(id: store.workspaces[idx].id)
+        }
+      }
+
+[TabContent/TabContentView.swift installKeyMonitor]
+   └─ + Ctrl+Tab        keyCode 48 + .control          → cycleTab(forward: true)     ← 新增
+   └─ + Ctrl+Shift+Tab  keyCode 48 + [.control,.shift] → cycleTab(forward: false)    ← 新增
+```
+
+### 数据流：`Cmd+1` 切 workspace
+
+```
+Cmd+1 keydown
+   ↓
+SwiftUI Commands → Button "Select Workspace 1" 触发
+   ↓
+post(.mux0SelectWorkspaceAtIndex, userInfo: ["index": 0])
+   ↓
+SidebarView.onReceive 收到
+   ↓
+store.workspaces[0] 存在 → store.select(id: workspaces[0].id)
+   ↓
+WorkspaceStore @Observable 触发 selectedId 变更
+   ↓
+SidebarListBridge / TabBridge.updateNSView 各自重渲
+   ↓
+TabContentView.reloadFromStore() 切到该 workspace 的 selectedTab
+```
+
+### 数据流：`Ctrl+Tab` 切 tab
+
+```
+Ctrl+Tab keydown
+   ↓
+TabContentView.keyMonitor (NSEvent.addLocalMonitorForEvents)
+   ↓ 匹配 keyCode 48 (Tab) + .control 修饰
+   ↓
+cycleTab(forward: true)  // 现有方法，直接调，不走 NotificationCenter
+   ↓
+return nil  // 吃掉事件，不传给 ghostty surface
+```
+
+## Components
+
+### 1. `mux0App.swift` — 菜单与快捷键绑定
+
+**新增**：`@CommandsBuilder workspaceCommands`，发到 File 菜单。
+
+```swift
+@CommandsBuilder private var workspaceCommands: some Commands {
+    CommandGroup(after: .newItem) {
+        Divider()
+        ForEach(1...9, id: \.self) { idx in
+            Button(String(localized: L10n.Menu.selectWorkspaceN(idx)
+                              .withLocale(LanguageStore.shared.locale))) {
+                NotificationCenter.default.post(
+                    name: .mux0SelectWorkspaceAtIndex,
+                    object: nil,
+                    userInfo: ["index": idx - 1])
+            }
+            .keyboardShortcut(KeyEquivalent(Character(String(idx))), modifiers: .command)
+        }
+    }
+}
+```
+
+放置点：`var body: some Scene` 的 `.commands { ... }` 里。注意 `@CommandsBuilder` 的 10-element tuple 上限，本来 `terminalCommands` 已经独立出来；本次再独立 `workspaceCommands` 即可。
+
+**改动**：`terminalCommands` 末尾的 `Cmd+1-9` ForEach 把 modifier 改为 `[.command, .option]`，并把文案 key 沿用现有 `L10n.Menu.selectTabN`：
+
+```swift
+ForEach(1...9, id: \.self) { idx in
+    Button(String(localized: L10n.Menu.selectTabN(idx)...)) { ... }
+        .keyboardShortcut(KeyEquivalent(Character(String(idx))),
+                          modifiers: [.command, .option])  // ← 改这里
+}
+```
+
+### 2. `ContentView.swift` — Notification 名字
+
+```swift
+extension Notification.Name {
+    // ... 已有
+    static let mux0SelectWorkspaceAtIndex = Notification.Name("mux0.selectWorkspaceAtIndex")
+}
+```
+
+### 3. `Sidebar/SidebarView.swift` — workspace 选择路由
+
+`SidebarView` 是 SwiftUI 壳，`@Bindable var store: WorkspaceStore`，最适合接收这个 notification（不需要桥接 AppKit 层）。
+
+加在 `.onReceive(NotificationCenter.default.publisher(for: .mux0BeginCreateWorkspace))` 旁边：
+
+```swift
+.onReceive(NotificationCenter.default.publisher(for: .mux0SelectWorkspaceAtIndex)) { note in
+    guard let idx = note.userInfo?["index"] as? Int,
+          idx >= 0, idx < store.workspaces.count else { return }
+    store.select(id: store.workspaces[idx].id)
+}
+```
+
+`WorkspaceStore.select(id:)` 内部已有 `guard contains` 防御（见 `WorkspaceStore.swift:92-95`），双重保险无副作用。
+
+### 4. `TabContent/TabContentView.swift` — Ctrl+Tab key monitor
+
+在现有 `installKeyMonitor()` 里追加分支：
+
+```swift
+private func installKeyMonitor() {
+    keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+        guard let self else { return event }
+
+        // 只看 ⌘⌃⌥⇧ 这四位，忽略 .numericPad / .function / .capsLock
+        let interesting: NSEvent.ModifierFlags = [.command, .control, .option, .shift]
+        let mods = event.modifierFlags.intersection(interesting)
+
+        // 已有：⌘⌥↑/↓
+        if mods == [.command, .option] {
+            switch event.keyCode {
+            case 125: self.focusAdjacentPane(forward: true);  return nil
+            case 126: self.focusAdjacentPane(forward: false); return nil
+            default: break
+            }
+        }
+
+        // 新增：Ctrl+Tab / Ctrl+Shift+Tab（keyCode 48 = Tab）
+        if event.keyCode == 48 {
+            if mods == [.control] {
+                self.cycleTab(forward: true);  return nil
+            }
+            if mods == [.control, .shift] {
+                self.cycleTab(forward: false); return nil
+            }
+        }
+
+        return event
+    }
+}
+```
+
+`window?.isKeyWindow` 不需要在这里检查——`addLocalMonitorForEvents` 只接收当前进程 key window 的事件，且 `cycleTab` 自己又 guard 了 `selectedWorkspace` 是否存在。
+
+> **为什么不放 menu**：跟代码里现有注释一致："intentional hidden duplicates not shown in the menu, kept because they're a common pane-nav habit"。`Ctrl+Tab` / `⌘⇧]` 是同一动作的两种习惯；菜单里只展示一种，避免菜单 blink + 重复展示。
+
+### 5. i18n — 9 个新文案
+
+`Localization/L10n.swift`：
+
+```swift
+enum Menu {
+    // ... 已有
+    static func selectWorkspaceN(_ n: Int) -> LocalizedStringResource {
+        LocalizedStringResource("menu.terminal.selectWorkspace.\(n)")
+    }
+}
+```
+
+`Localization/Localizable.xcstrings`：9 条，比照现有 `menu.terminal.selectTab.N` key：
+
+| Key | English | 简体中文 |
+|-----|---------|----------|
+| `menu.terminal.selectWorkspace.1` | Select Workspace 1 | 选择工作区 1 |
+| … `.2-.9` | Select Workspace N | 选择工作区 N |
+
+> 命名 key 复用 `menu.terminal.*` 前缀只是为了跟现有 `selectTab.N` 风格一致；实际菜单挂在 File 菜单底下。这不是错的——`menu.terminal` 是历史前缀，不影响 UI。
+
+`mux0Tests/L10nSmokeTests.swift`：在现有 smoke test 列表里加这 9 个 key（覆盖中英）。
+
+## Boundary Conditions
+
+| 条件 | 行为 |
+|------|------|
+| `Cmd+5` 但只有 3 个 workspace | 静默忽略——`SidebarView.onReceive` 的 `guard idx < count` 直接 return；`store.select(id:)` 也 guard contains |
+| `Cmd+1` 当前已经是第 1 个 workspace | `select(id:)` 把 selectedId 设成同样的值；@Observable 不会触发实际重渲（值未变），无副作用 |
+| `Ctrl+Tab` 但当前 workspace 只有 1 个 tab | `cycleTab` 算 `(0 + 1) % 1 = 0`，`store?.selectTab(id: same, in: ws)`；同上无副作用 |
+| 终端里运行 `vim` / TUI app 用 `Ctrl+Tab` 做窗口切换 | 被 mux0 拦截，**不会**传给 ghostty surface。考虑到 `Ctrl+Tab` 在主流终端 TUI 里用得极少（vim/tmux 都不默认绑），可以接受 |
+| `Cmd+Option+5` 但当前 workspace 只有 3 个 tab | `selectTab(at:)` 已有 `guard index < ws.tabs.count`，静默忽略（与改前 `Cmd+5` 行为一致） |
+| `Cmd+1-9` 跟 NSWindow 的"显示主窗口"系统快捷键冲突 | macOS 系统级没占用 `⌘1-9`；app 自己的 keyEquivalent 会优先 |
+| 同时多个 mux0 窗口（多 workspace 多窗口场景） | `mux0SelectWorkspaceAtIndex` 是广播；但 `WorkspaceStore.selectedId` 是单例 store 上的状态，所有窗口共享。当前 mux0 是单 WindowGroup 单 store 模式，不会出现多窗口分歧 |
+
+## i18n
+
+新增 9 条 key（中英），格式参照现有 `menu.terminal.selectTab.N`。Smoke test 加入 9 条。
+
+## Testing
+
+mux0 现有测试以 model 层为主，键盘绑定难单测。本次改动单测覆盖：
+
+- `WorkspaceStoreTests`：`select(id:)` 在 id 不在 workspaces 中时不改 `selectedId`（这是已有行为，加测验回归即可）
+- `L10nSmokeTests`：9 条新 i18n key 在中英下都解析
+
+手动验证清单（写进 PR description 取代默认 test plan，按照用户记忆 `feedback_pr_body_no_test_plan` 的精神浓缩）：
+
+1. 多个 workspace 时 `Cmd+1`/`Cmd+2`/`Cmd+3` 切 workspace
+2. 只有 2 个 workspace 时 `Cmd+9` 无反应（不 beep）
+3. `Cmd+Opt+1`/`Cmd+Opt+2` 切当前 workspace 的 tab
+4. `Ctrl+Tab` / `Ctrl+Shift+Tab` 在 1 个 tab、3 个 tab 时分别表现
+5. 终端聚焦在 `vim` 时按 `Ctrl+Tab` —— mux0 切 tab，shell 不收到 `\t`
+6. File 菜单里能看到 "Select Workspace 1" 到 "Select Workspace 9"，快捷键显示 `⌘1`…`⌘9`
+7. Terminal 菜单里 "Select Tab 1" 显示 `⌘⌥1`（不再是 `⌘1`）
+8. 中英语言切换后，菜单文案跟随变更
+
+## Documentation Updates
+
+按 CLAUDE.md "文档与目录结构同步"约定，本次改动**不新增/重命名/移动 Swift 文件**，仅在已有文件内追加方法/分支/i18n 文案。Directory Structure 无变动，无需改 CLAUDE.md / AGENTS.md。
+
+`docs/architecture.md` 里"Keyboard Shortcuts"或"Menu Commands"章节如果列了完整快捷键表，需要同步更新（实施时检查；如不存在则跳过）。
+
+## Open Questions
+
+无。
+
+## Out of Scope (确认放弃)
+
+- `Cmd+Shift+T` 重开关闭的 tab
+- 三指左右滑动切 tab

--- a/docs/superpowers/specs/2026-05-08-quick-action-agent-resume-design.md
+++ b/docs/superpowers/specs/2026-05-08-quick-action-agent-resume-design.md
@@ -1,0 +1,170 @@
+# Quick Action Tab — Agent Session Resume
+
+**Date:** 2026-05-08
+**Branch (proposed):** `agent/quickaction-agent-resume`
+**Status:** Approved, pending plan
+
+## 背景
+
+通过侧边栏右上角 Quick Action 按钮（claude / codex / opencode）启动的 tab，
+关闭 mux0 后再打开**不会** resume 之前的 agent session — 每次都是裸命令
+重新开始。但用户在普通终端里手敲 `claude` 启动的 session 重启后**会**自动
+变成 `claude --resume <id>`。
+
+行为差异源于 `TabContent/TabContentView.swift` 的 `resolvedStartupCommand(
+forTerminal:)`：
+
+```swift
+// (0) Quick action：命中即 return 裸命令
+if ... let actionId = tab.quickActionId, ... {
+    return "\(cmd)\n"
+}
+// (1) Agent resume：永远轮不到
+if let pending = store?.consumePendingPrefill(...) { ... }
+```
+
+代码注释明确写了 quick action 分支的语义是「重启即重新执行」，但当时没有
+跟 agent resume 机制做协调。pendingPrefills 已经被正确写盘
+（`WorkspaceStore.recordResumeCommand`），只是被 (0) 分支吃掉了。
+
+## 目标
+
+让 Quick Action 启动的 claude / codex / opencode tab 在重启后，
+跟普通终端一样继承 agent session（前提是用户已开启 Settings → Agents 里
+对应的 Resume toggle）。
+
+非目标：
+
+- 不改 hook wrapper（`Resources/agent-hooks/`）
+- 不改 pendingPrefills 写入路径
+- 不改 toggle UI 或默认值
+- 不解决「用户主动 exit 后重启又被起回 claude」（这是 quick action 自身
+  「重启即重新执行」的固有语义，跟 resume 正交）
+
+## 设计
+
+### 单点改动
+
+`mux0/TabContent/TabContentView.swift` 的 `resolvedStartupCommand(forTerminal:)`
+分支 (0) 内插入 resume 命中检测：
+
+```swift
+// (0) Quick action tab's first terminal
+if let tab = ..., let actionId = tab.quickActionId,
+   id == tab.layout.allTerminalIds().first {
+
+    // 0a. 若该 quick action 是 builtin agent，且 Resume toggle 开 + 有
+    //     prefill → 用 prefill 而非裸命令。命中要求 prefill 解析出的 agent
+    //     与当前 quick action agent 一致（防止 prefill 错配）。
+    if let agent = HookMessage.Agent(rawValue: actionId),
+       settingsStore?.get(agent.resumeSettingsKey) == "true",
+       let pending = store?.consumePendingPrefill(terminalId: id),
+       HookMessage.Agent.fromResumeCommand(pending) == agent {
+        return pending  // e.g. "claude --resume <id>"
+    }
+
+    // 0b. fallback：原有 quick action 命令（含 builtin override）
+    if let cmd = quickActionsStore?.command(for: actionId) {
+        return "\(cmd)\n"
+    }
+}
+// (1) 既有 agent resume（裸终端用） — 不变
+// (2) workspace defaultCommand — 不变
+```
+
+### 关键观察
+
+`BuiltinQuickAction.rawValue` 跟 `HookMessage.Agent.rawValue` 完全一致
+（`"claude"` / `"codex"` / `"opencode"`），所以从 quickActionId 映射到
+Agent 一行 `Agent(rawValue:)` 就行 — 自定义 quick action 用 UUID 字符串，
+天然不命中。
+
+### Override 取舍（已定）
+
+用户改了 builtin claude 的命令字符串（比如 `claude --debug`）+ Resume
+toggle 开 + 有 prefill 时，**resume 优先，忽略 override**。理由：
+
+- resume 命令是 hook 上报的合法整条形式（`claude --resume <id>`），
+  agent 自己拼好的
+- 用户改 builtin 命令是稀有 case，绝大部分是改 flag；既然主动开了 resume
+  toggle，期望就是「重启续上」
+- 简单 = 可预期：开关一开，所有 claude tab 一致行为
+
+### 行为表
+
+| 场景 | 旧行为 | 新行为 |
+|------|--------|--------|
+| Quick Action `claude` tab，Resume toggle 开，有 prefill | 裸 `claude\n` | `claude --resume <id>` |
+| 同上但 Resume toggle 关 | 裸 `claude\n` | 裸 `claude\n` |
+| 同上但 prefill 为空（首次 / 已被 clearResumePrefills 清过） | 裸 `claude\n` | 裸 `claude\n` |
+| Quick Action `claude` tab，但 builtin 命令 override 成 `claude --debug` | `claude --debug\n` | `claude --resume <id>` |
+| Quick Action `gitui` tab（非 agent） | `gitui\n` | `gitui\n` |
+| 自定义 Quick Action（actionId 是 UUID） | 用户命令 | 用户命令（`Agent(rawValue:)` 失败 → 0b） |
+| Quick Action tab 内 split 出的 pane | workspace defaultCommand | workspace defaultCommand（不是第一个 terminal，不进 0 分支） |
+| 普通终端（无 quickActionId） | 走 (1) → resume / 或 (2) | 不变 |
+| `claude` quick action tab 但 prefill 是 `codex --resume ...`（理论不应发生） | — | 不 resume，落到 0b（agent mismatch 保护） |
+
+## 不需要改
+
+- `WorkspaceStore.recordResumeCommand` / `consumePendingPrefill`：现有写
+  盘+读取逻辑已经覆盖 quick action tab（key 是 terminalId，跟 tab 来源
+  无关）
+- `clearResumePrefills(forAgent:)`：toggle 关闭时清掉对应 agent 的所有
+  prefill —— 已存在，无须改
+- CLAUDE.md「surface 不序列化」语义不变；只在 `docs/agent-hooks.md` 里
+  补一行「Quick Action tab 也参与 resume」的说明
+
+## 测试策略
+
+`resolvedStartupCommand` 当前是 `private`。改动后逻辑分支变多，需要单元
+测试，因此抽出一个纯函数 helper：
+
+```swift
+// 静态、纯函数：仅依赖入参，便于测试
+static func resolveStartupCommand(
+    forTerminal id: UUID,
+    in tab: TerminalTab?,
+    workspace: Workspace?,
+    quickActionsStore: QuickActionsStore?,
+    settingsStore: SettingsConfigStore?,
+    pendingPrefill: String?
+) -> String?
+```
+
+`TabContentView.resolvedStartupCommand` 内部组装入参后调用之；测试直接
+调用 static helper，避免桥接 NSView/store 真实实例。
+
+新增 `mux0Tests/TabContent/StartupCommandResolverTests.swift`，覆盖：
+
+1. quick action `claude` + toggle on + matching prefill → 返回 prefill
+2. 同上 + toggle off → 返回裸 `claude\n`
+3. 同上 + prefill 解析出的 agent 与 actionId mismatch（`codex --resume ...`） → 裸 `claude\n`
+4. 同上 + prefill 为空 → 裸 `claude\n`
+5. quick action `gitui` + 任意 prefill → `gitui\n`（非 agent 不走 resume）
+6. 自定义 quick action（UUID id）+ matching-looking prefill → 用户命令（Agent rawValue 不命中）
+7. quick action `claude` + builtin override `claude --debug` + toggle on + prefill → 返回 prefill（A1 取舍）
+8. 普通终端（无 quickActionId） + claude prefill + toggle on → 返回 prefill（既有 (1) 分支不回归）
+9. 普通终端 + 无 prefill + workspace defaultCommand → 返回 defaultCommand（既有 (2) 分支不回归）
+
+## 影响面
+
+- 一个 Swift 文件主要改动：`mux0/TabContent/TabContentView.swift`
+- 新增一个 helper 文件或保持在 TabContentView.swift 内部 static 方法（plan
+  阶段决定）
+- 一个新测试文件
+- 一行 `docs/agent-hooks.md` 更新
+
+## 风险
+
+- **prefill 与 quick action agent 类型 mismatch 时被错误注入**：通过
+  `HookMessage.Agent.fromResumeCommand(pending) == agent` 二次校验
+  消除
+- **回归普通终端 (1) 分支**：通过测试 8/9 锁定既有行为
+- **opencode wrapper 不上报 resumeCommand**：自然落到 fallback 0b，跑裸
+  `opencode\n` —— 跟现状等价，无回归
+
+## 提交格式
+
+`feat(tabcontent): resume agent session on quick-action tab restart`
+
+scope `tabcontent` 与 CLAUDE.md 第 5 条 commit 规则一致。

--- a/mux0.xcodeproj/project.pbxproj
+++ b/mux0.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		2BB1606A5799193109DE274C /* GhosttyBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97BE27EB11ED1ED01C8843B7 /* GhosttyBridge.swift */; };
 		32A7B12961D2F46AEBD0E3F0 /* MetadataRefresherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92650C34DB180A72B23273A0 /* MetadataRefresherTests.swift */; };
 		368CDF074D86E31677DD944E /* AppearanceSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3A60150D4D181A6D9B55930 /* AppearanceSectionView.swift */; };
+		39B56550E6DE3A7BF8E95160 /* StartupCommandResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0520C77C17845C086A5E597A /* StartupCommandResolverTests.swift */; };
 		4DF25EEF8F9CE22D00062158 /* SettingsTabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1BA2A24846F1D1712469C3 /* SettingsTabBarView.swift */; };
 		4E4FED23A4504E0204D3C515 /* WorkspacePasteboardType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F3CA90C6310DE9C99652EB /* WorkspacePasteboardType.swift */; };
 		5050C197246573A2D7174B05 /* QuickAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB6F2650B84DBA28A06D938D /* QuickAction.swift */; };
@@ -70,6 +71,7 @@
 		B10F416FF03BF20B04C7BD74 /* ThemePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD1034A9A7330C528BE1EFE1 /* ThemePickerView.swift */; };
 		B146356665E4C8B072624939 /* ShellSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47A19B43AC5D68C431FBB96C /* ShellSectionView.swift */; };
 		B35766C44967278D296440C0 /* HookMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 399D6E84F70926B48FDB254D /* HookMessageTests.swift */; };
+		B412AD249899F1C04B40E501 /* StartupCommandResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04EE67FE969E31DA1B40FA42 /* StartupCommandResolver.swift */; };
 		B87CA03C3EDF66D3B0D2C8AF /* GhosttyTerminalViewPwdTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5347252E77411776BBE4282 /* GhosttyTerminalViewPwdTests.swift */; };
 		BA2F16D1DB0CA35014A505F8 /* QuickActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5435F2C6AADD54DE910072 /* QuickActionTests.swift */; };
 		BA96FADF69CB3C0BFB863419 /* TerminalStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F9A0D6FCA49BEE08183E290 /* TerminalStatus.swift */; };
@@ -112,6 +114,8 @@
 /* Begin PBXFileReference section */
 		0052317F2679AB0572F50932 /* IconButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconButton.swift; sourceTree = "<group>"; };
 		036836909C5E414F3E9B95DC /* SettingsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSection.swift; sourceTree = "<group>"; };
+		04EE67FE969E31DA1B40FA42 /* StartupCommandResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupCommandResolver.swift; sourceTree = "<group>"; };
+		0520C77C17845C086A5E597A /* StartupCommandResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupCommandResolverTests.swift; sourceTree = "<group>"; };
 		0B75BC1D38F67C220D3F82A8 /* TerminalStatusIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalStatusIconView.swift; sourceTree = "<group>"; };
 		105802CACA1ABC48684A2F0C /* MetadataRefresher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataRefresher.swift; sourceTree = "<group>"; };
 		107354077329DDFCCA716A4D /* QuickActionsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickActionsStore.swift; sourceTree = "<group>"; };
@@ -379,6 +383,7 @@
 				8B5435F2C6AADD54DE910072 /* QuickActionTests.swift */,
 				8E705AF49A322B7ECB5700BB /* SettingsConfigStoreTests.swift */,
 				2445B39E48FEA8F4AC318C08 /* SidebarListBridgeTests.swift */,
+				0520C77C17845C086A5E597A /* StartupCommandResolverTests.swift */,
 				CC7EFDC8D28B1681B068CE01 /* StatusIndicatorGateTests.swift */,
 				821BF7B943BBA8650E8769A4 /* TerminalPwdStoreTests.swift */,
 				CC8D978AA26C3DD97EF58200 /* TerminalStatusIconViewTests.swift */,
@@ -397,6 +402,7 @@
 			children = (
 				A5F940956C8E5C463DA771CE /* PasteboardTypes.swift */,
 				F5E3E4715565F7F2A0692381 /* SplitPaneView.swift */,
+				04EE67FE969E31DA1B40FA42 /* StartupCommandResolver.swift */,
 				5DEC02C6A3912B9FFA44F2E2 /* SurfaceScrollView.swift */,
 				EF52B8A70429B8C4F21259E8 /* TabBarView.swift */,
 				84326382AC1806C28810AF31 /* TabContentView.swift */,
@@ -614,6 +620,7 @@
 				543181BB757BF9C86BFEB93E /* QuickActionsStoreTests.swift in Sources */,
 				915558F09223486690E05227 /* SettingsConfigStoreTests.swift in Sources */,
 				50E216D7B2C3E79CC5F2BD35 /* SidebarListBridgeTests.swift in Sources */,
+				39B56550E6DE3A7BF8E95160 /* StartupCommandResolverTests.swift in Sources */,
 				D795617034323AC803958EEE /* StatusIndicatorGateTests.swift in Sources */,
 				A88A524A7FCB090037E7DB2C /* TerminalPwdStoreTests.swift in Sources */,
 				6AA362AD3255878AD318860E /* TerminalStatusIconViewTests.swift in Sources */,
@@ -665,6 +672,7 @@
 				EBAE55689BA99138A7DF1F17 /* SidebarView.swift in Sources */,
 				8548616652B7ABFDA2934C4D /* SparkleBridge.swift in Sources */,
 				7CB3C1A6EA7A40B724C7F8FB /* SplitPaneView.swift in Sources */,
+				B412AD249899F1C04B40E501 /* StartupCommandResolver.swift in Sources */,
 				DB838A8F31BA5F87C13A1CC3 /* SurfaceScrollView.swift in Sources */,
 				BE4934BAEB0C0F7EA0F11903 /* TabBarView.swift in Sources */,
 				04E0044A5A0B062E6B332F28 /* TabBridge.swift in Sources */,

--- a/mux0/TabContent/StartupCommandResolver.swift
+++ b/mux0/TabContent/StartupCommandResolver.swift
@@ -5,8 +5,19 @@ import Foundation
 /// `TabContentView.resolvedStartupCommand(forTerminal:)`.
 ///
 /// Source order:
-///   0. Quick action tab's first terminal — return
-///      `"<quickActionCommand>\n"` (built-in default or user override).
+///   0. Quick action tab's first terminal:
+///      0a. If the action id is a builtin agent (claude / codex / opencode),
+///          the agent's Resume toggle is on, AND `pendingPrefill` is a
+///          matching `<agent> --resume <id>` (or `codex resume <id>` /
+///          `opencode --session <id>`)
+///          string → return the prefill verbatim. The agent equality guard
+///          prevents a stale prefill written by a different agent from
+///          being replayed here. User overrides of the builtin command
+///          (e.g. `claude --debug`) are intentionally bypassed: the resume
+///          command is the agent's canonical CLI form, and a user who
+///          turned Resume on expects continuity.
+///      0b. Otherwise → return `"<quickActionCommand>\n"` (built-in default
+///          or user override).
 ///   1. Pending agent resume command (`claude --resume <id>` /
 ///      `codex resume <id>` / `opencode --session <id>`) — only when the
 ///      matching agent's Resume toggle is on. Default OFF means stale
@@ -28,12 +39,29 @@ enum StartupCommandResolver {
         // (0) Quick action tab's first terminal.
         if let tab,
            let actionId = tab.quickActionId,
-           terminalId == tab.layout.allTerminalIds().first,
-           let cmd = quickActionCommand(actionId) {
-            return "\(cmd)\n"
+           terminalId == tab.layout.allTerminalIds().first {
+
+            // (0a) If this Quick Action is a builtin agent, the agent's
+            //      Resume toggle is on, AND we have a stored prefill whose
+            //      leading CLI token matches the same agent → replay that
+            //      `<agent> --resume <id>` instead of the bare command.
+            //      The agent equality guard prevents a stale prefill written
+            //      by a different agent from being replayed here.
+            if let agent = HookMessage.Agent(rawValue: actionId),
+               isResumeEnabled(agent),
+               let pending = pendingPrefill,
+               HookMessage.Agent.fromResumeCommand(pending) == agent {
+                return pending
+            }
+
+            // (0b) Fallback: original Quick Action command (built-in default
+            //      or user override).
+            if let cmd = quickActionCommand(actionId) {
+                return "\(cmd)\n"
+            }
         }
 
-        // (1) Agent resume.
+        // (1) Agent resume — naked terminal path.
         if let pending = pendingPrefill,
            let agent = HookMessage.Agent.fromResumeCommand(pending),
            isResumeEnabled(agent) {

--- a/mux0/TabContent/StartupCommandResolver.swift
+++ b/mux0/TabContent/StartupCommandResolver.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Pure resolver for the shell command auto-injected into a freshly created
+/// ghostty surface. Mirrors the precedence rules previously inlined in
+/// `TabContentView.resolvedStartupCommand(forTerminal:)`.
+///
+/// Source order:
+///   0. Quick action tab's first terminal — return
+///      `"<quickActionCommand>\n"` (built-in default or user override).
+///   1. Pending agent resume command (`claude --resume <id>` /
+///      `codex resume <id>` / `opencode --session <id>`) — only when the
+///      matching agent's Resume toggle is on. Default OFF means stale
+///      UserDefaults entries are ignored, not replayed.
+///   2. Workspace-level `defaultCommand`.
+///
+/// Inputs are passed explicitly (rather than wiring up real stores) so the
+/// resolver can be unit-tested without bringing up an NSView, WorkspaceStore,
+/// SettingsConfigStore, or QuickActionsStore.
+enum StartupCommandResolver {
+    static func resolve(
+        terminalId: UUID,
+        tab: TerminalTab?,
+        workspaceDefaultCommand: String?,
+        quickActionCommand: (QuickActionId) -> String?,
+        isResumeEnabled: (HookMessage.Agent) -> Bool,
+        pendingPrefill: String?
+    ) -> String? {
+        // (0) Quick action tab's first terminal.
+        if let tab,
+           let actionId = tab.quickActionId,
+           terminalId == tab.layout.allTerminalIds().first,
+           let cmd = quickActionCommand(actionId) {
+            return "\(cmd)\n"
+        }
+
+        // (1) Agent resume.
+        if let pending = pendingPrefill,
+           let agent = HookMessage.Agent.fromResumeCommand(pending),
+           isResumeEnabled(agent) {
+            return pending
+        }
+
+        // (2) Workspace default command.
+        return workspaceDefaultCommand
+    }
+}

--- a/mux0/TabContent/TabContentView.swift
+++ b/mux0/TabContent/TabContentView.swift
@@ -273,21 +273,9 @@ final class TabContentView: NSView {
         return tv
     }
 
-    /// Pick the shell command to auto-execute on a fresh surface. Source order:
-    ///   0. Quick action tab's first terminal — resolved via
-    ///      `QuickActionsStore.command(for:)`. Built-in actions fall back to
-    ///      default commands (e.g. `gitui`); custom actions return nil if
-    ///      their command is empty (in which case the next branch's defaults
-    ///      take over). Fires every time the surface is built — so restarting
-    ///      mux0 re-runs the action automatically. Splitting inside a quick
-    ///      action tab does NOT apply this to the new pane (only the layout's
-    ///      first terminal id matches).
-    ///   1. Pending agent resume command (`claude --resume <id>` /
-    ///      `codex resume <id>`) — only when the matching agent's Resume
-    ///      toggle in Settings is ON. Default OFF means stale UserDefaults
-    ///      entries from earlier runs (or before the toggle existed) are
-    ///      ignored, not replayed.
-    ///   2. Workspace-level `defaultCommand`.
+    /// Thin wrapper that gathers state from the active workspace and forwards
+    /// to `StartupCommandResolver.resolve` — see that type's doc comment for
+    /// the full source-order rules (Quick Action / agent resume / default).
     private func resolvedStartupCommand(forTerminal id: UUID) -> String? {
         let workspace = store?.selectedWorkspace
         let tab = workspace?.tabs.first { $0.layout.allTerminalIds().contains(id) }

--- a/mux0/TabContent/TabContentView.swift
+++ b/mux0/TabContent/TabContentView.swift
@@ -289,26 +289,21 @@ final class TabContentView: NSView {
     ///      ignored, not replayed.
     ///   2. Workspace-level `defaultCommand`.
     private func resolvedStartupCommand(forTerminal id: UUID) -> String? {
-        // (0) Quick action tab's first terminal → resolve via QuickActionsStore.
-        if let tab = store?.selectedWorkspace?.tabs.first(where: {
-                $0.layout.allTerminalIds().contains(id)
-            }),
-            let actionId = tab.quickActionId,
-            id == tab.layout.allTerminalIds().first,
-            let cmd = quickActionsStore?.command(for: actionId)
-        {
-            return "\(cmd)\n"
-        }
-
-        // (1) Agent resume.
-        if let pending = store?.consumePendingPrefill(terminalId: id),
-           let agent = HookMessage.Agent.fromResumeCommand(pending),
-           settingsStore?.get(agent.resumeSettingsKey) == "true" {
-            return pending
-        }
-
-        // (2) Workspace default command.
-        return store?.selectedWorkspace?.defaultCommand
+        let workspace = store?.selectedWorkspace
+        let tab = workspace?.tabs.first { $0.layout.allTerminalIds().contains(id) }
+        let pendingPrefill = store?.consumePendingPrefill(terminalId: id)
+        return StartupCommandResolver.resolve(
+            terminalId: id,
+            tab: tab,
+            workspaceDefaultCommand: workspace?.defaultCommand,
+            quickActionCommand: { [quickActionsStore] actionId in
+                quickActionsStore?.command(for: actionId)
+            },
+            isResumeEnabled: { [settingsStore] agent in
+                settingsStore?.get(agent.resumeSettingsKey) == "true"
+            },
+            pendingPrefill: pendingPrefill
+        )
     }
 
     private func focusTerminal(_ id: UUID) {

--- a/mux0Tests/StartupCommandResolverTests.swift
+++ b/mux0Tests/StartupCommandResolverTests.swift
@@ -131,4 +131,103 @@ final class StartupCommandResolverTests: XCTestCase {
         )
         XCTAssertEqual(result, "default-cmd")
     }
+
+    // MARK: - Quick Action resume (Task 2)
+
+    func testQuickActionClaude_resumeOn_matchingPrefill_returnsPrefill() {
+        let term = UUID()
+        let tab = TerminalTab(title: "T", terminalId: term, quickActionId: "claude")
+        let result = StartupCommandResolver.resolve(
+            terminalId: term,
+            tab: tab,
+            workspaceDefaultCommand: nil,
+            quickActionCommand: { _ in "claude" },
+            isResumeEnabled: { $0 == .claude },
+            pendingPrefill: "claude --resume abc-123"
+        )
+        XCTAssertEqual(result, "claude --resume abc-123")
+    }
+
+    func testQuickActionClaude_resumeOn_mismatchedPrefill_returnsNakedClaude() {
+        let term = UUID()
+        let tab = TerminalTab(title: "T", terminalId: term, quickActionId: "claude")
+        let result = StartupCommandResolver.resolve(
+            terminalId: term,
+            tab: tab,
+            workspaceDefaultCommand: nil,
+            quickActionCommand: { _ in "claude" },
+            isResumeEnabled: { _ in true },
+            // Cross-agent prefill must not be replayed: the (0a) agent
+            // equality guard (`fromResumeCommand(pending) == agent`) is
+            // what prevents this — without it, this test would return
+            // the codex prefill instead of "claude\n".
+            pendingPrefill: "codex resume xyz-789"
+        )
+        XCTAssertEqual(result, "claude\n")
+    }
+
+    func testQuickActionClaude_overrideCommand_resumeOn_returnsPrefill() {
+        // User changed the builtin claude command to `claude --debug` AND
+        // turned the Resume toggle on. Spec: resume wins, ignore override.
+        let term = UUID()
+        let tab = TerminalTab(title: "T", terminalId: term, quickActionId: "claude")
+        let result = StartupCommandResolver.resolve(
+            terminalId: term,
+            tab: tab,
+            workspaceDefaultCommand: nil,
+            quickActionCommand: { _ in "claude --debug" },
+            isResumeEnabled: { $0 == .claude },
+            pendingPrefill: "claude --resume abc-123"
+        )
+        XCTAssertEqual(result, "claude --resume abc-123")
+    }
+
+    func testQuickActionCustomUUID_claudePrefill_returnsCustomCommand() {
+        // Custom Quick Action id is a UUID string — `Agent(rawValue:)` fails,
+        // so the resume branch must NOT fire for it.
+        let term = UUID()
+        let customId = UUID().uuidString
+        let tab = TerminalTab(title: "T", terminalId: term, quickActionId: customId)
+        let result = StartupCommandResolver.resolve(
+            terminalId: term,
+            tab: tab,
+            workspaceDefaultCommand: nil,
+            quickActionCommand: { _ in "my-script.sh" },
+            isResumeEnabled: { _ in true },
+            pendingPrefill: "claude --resume abc-123"
+        )
+        XCTAssertEqual(result, "my-script.sh\n")
+    }
+
+    func testQuickActionCodex_resumeOn_returnsCodexResumePrefill() {
+        // Codex uses `codex resume <id>` (no double-dash). Verify both
+        // builtin agents work, not just claude.
+        let term = UUID()
+        let tab = TerminalTab(title: "T", terminalId: term, quickActionId: "codex")
+        let result = StartupCommandResolver.resolve(
+            terminalId: term,
+            tab: tab,
+            workspaceDefaultCommand: nil,
+            quickActionCommand: { _ in "codex" },
+            isResumeEnabled: { $0 == .codex },
+            pendingPrefill: "codex resume xyz-789"
+        )
+        XCTAssertEqual(result, "codex resume xyz-789")
+    }
+
+    func testQuickActionOpencode_resumeOn_returnsOpencodeSessionPrefill() {
+        // Opencode uses `opencode --session <id>` (not `--resume`).
+        // Confirms (0a) treats all three builtin agents symmetrically.
+        let term = UUID()
+        let tab = TerminalTab(title: "T", terminalId: term, quickActionId: "opencode")
+        let result = StartupCommandResolver.resolve(
+            terminalId: term,
+            tab: tab,
+            workspaceDefaultCommand: nil,
+            quickActionCommand: { _ in "opencode" },
+            isResumeEnabled: { $0 == .opencode },
+            pendingPrefill: "opencode --session sess-42"
+        )
+        XCTAssertEqual(result, "opencode --session sess-42")
+    }
 }

--- a/mux0Tests/StartupCommandResolverTests.swift
+++ b/mux0Tests/StartupCommandResolverTests.swift
@@ -1,0 +1,134 @@
+import XCTest
+@testable import mux0
+
+final class StartupCommandResolverTests: XCTestCase {
+    // MARK: - Quick Action branch (unchanged after Task 2)
+
+    func testQuickActionGitui_returnsNakedCommand() {
+        let term = UUID()
+        let tab = TerminalTab(title: "T", terminalId: term, quickActionId: "gitui")
+        let result = StartupCommandResolver.resolve(
+            terminalId: term,
+            tab: tab,
+            workspaceDefaultCommand: "should-not-fire",
+            quickActionCommand: { _ in "gitui" },
+            isResumeEnabled: { _ in true },
+            pendingPrefill: "claude --resume abc"  // ignored: gitui isn't an agent
+        )
+        XCTAssertEqual(result, "gitui\n")
+    }
+
+    func testQuickActionClaude_noPrefill_returnsNakedClaude() {
+        let term = UUID()
+        let tab = TerminalTab(title: "T", terminalId: term, quickActionId: "claude")
+        let result = StartupCommandResolver.resolve(
+            terminalId: term,
+            tab: tab,
+            workspaceDefaultCommand: nil,
+            quickActionCommand: { _ in "claude" },
+            isResumeEnabled: { _ in true },
+            pendingPrefill: nil
+        )
+        XCTAssertEqual(result, "claude\n")
+    }
+
+    func testQuickActionClaude_toggleOff_returnsNakedClaude() {
+        let term = UUID()
+        let tab = TerminalTab(title: "T", terminalId: term, quickActionId: "claude")
+        let result = StartupCommandResolver.resolve(
+            terminalId: term,
+            tab: tab,
+            workspaceDefaultCommand: nil,
+            quickActionCommand: { _ in "claude" },
+            isResumeEnabled: { _ in false },
+            pendingPrefill: "claude --resume abc"
+        )
+        XCTAssertEqual(result, "claude\n")
+    }
+
+    // MARK: - Naked terminal Agent resume branch (must not regress)
+
+    func testNakedTerminal_resumeOn_returnsPrefill() {
+        let term = UUID()
+        let tab = TerminalTab(title: "T", terminalId: term, quickActionId: nil)
+        let result = StartupCommandResolver.resolve(
+            terminalId: term,
+            tab: tab,
+            workspaceDefaultCommand: "default-cmd",
+            quickActionCommand: { _ in nil },
+            isResumeEnabled: { _ in true },
+            pendingPrefill: "claude --resume abc"
+        )
+        XCTAssertEqual(result, "claude --resume abc")
+    }
+
+    func testNakedTerminal_resumeOff_returnsDefaultCommand() {
+        let term = UUID()
+        let tab = TerminalTab(title: "T", terminalId: term, quickActionId: nil)
+        let result = StartupCommandResolver.resolve(
+            terminalId: term,
+            tab: tab,
+            workspaceDefaultCommand: "default-cmd",
+            quickActionCommand: { _ in nil },
+            isResumeEnabled: { _ in false },
+            pendingPrefill: "claude --resume abc"
+        )
+        XCTAssertEqual(result, "default-cmd")
+    }
+
+    func testNakedTerminal_noPrefill_returnsDefaultCommand() {
+        let term = UUID()
+        let tab = TerminalTab(title: "T", terminalId: term, quickActionId: nil)
+        let result = StartupCommandResolver.resolve(
+            terminalId: term,
+            tab: tab,
+            workspaceDefaultCommand: "default-cmd",
+            quickActionCommand: { _ in nil },
+            isResumeEnabled: { _ in true },
+            pendingPrefill: nil
+        )
+        XCTAssertEqual(result, "default-cmd")
+    }
+
+    func testNakedTerminal_noPrefill_noDefault_returnsNil() {
+        let term = UUID()
+        let tab = TerminalTab(title: "T", terminalId: term, quickActionId: nil)
+        let result = StartupCommandResolver.resolve(
+            terminalId: term,
+            tab: tab,
+            workspaceDefaultCommand: nil,
+            quickActionCommand: { _ in nil },
+            isResumeEnabled: { _ in true },
+            pendingPrefill: nil
+        )
+        XCTAssertNil(result)
+    }
+
+    // MARK: - Quick Action tab, non-first pane (split sibling)
+
+    func testQuickActionTab_secondPane_fallsThroughToDefault() {
+        let firstTerm = UUID()
+        let secondTerm = UUID()
+        // SplitNode.split is positional: (UUID, SplitDirection, CGFloat,
+        // SplitNode, SplitNode).
+        let layout: SplitNode = .split(
+            UUID(),
+            .horizontal,
+            0.5,
+            .terminal(firstTerm),
+            .terminal(secondTerm)
+        )
+        var tab = TerminalTab(title: "T", terminalId: firstTerm, quickActionId: "claude")
+        tab.layout = layout
+        // resolve for the SECOND terminal — not the first leaf.
+        let result = StartupCommandResolver.resolve(
+            terminalId: secondTerm,
+            tab: tab,
+            workspaceDefaultCommand: "default-cmd",
+            quickActionCommand: { _ in "claude" },
+            isResumeEnabled: { _ in true },
+            pendingPrefill: nil
+        )
+        XCTAssertEqual(result, "default-cmd")
+    }
+}


### PR DESCRIPTION
## Summary

- 之前侧边栏右上角 claude / codex / opencode Quick Action 启动的 tab，每次重启都裸跑 CLI，即使 Resume toggle 开着、且已记录 session id —— Quick Action 命令分支永远赢，prefill 被吃掉
- 新增 (0a) 子分支：当 `tab.quickActionId` 命中 builtin agent、对应 Resume toggle 开启、`pendingPrefills[terminalId]` 是匹配 agent 的 `<agent> --resume <id>` 时，注入 prefill 而非裸命令；用户 override 的 builtin 命令在 resume 路径下被有意绕过（恢复 session 比保留 flag 更优先）
- 重构：把 `TabContentView.resolvedStartupCommand` 的 3-branch precedence 抽成纯静态 `StartupCommandResolver.resolve(...)`，闭包接 store / settings，可独立单测
- 14 个 unit tests 覆盖 builtin agent / 自定义 UUID / override / mismatch / 多 split 兄弟节点等矩阵

🤖 Generated with [Claude Code](https://claude.com/claude-code)