### PR TITLE
feat: keyboard shortcuts for tab/workspace switching

### DIFF
--- a/mux0/ContentView.swift
+++ b/mux0/ContentView.swift
@@ -357,6 +357,7 @@ extension Notification.Name {
     static let mux0SelectNextTab        = Notification.Name("mux0.selectNextTab")
     static let mux0SelectPrevTab        = Notification.Name("mux0.selectPrevTab")
     static let mux0SelectTabAtIndex     = Notification.Name("mux0.selectTabAtIndex")
+    static let mux0SelectWorkspaceAtIndex = Notification.Name("mux0.selectWorkspaceAtIndex")
 
     // Pane focus navigation (also bound in the "Terminal" menu).
     static let mux0FocusNextPane        = Notification.Name("mux0.focusNextPane")

--- a/mux0/Localization/L10n.swift
+++ b/mux0/Localization/L10n.swift
@@ -244,5 +244,9 @@ enum L10n {
         static func selectTabN(_ n: Int) -> LocalizedStringResource {
             LocalizedStringResource("menu.selectTab \(n)")
         }
+        /// `%lld` will be formatted at call site in mux0App.
+        static func selectWorkspaceN(_ n: Int) -> LocalizedStringResource {
+            LocalizedStringResource("menu.selectWorkspace \(n)")
+        }
     }
 }

--- a/mux0/Localization/Localizable.xcstrings
+++ b/mux0/Localization/Localizable.xcstrings
@@ -106,6 +106,13 @@
         "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "切换到第 %lld 个 Tab" } }
       }
     },
+    "menu.selectWorkspace %lld" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Select Workspace %lld" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "切换到第 %lld 个工作区" } }
+      }
+    },
     "menu.settings" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/mux0/Sidebar/SidebarView.swift
