### PR TITLE
fix(agent-hooks): claude wrapper passes through known subcommands

### DIFF
--- a/Resources/agent-hooks/claude-wrapper.sh
+++ b/Resources/agent-hooks/claude-wrapper.sh
@@ -1,6 +1,23 @@
 #!/bin/bash
-# claude-wrapper.sh — launch Claude Code with mux0 lifecycle hooks injected.
-# Written for mux0 from scratch; do not redistribute without verifying license compat.
+# claude-wrapper.sh — launch Claude Code with mux0 lifecycle hooks injected
+# via `claude --settings <json>` on the top-level REPL/print modes.
+#
+# Why CLI flag instead of CLAUDE_CONFIG_DIR overlay?
+# Claude derives its macOS keychain service name from
+# `sha256(CLAUDE_CONFIG_DIR)[:8]` — overriding the env var would shift the
+# hash, so OAuth tokens stored in keychain under the real
+# `~/.claude` hash become unreachable and the user has to log in again on
+# every session. Keeping CLAUDE_CONFIG_DIR untouched and injecting hooks
+# via a CLI flag preserves login state and shares it with non-mux0 claude.
+#
+# Why a passthrough blocklist?
+# claude's subcommands (`mcp`, `doctor`, `--remote-control`, …) inherit
+# commander.js's argument parser, which doesn't always recognize the
+# top-level `--settings` flag — `claude remote-control` regressed with
+# "Unknown argument: { hooks: …}" (issue #26). Hooks are meaningless for
+# those one-shot subcommands anyway, so we passthrough without injection
+# whenever any arg matches a known subcommand or help/version flag.
+#
 # Reads MUX0_AGENT_HOOKS_DIR, MUX0_HOOK_SOCK, MUX0_TERMINAL_ID from env.
 
 set -e
@@ -36,6 +53,35 @@ fi
 # If mux0 env is missing (e.g. user ran this wrapper outside mux0), passthrough.
 if [ -z "$MUX0_AGENT_HOOKS_DIR" ] || [ -z "$MUX0_HOOK_SOCK" ] || [ -z "$MUX0_TERMINAL_ID" ]; then
     exec "$REAL_CLAUDE" "$@"
+fi
+
+# Subcommand / help / version passthrough. Walk all args (not just $1) so
+# things like `claude --debug remote-control` are caught too. Source of
+# truth: `claude --help` "Commands" section, plus the historical
+# `migrate-installer`/`config`/`remote-control` aliases that may not show
+# up in --help but still parse. If Claude Code adds a new subcommand and a
+# user reports it breaking, append the name here.
+#
+# Print mode escape: `claude -p update` is a print turn whose prompt happens
+# to equal a subcommand name; commander treats the positional as a prompt
+# (not a subcommand), so we MUST still inject hooks. Skip the blocklist scan
+# whenever `-p`/`--print` is anywhere in args — print mode never combines
+# with a subcommand.
+PRINT_MODE=0
+for arg in "$@"; do
+    case "$arg" in
+        -p|--print) PRINT_MODE=1; break ;;
+    esac
+done
+
+if [ "$PRINT_MODE" = "0" ]; then
+    for arg in "$@"; do
+        case "$arg" in
+            agents|auth|auto-mode|config|doctor|install|mcp|migrate-installer|plugin|plugins|project|remote-control|setup-token|ultrareview|update|upgrade|--help|-h|--version|-v)
+                exec "$REAL_CLAUDE" "$@"
+                ;;
+        esac
+    done
 fi
 
 EMIT="$MUX0_AGENT_HOOKS_DIR/hook-emit.sh"

--- a/docs/agent-hooks.md
+++ b/docs/agent-hooks.md
@@ -50,7 +50,7 @@ Agent turn 没有真实的 exit code，但 Claude Code / Codex 的 `PostToolUse`
 
 | Agent | 机制 | 文件 |
 |-------|------|------|
-| Claude Code | `--settings` 注入 hooks JSON（SessionStart/UserPromptSubmit/PreToolUse/Stop/Notification/SessionEnd） | `claude-wrapper.sh` |
+| Claude Code | `claude --settings <json>` 注入 hooks（SessionStart/UserPromptSubmit/PreToolUse/PostToolUse/Stop/Notification/SessionEnd）。**不**改 `CLAUDE_CONFIG_DIR`——claude 用 `sha256(CLAUDE_CONFIG_DIR)[:8]` 作为 macOS keychain service 名后缀，换路径就会跟原生 claude 的 keychain 登录态对不上。对 `mcp`/`doctor`/`--remote-control` 等 commander 子命令做 passthrough（它们的 sub-parser 不识别 `--settings`） | `claude-wrapper.sh` |
 | OpenCode | 插件订阅 bus 事件（tool.execute.before / permission.asked / session.idle 等） | `opencode-plugin/mux0-status.js` |
 | Codex | 实验性 `hooks.json` + `notify` 兜底 | `codex-wrapper.sh` |
 


### PR DESCRIPTION
## Summary

- `claude remote-control` 和其他 commander.js 子命令拒绝 `--settings <json>` flag，注入会报 "Unknown argument: { hooks: …}"。
- 改用 blocklist：walk 所有 args，命中已知子命令（`agents auth auto-mode config doctor install mcp migrate-installer plugin(s) project remote-control setup-token ultrareview update upgrade`）或 `--help/--version` 时 passthrough，不注入 hooks。这些 one-shot 子命令本来也没有 hook 生命周期事件。
- 曾尝试 overlay `CLAUDE_CONFIG_DIR` 方案（同 codex-wrapper 套路），但发现 claude 用 `sha256(CLAUDE_CONFIG_DIR)[:8]` 作为 macOS keychain service 名后缀——每次 mktemp 新 overlay 路径 → 新 service → 用户每次重启 mux0 都要重新登录 claude。回退到 CLI flag + blocklist，keychain hash 跟原生 claude 一致，登录态共享。
- 后续 Claude Code 出新子命令导致同问题时，把名字追加进 wrapper 的 case 语句即可。

Fixes #26