### PR TITLE
fix(agent-hooks): repair codex wrapper cleanup so config.toml + OVERLAY housekeeping persists

### DIFF
--- a/Resources/agent-hooks/codex-wrapper.sh
+++ b/Resources/agent-hooks/codex-wrapper.sh
@@ -88,14 +88,28 @@ export CODEX_HOME="$OVERLAY"
 # Also mark the terminal idle on exit — otherwise the precmd hook has to fire
 # before the icon updates, which can lag if the user closes the window.
 cleanup() {
-    # Codex writes config.toml via `tempfile + rename(2)`, which replaces the
-    # symlink we placed at $OVERLAY/config.toml with a regular file. If that
-    # happened (i.e. it's no longer a symlink but is a real file), copy it
-    # back to the user's real CODEX_HOME so changes from `codex features
-    # enable`, `codex login`, etc. persist across sessions.
-    if [ -f "$OVERLAY/config.toml" ] && [ ! -L "$OVERLAY/config.toml" ]; then
-        mkdir -p "$USER_HOME"
-        cp -f "$OVERLAY/config.toml" "$USER_HOME/config.toml" 2>/dev/null || true
+    # Codex persists state files (config.toml, hooks.state, possibly others)
+    # via `tempfile + rename(2)`, which atomically REPLACES the symlink we
+    # placed in the overlay with a regular file. Any top-level entry that's
+    # now a regular file (not a symlink) is something codex wrote during this
+    # session; copy it back to the user's real CODEX_HOME so it survives the
+    # `rm -rf` below. This is what lets `codex features enable`, `codex
+    # login`, and — most importantly — hook trust approvals from `/hooks`
+    # persist across mux0-launched codex sessions.
+    #
+    # hooks.json is excluded because we wrote it ourselves into the overlay
+    # and the user's real CODEX_HOME shouldn't grow a mux0-managed file.
+    if [ -d "$OVERLAY" ]; then
+        for item in "$OVERLAY"/*; do
+            [ -f "$item" ] || continue
+            [ -L "$item" ] && continue
+            name=$(basename "$item")
+            case "$name" in
+                hooks.json) continue ;;
+            esac
+            mkdir -p "$USER_HOME"
+            cp -f "$item" "$USER_HOME/$name" 2>/dev/null || true
+        done
     fi
     rm -rf "$OVERLAY" 2>/dev/null || true
     "$EMIT" idle codex 2>/dev/null || true

--- a/Resources/agent-hooks/codex-wrapper.sh
+++ b/Resources/agent-hooks/codex-wrapper.sh
@@ -116,13 +116,28 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
-# Emit idle BEFORE exec: shell preexec already marked us running when the user
-# typed `codex`, but codex's own `notify` only fires on turn completion, and
-# hooks.json requires features.codex_hooks. Without this, the UI sits on
-# "running" from launch until the first turn completes — which is wrong,
-# since codex is actually idle at its input prompt.
+# Emit idle BEFORE handing off to codex: shell preexec already marked us
+# running when the user typed `codex`, but codex's own `notify` only fires
+# on turn completion. Without this, the UI sits on "running" from launch
+# until the first turn completes — wrong, since codex is actually idle at
+# its input prompt.
 "$EMIT" idle codex 2>/dev/null || true
 
-# Inject `notify` via -c so we don't have to mutate the user's config.toml.
-# Codex's `-c key=value` parses value as TOML; arrays work (see `codex --help`).
-exec "$REAL_CODEX" -c "notify=[\"$EMIT\", \"idle\", \"codex\"]" "$@"
+# Run codex as a subprocess instead of `exec`ing it. `exec` would replace
+# this bash process entirely, and bash does NOT fire EXIT/INT/TERM traps
+# after a successful exec — the overlay below would leak in $TMPDIR and,
+# more importantly, the cleanup trap would never copy codex's persisted
+# state files (hooks.state for `/hooks` trust approvals, config.toml for
+# `codex login` / `codex features enable`) back to the user's real
+# CODEX_HOME. The next mux0-launched codex session would then see a fresh
+# untrusted state and silently never run any hook.
+#
+# `notify` is injected via -c so we don't have to mutate the user's
+# config.toml. Codex's `-c key=value` parses value as TOML; arrays work
+# (see `codex --help`).
+#
+# `|| EXIT_CODE=$?` consumes a non-zero exit so `set -e` (top of file) does
+# not short-circuit before we forward the code via the final `exit`.
+EXIT_CODE=0
+"$REAL_CODEX" -c "notify=[\"$EMIT\", \"idle\", \"codex\"]" "$@" || EXIT_CODE=$?
+exit "$EXIT_CODE"

--- a/Resources/agent-hooks/tests/codex_wrapper_cleanup.sh
+++ b/Resources/agent-hooks/tests/codex_wrapper_cleanup.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# codex_wrapper_cleanup.sh — end-to-end smoke that proves codex-wrapper.sh
+# actually runs its cleanup trap after codex exits. The wrapper used to
+# `exec "$REAL_CODEX" ...`, which silently nuked the EXIT trap — so the
+# overlay's hooks.state (where codex persists /hooks trust approvals) and
+# config.toml writes never got copied back to the user's real CODEX_HOME,
+# leaving every mux0-launched codex session untrusted again. This test
+# guards against that regression by faking codex with a script that writes
+# a recognisable hooks.state into $CODEX_HOME and asserting the file ends
+# up in the user's CODEX_HOME after the wrapper returns.
+
+set -e
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$HERE/.."
+WRAPPER="$SCRIPT_DIR/codex-wrapper.sh"
+
+FAKE_HOME=$(mktemp -d -t mux0-codex-home.XXXXXX)
+FAKE_BIN_DIR=$(mktemp -d -t mux0-codex-bin.XXXXXX)
+USER_CODEX_HOME="$FAKE_HOME/.codex"
+mkdir -p "$USER_CODEX_HOME"
+
+cleanup_test() {
+    rm -rf "$FAKE_HOME" "$FAKE_BIN_DIR"
+}
+trap cleanup_test EXIT INT TERM
+
+# Fake codex: simulate a /hooks approve by writing hooks.state via the same
+# `tempfile + rename(2)` dance the real codex uses, then exit cleanly.
+FAKE_CODEX="$FAKE_BIN_DIR/codex"
+cat > "$FAKE_CODEX" <<'FAKE'
+#!/bin/bash
+set -e
+NEW_STATE="$CODEX_HOME/.hooks.state.tmp.$$"
+cat > "$NEW_STATE" <<TOML
+[hook.UserPromptSubmit]
+trusted = true
+trusted_hash = "smoke-test-hash"
+TOML
+mv "$NEW_STATE" "$CODEX_HOME/hooks.state"
+
+# Also touch config.toml the same way to cover the original writeback path.
+NEW_CFG="$CODEX_HOME/.config.toml.tmp.$$"
+echo "smoke = true" > "$NEW_CFG"
+mv "$NEW_CFG" "$CODEX_HOME/config.toml"
+FAKE
+chmod +x "$FAKE_CODEX"
+
+# Drive the wrapper. We can't use a real Unix-domain socket here without
+# spinning one up; pointing $MUX0_HOOK_SOCK at /dev/null is fine because the
+# wrapper's hook-emit.sh invocations are all guarded with `|| true`.
+HOME="$FAKE_HOME" \
+CODEX_HOME="$USER_CODEX_HOME" \
+MUX0_REAL_CODEX="$FAKE_CODEX" \
+MUX0_AGENT_HOOKS_DIR="$SCRIPT_DIR" \
+MUX0_HOOK_SOCK="/dev/null" \
+MUX0_TERMINAL_ID="WRAPPERSMOKE" \
+bash "$WRAPPER" >/dev/null 2>&1
+
+# Assertions
+if [ ! -f "$USER_CODEX_HOME/hooks.state" ]; then
+    echo "FAIL: cleanup did not copy hooks.state back to $USER_CODEX_HOME"
+    echo "(this means the EXIT trap never fired — typical sign that the"
+    echo " wrapper used 'exec \$REAL_CODEX' again instead of subprocess+wait)"
+    exit 1
+fi
+
+if ! grep -q "smoke-test-hash" "$USER_CODEX_HOME/hooks.state"; then
+    echo "FAIL: hooks.state contents were not preserved"
+    cat "$USER_CODEX_HOME/hooks.state"
+    exit 1
+fi
+
+if [ ! -f "$USER_CODEX_HOME/config.toml" ]; then
+    echo "FAIL: cleanup did not copy config.toml back (regression of a2ca37d)"
+    exit 1
+fi
+
+if ! grep -q "smoke = true" "$USER_CODEX_HOME/config.toml"; then
+    echo "FAIL: config.toml contents were not preserved"
+    cat "$USER_CODEX_HOME/config.toml"
+    exit 1
+fi
+
+echo "WRAPPER_CLEANUP_OK"

--- a/docs/agent-hooks.md
+++ b/docs/agent-hooks.md
@@ -72,34 +72,34 @@ Claude Code 的 `Notification` hook 本身是一个双重信号：**真实的权
 
 历史上 codex 0.12x 把 hook 引擎放在 `Stage::UnderDevelopment` 的 `codex_hooks` flag 后面，必须在 `~/.codex/config.toml` 里写 `[features] codex_hooks = true` 才会读 `hooks.json`。**0.130 起这个 flag 改名成 `hooks`，并升到 `stable`，默认 `true`**——绝大多数情况下不需要用户在 config 里写任何东西。`codex features list` 可以快速确认（`hooks   stable   true`）。如果环境里残留了旧的 `codex_hooks = true`，codex 会把它视为未知 key，按 `deny_unknown_fields` 在配置层报错；新装就别再写了。
 
-### Hook trust（0.130 引入，是真正的"看起来失效了"主因）
+### Hook trust（0.130 引入）
 
-0.130 起 codex 给 `hooks.json` 加了一道 **trust 闸门**：每条 hook 第一次被加载时都是 `untrusted`，codex 启动时会在 TUI 顶部显示一行类似 `1 hook needs review before it can run. Open /hooks to review it.`，必须用户进 `/hooks` 手动 approve 后才会执行。Trust 状态（`trusted_hash`）持久化在 `$CODEX_HOME/hooks.state`（TOML，由 codex 通过 `tempfile + rename(2)` 写）。
+0.130 起 codex 给 `hooks.json` 加了一道 **trust 闸门**：每条 hook 第一次被加载时都是 `untrusted`，codex 启动时会在 TUI 顶部显示一行类似 `1 hook needs review before it can run. Open /hooks to review it.`，必须用户进 `/hooks` 手动 approve 后才会执行。**不 trust 的话 `UserPromptSubmit` / `PreToolUse` / `PostToolUse` / `Stop` 一个都不会跑**，表面症状就是 mux0 sidebar / tab 图标常驻 idle、turn 进行中也不变 running——0.130 升级后用户最常碰到的就是这个。
 
-**这条机制对 mux0 wrapper 的影响**：wrapper 用 overlay `CODEX_HOME` 跑 codex（隔离 `hooks.json` 不污染用户家目录），cleanup 会 `rm -rf` 整个 overlay。所以**必须把 codex 在 overlay 里写出来的 `hooks.state` 回写到用户真 `~/.codex/`**，否则 trust 一进 cleanup 就丢，下次启动 hooks 又变成 untrusted——表面症状就是"codex tab 上图标常驻 idle、turn 进行中不变 running"。
+**Trust state 的存储位置**：是 `$CODEX_HOME/config.toml` 的 `[hooks.state]` 段（不是单独的 `hooks.state` 文件），由 codex 通过 `tempfile + rename(2)` 整体替换写出。每条 entry 形如：
 
-cleanup 现在的策略是：**任何 overlay 顶层从 symlink 变成 regular file 的条目，都视作 codex 持久化产物，cp 回 `$USER_HOME`**（除我们自己写的 `hooks.json`）。这一条同时覆盖了历史上 `config.toml` 的回写——细节见 `codex-wrapper.sh:90-118` 注释。
+```toml
+[hooks.state."<hooks.json 绝对路径>:<event_name_snake_case>:<group_idx>:<handler_idx>"]
+trusted_hash = "sha256:..."
+```
 
-**Trust hash 的稳定性**：trust 的 key 是 hook **命令字符串的哈希**。我们的命令包含 `$MUX0_AGENT_HOOKS_DIR`（通常是 `/Applications/mux0.app/Contents/Resources/agent-hooks`），所以：
+**mux0 overlay 模式下的关键约束**：每个 codex tab，wrapper 都 `mktemp -d` 出一个独立 OVERLAY (`/var/folders/.../T/mux0-codex.XXXXXX.<8 字符随机>`)，把 `hooks.json` 写进去，把 `~/.codex` 下其它文件 symlink 进去。trust state 的 key 因此包含每次都会变的随机 OVERLAY 路径——**所以每次新开 codex tab 都需要再 `/hooks` approve 一次**。这是 codex 0.130 trust 模型跟 mux0 隔离方案的根本冲突，单靠 wrapper 改 cleanup 解决不了。等价的真修复方向是让 OVERLAY 路径稳定（例如按 `MUX0_TERMINAL_ID` 派生）或者引入 `bypass_hook_trust`，后续可以补，但 trust 一次性手动这个 UX 本身已经够轻，目前选择接受。
 
-- 同一个 mux0.app 实例跨重启 / 跨 codex tab 都能复用 trust
-- mux0 升级覆盖安装到同一 `/Applications/mux0.app` 路径不会破 trust
-- **从 Debug 构建（`DerivedData/.../mux0.app`）切到 Release（`/Applications/mux0.app`）路径变了，会需要重新 trust 一次**——这个体验代价我们接受了
+**Cleanup 的实际作用**：早期想用 cleanup 解决 trust 持久化（误以为 trust 在独立 `hooks.state` 文件里），实际**不是这条主路**。cleanup 真正修的是另两件事：
 
-### 不 trust 的后果
+1. **OVERLAY 不再泄露在 `/tmp` 里**——wrapper 退出时 `rm -rf` 自己 mktemp 出来的目录
+2. **`codex login` / `codex features enable` 这类会改 `config.toml` 的子命令的写入**——codex 用 `tempfile + rename(2)` 把 overlay 里的 `config.toml` symlink 替换成 regular file，cleanup 把它 cp 回 `~/.codex/config.toml`（顺带也把每个 OVERLAY 的 trust state 条目持久化到用户家目录，但因为 key 里包含 OVERLAY 路径，长期会在 `config.toml` 末尾累积一堆死 entry，定期手工清理一次即可——影响微乎其微）
 
-- `UserPromptSubmit` / `PreToolUse` / `Stop` 都不会执行
-- 只剩 `notify = [...]`（turn 完成时触发）和 wrapper 启动时主动 emit 的一次 idle
-- 表现：codex 启动 / 结束时正确显示 idle，但 **turn 进行中状态不会变成 running**（卡 idle）
+cleanup 现在的策略：**任何 overlay 顶层从 symlink 变成 regular file 的条目都 cp 回 `$USER_HOME`**（除我们自己写的 `hooks.json`），细节见 `codex-wrapper.sh:88-118` 注释。能跑成是因为 wrapper 末尾改成 subprocess + wait 模式而不是 `exec`——bash 的 EXIT trap 在 `exec` 后不触发，旧版 wrapper 这段 cleanup 是死代码。
 
 ### 调试入口
 
 用户反馈 "codex 状态不对" 时按这条顺序查：
 
-1. 在 mux0 里启动 codex tab，进入 codex TUI 后输入 `/hooks`——若三条 hook 显示 `untrusted` 或 `needs review`，approve 一遍就好
-2. 看 `~/.codex/hooks.state` 是否存在且体积非零（trust 过的状态会在这里）
-3. 看 `~/Library/Caches/mux0/hook-emit.log` 里 `agent=codex` 的事件是否只有 `idle` 没 `running`——只有 idle 通常就是 trust 没建起来
-4. 最后再看 `codex features list` 确认 `hooks` 是 `stable=true`，以及 `codex-wrapper.sh` 自己的逻辑
+1. 在 mux0 里启动 codex tab，进入 codex TUI 后输入 `/hooks`——若三条 hook 显示 `untrusted` 或 `needs review`，approve 一遍就好（**每个新 codex tab 都要做一次**，见上文 trust 一节）
+2. 看 `~/.codex/config.toml` 末尾有没有 `[hooks.state]` 段，里面 entry 是不是包含**当前** OVERLAY 的路径（OVERLAY 路径从 codex 进程的 `CODEX_HOME` env 看，或者 `ls -dt /var/folders/*/T/mux0-codex.XXXXXX.* | head -1`）
+3. 看 `~/Library/Caches/mux0/hook-emit.log` 里 `agent=codex` 的事件类型——`grep 'agent=codex' ~/Library/Caches/mux0/hook-emit.log | awk '{print $2}' | sort -u`。如果只有 `event=idle`，说明 hook 根本没在 turn 进行中触发，回去查 trust
+4. 最后再看 `codex features list` 确认 `hooks` 是 `stable=true`，以及 `codex-wrapper.sh` 自己的逻辑（subprocess 形态 + cleanup 真的执行）
 
 ### hooks.json Schema 注意事项
 

--- a/docs/agent-hooks.md
+++ b/docs/agent-hooks.md
@@ -66,25 +66,40 @@ Claude Code 的 `Notification` hook 本身是一个双重信号：**真实的权
 
 因此 `HookDispatcher` 对 `needsInput` 事件加了一道门：**只有当当前状态是 `.running` 时才转入 `.needsInput`**，在 `success / failed / idle / neverRan` 状态下收到 `needsInput` 直接丢弃。这样能保留 turn 结束后的终态不被后续心跳污染，同时不影响真实的权限请求场景（权限请求发生在 turn 进行中，状态必然是 `.running`）。OpenCode 的 `permission.asked` 同理适用。
 
-## Codex 的特殊规则：实验 flag
+## Codex 的特殊规则：feature flag + hook trust
 
-**Codex 的 hooks 默认不生效，用户必须在 `~/.codex/config.toml` 里显式打开：**
+### Feature flag（0.130 之后已经是 stable）
 
-```toml
-[features]
-codex_hooks = true
-```
+历史上 codex 0.12x 把 hook 引擎放在 `Stage::UnderDevelopment` 的 `codex_hooks` flag 后面，必须在 `~/.codex/config.toml` 里写 `[features] codex_hooks = true` 才会读 `hooks.json`。**0.130 起这个 flag 改名成 `hooks`，并升到 `stable`，默认 `true`**——绝大多数情况下不需要用户在 config 里写任何东西。`codex features list` 可以快速确认（`hooks   stable   true`）。如果环境里残留了旧的 `codex_hooks = true`，codex 会把它视为未知 key，按 `deny_unknown_fields` 在配置层报错；新装就别再写了。
 
-**为什么需要**：`codex_hooks` 是 OpenAI 标记的 `Stage::UnderDevelopment` 特性（源码在 `codex-rs/features/src/lib.rs`），官方保留修改权，默认关闭。我们的 wrapper 用 overlay `CODEX_HOME` 放 `hooks.json`，但 flag 必须在用户主 config 里声明——overlay 也无法替用户打开未声明的实验 flag。
+### Hook trust（0.130 引入，是真正的"看起来失效了"主因）
 
-**不开的后果**：
-- `hooks.json` 被 codex 完全忽略，`UserPromptSubmit` / `PreToolUse` / `Stop` 都收不到
+0.130 起 codex 给 `hooks.json` 加了一道 **trust 闸门**：每条 hook 第一次被加载时都是 `untrusted`，codex 启动时会在 TUI 顶部显示一行类似 `1 hook needs review before it can run. Open /hooks to review it.`，必须用户进 `/hooks` 手动 approve 后才会执行。Trust 状态（`trusted_hash`）持久化在 `$CODEX_HOME/hooks.state`（TOML，由 codex 通过 `tempfile + rename(2)` 写）。
+
+**这条机制对 mux0 wrapper 的影响**：wrapper 用 overlay `CODEX_HOME` 跑 codex（隔离 `hooks.json` 不污染用户家目录），cleanup 会 `rm -rf` 整个 overlay。所以**必须把 codex 在 overlay 里写出来的 `hooks.state` 回写到用户真 `~/.codex/`**，否则 trust 一进 cleanup 就丢，下次启动 hooks 又变成 untrusted——表面症状就是"codex tab 上图标常驻 idle、turn 进行中不变 running"。
+
+cleanup 现在的策略是：**任何 overlay 顶层从 symlink 变成 regular file 的条目，都视作 codex 持久化产物，cp 回 `$USER_HOME`**（除我们自己写的 `hooks.json`）。这一条同时覆盖了历史上 `config.toml` 的回写——细节见 `codex-wrapper.sh:90-118` 注释。
+
+**Trust hash 的稳定性**：trust 的 key 是 hook **命令字符串的哈希**。我们的命令包含 `$MUX0_AGENT_HOOKS_DIR`（通常是 `/Applications/mux0.app/Contents/Resources/agent-hooks`），所以：
+
+- 同一个 mux0.app 实例跨重启 / 跨 codex tab 都能复用 trust
+- mux0 升级覆盖安装到同一 `/Applications/mux0.app` 路径不会破 trust
+- **从 Debug 构建（`DerivedData/.../mux0.app`）切到 Release（`/Applications/mux0.app`）路径变了，会需要重新 trust 一次**——这个体验代价我们接受了
+
+### 不 trust 的后果
+
+- `UserPromptSubmit` / `PreToolUse` / `Stop` 都不会执行
 - 只剩 `notify = [...]`（turn 完成时触发）和 wrapper 启动时主动 emit 的一次 idle
-- 表现：codex 启动/结束时正确显示 idle，但 **turn 进行中状态不会变成 running**（停留在 idle）
+- 表现：codex 启动 / 结束时正确显示 idle，但 **turn 进行中状态不会变成 running**（卡 idle）
 
-**开了之后的预期**：UserPromptSubmit → running，Stop → idle，PreToolUse → running（目前 codex 只对 `Bash` 工具触发 PreToolUse，MCP/文件工具还没接）。
+### 调试入口
 
-**调试入口**：用户反馈 "codex 状态不对"，先问 flag 是否打开——未开是已知限制，非 bug；开了仍不对才去查 `~/Library/Caches/mux0/hook-emit.log` 和 `codex-wrapper.sh`。
+用户反馈 "codex 状态不对" 时按这条顺序查：
+
+1. 在 mux0 里启动 codex tab，进入 codex TUI 后输入 `/hooks`——若三条 hook 显示 `untrusted` 或 `needs review`，approve 一遍就好
+2. 看 `~/.codex/hooks.state` 是否存在且体积非零（trust 过的状态会在这里）
+3. 看 `~/Library/Caches/mux0/hook-emit.log` 里 `agent=codex` 的事件是否只有 `idle` 没 `running`——只有 idle 通常就是 trust 没建起来
+4. 最后再看 `codex features list` 确认 `hooks` 是 `stable=true`，以及 `codex-wrapper.sh` 自己的逻辑
 
 ### hooks.json Schema 注意事项
 


### PR DESCRIPTION
## Summary

Codex 0.130+ hooks 已经 stable + 默认 ON（`[features] hooks = true`，旧的 `codex_hooks` 是 deprecated alias），同时引入了 hook trust 闸门：每条 hook 第一次出现都要进 `/hooks` 手动 approve 才会执行，trust state 写在 `$CODEX_HOME/config.toml` 的 `[hooks.state]` 段、key 包含 hooks.json 的绝对路径。

调研 "codex 状态显示卡 idle" 时顺手发现 `a2ce7da` 引入的 cleanup 是死代码：wrapper 末尾的 `exec "$REAL_CODEX"` 替换了 bash 进程，EXIT/INT/TERM trap 永远不触发。结果：

- `codex login` / `codex features enable` 写到 OVERLAY 里的 `config.toml` 改动从来没回写到 `~/.codex/`
- OVERLAY tmpdir 永远不会被清理，长期堆在 `/var/folders/.../T/mux0-codex.XXXXXX.*`（实测一台机器堆了 35 个）

修复：

- wrapper 末尾从 `exec` 改成 subprocess + wait + cleanup，bash 不再被替换、trap 真正能跑。`|| EXIT_CODE=$?` 兜住非零退出码，`exit "\$EXIT_CODE"` 透传给 mux0
- cleanup 从「只回写 config.toml」泛化成「任何 overlay 顶层被替换成 regular file 的条目都 cp 回 `$USER_HOME`」（除我们自己写的 `hooks.json`），同时覆盖 config.toml 和未来 codex 可能新增的状态文件
- 加 `tests/codex_wrapper_cleanup.sh` 端到端 smoke：用 fake codex binary 模拟 `tempfile + rename(2)`，断言 cleanup 真的把文件 cp 回用户家目录。手动反向验证 — 用 awk 临时合成 exec-form wrapper，测试如期失败
- doc 改写：trust state 位置纠正到 `config.toml [hooks.state]`，trust hash key 包含 OVERLAY 路径所以「每次新 codex tab 都要 `/hooks` approve 一次」这个 UX 代价写明了，debug checklist 重做

**这一组修复不能让 trust 跨 codex tab 复用** — 那是 codex hook trust hash 跟 mux0 overlay 隔离的设计冲突，需要稳定的 OVERLAY 路径或 `bypass_hook_trust`，后续单独处理。这里只修可观察的两个 silent bug。