+++ b/mux0/Sidebar/SidebarView.swift
@@ -71,6 +71,11 @@ struct SidebarView: View {
         .onReceive(NotificationCenter.default.publisher(for: .mux0BeginCreateWorkspace)) { _ in
             createWorkspaceWithDefaultName()
         }
+        .onReceive(NotificationCenter.default.publisher(for: .mux0SelectWorkspaceAtIndex)) { note in
+            guard let idx = note.userInfo?["index"] as? Int,
+                  idx >= 0, idx < store.workspaces.count else { return }
+            store.select(id: store.workspaces[idx].id)
+        }
         .alert(String(localized: (L10n.Sidebar.deleteAlertTitle).withLocale(locale)),
                isPresented: Binding(
                    get: { workspaceToDelete != nil },

--- a/mux0/TabContent/TabContentView.swift
+++ b/mux0/TabContent/TabContentView.swift
@@ -481,19 +481,38 @@ final class TabContentView: NSView {
     // MARK: - Key monitor for ⌘⌥arrow pane navigation
 
     private func installKeyMonitor() {
-        // ⌘⌥→ and ⌘⌥← are now menu items (Terminal → Focus Next/Previous Pane),
-        // so SwiftUI dispatches those via .mux0FocusNextPane / .mux0FocusPrevPane.
-        // The monitor remains only for the ↑/↓ aliases — intentional hidden duplicates
-        // not shown in the menu, kept because they're a common pane-nav habit.
+        // 处理两组 menu 不可见的 hidden duplicate 快捷键：
+        // - ⌘⌥↑/↓ 是 Terminal → Focus Next/Previous Pane 的别名（菜单展示
+        //   ⌘⌥→/← 给水平 pane 直觉；↑/↓ 是常见 pane-nav 习惯）
+        // - Ctrl+Tab / Ctrl+Shift+Tab 是 Terminal → Select Next/Previous Tab
+        //   (⌘⇧]/[) 的浏览器/iTerm 风格别名
         keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
-            guard let self,
-                  event.modifierFlags.intersection([.command, .option]) == [.command, .option]
-            else { return event }
-            switch event.keyCode {
-            case 125: self.focusAdjacentPane(forward: true);  return nil  // ↓
-            case 126: self.focusAdjacentPane(forward: false); return nil  // ↑
-            default: return event
+            guard let self else { return event }
+
+            // 只看 ⌘⌃⌥⇧ 这四位，忽略 .numericPad / .function / .capsLock 等
+            let interesting: NSEvent.ModifierFlags = [.command, .control, .option, .shift]
+            let mods = event.modifierFlags.intersection(interesting)
+
+            // ⌘⌥↑/↓ — pane 切焦点
+            if mods == [.command, .option] {
+                switch event.keyCode {
+                case 125: self.focusAdjacentPane(forward: true);  return nil  // ↓
+                case 126: self.focusAdjacentPane(forward: false); return nil  // ↑
+                default: break
+                }
             }
+
+            // Ctrl+Tab / Ctrl+Shift+Tab — tab 循环（keyCode 48 = Tab）
+            if event.keyCode == 48 {
+                if mods == [.control] {
+                    self.cycleTab(forward: true);  return nil
+                }
+                if mods == [.control, .shift] {
+                    self.cycleTab(forward: false); return nil
+                }
+            }
+
+            return event
         }
     }
 

--- a/mux0/TabContent/TabContentView.swift
+++ b/mux0/TabContent/TabContentView.swift
@@ -478,7 +478,7 @@ final class TabContentView: NSView {
         return terminalViews[tab.focusedTerminalId]
     }
 
-    // MARK: - Key monitor for ⌘⌥arrow pane navigation
+    // MARK: - Key monitor (hidden shortcut aliases)
 
     private func installKeyMonitor() {
         // 处理两组 menu 不可见的 hidden duplicate 快捷键：

--- a/mux0/mux0App.swift
+++ b/mux0/mux0App.swift
@@ -87,6 +87,7 @@ struct mux0App: App {
                 .keyboardShortcut("a", modifiers: .command)
             }
 
+            workspaceCommands
             terminalCommands
         }
     }
@@ -102,6 +103,25 @@ struct mux0App: App {
         CommandGroup(replacing: .windowArrangement) { EmptyView() }  // NSWindow-tab items
         CommandGroup(replacing: .help) {
             Button(String(localized: L10n.Menu.help.withLocale(LanguageStore.shared.locale))) {}.disabled(true)  // placeholder; removes default Search field
+        }
+    }
+
+    @CommandsBuilder private var workspaceCommands: some Commands {
+        // 把 Cmd+1-9 绑成「切第 N 个 workspace」放在 File 菜单的 New Workspace 后面。
+        // 旧的「Cmd+1-9 切第 N 个 Tab」被降级到 Cmd+Opt+1-9（见 terminalCommands 末尾）。
+        // workspace 数量 < N 时由 SidebarView.onReceive 静默忽略，不弹 alert / 不 beep。
+        CommandGroup(after: .newItem) {
+            Divider()
+            ForEach(1...9, id: \.self) { idx in
+                Button(String(localized: L10n.Menu.selectWorkspaceN(idx)
+                                  .withLocale(LanguageStore.shared.locale))) {
+                    NotificationCenter.default.post(
+                        name: .mux0SelectWorkspaceAtIndex,
+                        object: nil,
+                        userInfo: ["index": idx - 1])
+                }
+                .keyboardShortcut(KeyEquivalent(Character(String(idx))), modifiers: .command)
+            }
         }
     }
 
@@ -152,7 +172,7 @@ struct mux0App: App {
                         object: nil,
                         userInfo: ["index": idx - 1])
                 }
-                .keyboardShortcut(KeyEquivalent(Character(String(idx))), modifiers: .command)
+                .keyboardShortcut(KeyEquivalent(Character(String(idx))), modifiers: [.command, .option])
             }
         }
     }

--- a/mux0Tests/L10nSmokeTests.swift
+++ b/mux0Tests/L10nSmokeTests.swift
@@ -30,6 +30,7 @@ final class L10nSmokeTests: XCTestCase {
         "menu.selectNextTab",
         "menu.selectPrevTab",
         "menu.selectTab %lld",
+        "menu.selectWorkspace %lld",   // ← new
         "menu.settings",
         "menu.splitHorizontal",
         "menu.splitVertical",

--- a/mux0Tests/NotificationNamesTests.swift
+++ b/mux0Tests/NotificationNamesTests.swift
@@ -5,6 +5,8 @@ final class NotificationNamesTests: XCTestCase {
     func testNewMenuNotificationRawValues() {
         XCTAssertEqual(Notification.Name.mux0FocusNextPane.rawValue, "mux0.focusNextPane")
         XCTAssertEqual(Notification.Name.mux0FocusPrevPane.rawValue, "mux0.focusPrevPane")
+        XCTAssertEqual(Notification.Name.mux0SelectWorkspaceAtIndex.rawValue,
+                       "mux0.selectWorkspaceAtIndex")
         // 注：mux0Copy / mux0Paste / mux0SelectAll 已删除——⌘C/⌘V/⌘A 不再走通知，
         // 改由 mux0App 的 pasteboard CommandGroup 通过 NSApp.sendAction(:to:nil)
         // 沿 responder chain 派发标准 selector，命中 NSText（rename / 设置 TextField）

--- a/mux0Tests/WorkspaceStoreTests.swift
+++ b/mux0Tests/WorkspaceStoreTests.swift
@@ -24,6 +24,24 @@ final class WorkspaceStoreTests: XCTestCase {
         XCTAssertEqual(store.selectedId, betaId)
     }
 
+    func testSelectWorkspace_unknownIdIsNoop() {
+        let store = WorkspaceStore(persistenceKey: "test-\(UUID())")
+        store.createWorkspace(name: "alpha")
+        let alphaId = store.workspaces[0].id
+        let unknownId = UUID()
+        store.select(id: unknownId)
+        XCTAssertEqual(store.selectedId, alphaId,
+                       "Selecting an unknown workspace id should not change selectedId")
+    }
+
+    func testSelectWorkspace_sameIdIsNoop() {
+        let store = WorkspaceStore(persistenceKey: "test-\(UUID())")
+        store.createWorkspace(name: "alpha")
+        let alphaId = store.workspaces[0].id
+        store.select(id: alphaId)  // already selected
+        XCTAssertEqual(store.selectedId, alphaId)
+    }
+
     func testDeleteWorkspace() {
         let store = WorkspaceStore(persistenceKey: "test-\(UUID())")
         store.createWorkspace(name: "to-delete")

--- a/mux0Tests/WorkspaceStoreTests.swift
+++ b/mux0Tests/WorkspaceStoreTests.swift
@@ -39,7 +39,8 @@ final class WorkspaceStoreTests: XCTestCase {
         store.createWorkspace(name: "alpha")
         let alphaId = store.workspaces[0].id
         store.select(id: alphaId)  // already selected
-        XCTAssertEqual(store.selectedId, alphaId)
+        XCTAssertEqual(store.selectedId, alphaId,
+                       "Re-selecting the already-selected workspace id should leave selectedId unchanged")
     }
 
     func testDeleteWorkspace() {


### PR DESCRIPTION
## Summary

- `⌘1`…`⌘9` 切换到第 N 个 workspace（之前绑的是 tab）
- `⌘⌥1`…`⌘⌥9` 切换到当前 workspace 的第 N 个 tab（从 `⌘1-9` 降一档）
- `Ctrl+Tab` / `Ctrl+Shift+Tab` 循环 tab（与现有 `⌘⇧]/[` 等价的 hidden duplicate，沿用 `⌘⌥↑/↓` 的 NSEvent monitor 模式）

数据流：SwiftUI menu → `mux0SelectWorkspaceAtIndex` 通知 → `SidebarView.onReceive` → `WorkspaceStore.select(id:)`（带边界检查）。workspace 数量 < N 时静默忽略。

Spec: `docs/superpowers/specs/2026-05-07-keyboard-shortcuts-tab-workspace-design.md`
Plan: `docs/superpowers/plans/2026-05-07-keyboard-shortcuts-tab-workspace.md`

## Refs #19

Issue #19 列了 5 项快捷键/通知改进，本 PR 覆盖其中 2 项；其余暂不实现：

- [x] (2) `Ctrl+Tab` / `Ctrl+Shift+Tab` 切 tab
- [x] (3) `⌘1-9` 切 workspace
- [ ] (1) `⌘⇧T` 重开关闭的 tab — 决定不做
- [ ] (4) 三指触摸板滑动切 tab — 决定不做
- [ ] (5) Claude 请求完成时的系统通知 — 范围外（属于通知系统，单独处理）

> Note: plan specified `feat(menu)` for the menu commit, but `menu` is not in CLAUDE.md's allowed scopes; `feat(bridge)` was used as the nearest match (mux0App menu commands are the SwiftUI ↔ AppKit notification bridge entry point).