### PR TITLE
fix(ghostty): correct set_occlusion semantic flip → v0.5.1

### DIFF
--- a/Vendor/ghostty/include/ghostty.h
+++ b/Vendor/ghostty/include/ghostty.h
@@ -364,7 +364,6 @@ typedef enum {
 } ghostty_input_trigger_tag_e;
 
 typedef union {
-  ghostty_input_key_e translated;
   ghostty_input_key_e physical;
   uint32_t unicode;
   // catch_all has no payload
@@ -1055,6 +1054,7 @@ typedef union {
 // apprt.ipc.Action.Key
 typedef enum {
   GHOSTTY_IPC_ACTION_NEW_WINDOW,
+  GHOSTTY_IPC_ACTION_TOGGLE_QUICK_TERMINAL,
 } ghostty_ipc_action_tag_e;
 
 //-------------------------------------------------------------------
@@ -1078,6 +1078,7 @@ GHOSTTY_API bool ghostty_config_get(ghostty_config_t, void*, const char*, uintpt
 GHOSTTY_API ghostty_input_trigger_s ghostty_config_trigger(ghostty_config_t,
                                                               const char*,
                                                               uintptr_t);
+GHOSTTY_API bool ghostty_config_key_is_binding(ghostty_config_t, ghostty_input_key_s);
 GHOSTTY_API uint32_t ghostty_config_diagnostics_count(ghostty_config_t);
 GHOSTTY_API ghostty_diagnostic_s ghostty_config_get_diagnostic(ghostty_config_t, uint32_t);
 GHOSTTY_API ghostty_string_s ghostty_config_open_path(void);
@@ -1089,7 +1090,6 @@ GHOSTTY_API void ghostty_app_tick(ghostty_app_t);
 GHOSTTY_API void* ghostty_app_userdata(ghostty_app_t);
 GHOSTTY_API void ghostty_app_set_focus(ghostty_app_t, bool);
 GHOSTTY_API bool ghostty_app_key(ghostty_app_t, ghostty_input_key_s);
-GHOSTTY_API bool ghostty_app_key_is_binding(ghostty_app_t, ghostty_input_key_s);
 GHOSTTY_API void ghostty_app_keyboard_changed(ghostty_app_t);
 GHOSTTY_API void ghostty_app_open_config(ghostty_app_t);
 GHOSTTY_API void ghostty_app_update_config(ghostty_app_t, ghostty_config_t);

--- a/landing-page/index.html
+++ b/landing-page/index.html
@@ -1220,7 +1220,7 @@ kbd{
         <span data-i18n="hero.cta.source">View source</span>
         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17L17 7M9 7h8v8"/></svg>
       </a>
-      <span class="chip-meta"><span class="mono" data-i18n="hero.meta.ver">v0.5.0</span></span>
+      <span class="chip-meta"><span class="mono" data-i18n="hero.meta.ver">v0.5.1</span></span>
     </div>
 
     <!-- hero window (interactive) -->
@@ -1247,7 +1247,7 @@ kbd{
               </div>
               <div class="ws-list" id="ws-list"></div>
               <div class="sidebar-footer">
-                <span class="mono">v0.5.0</span>
+                <span class="mono">v0.5.1</span>
                 <button class="side-icon disabled" data-disabled-msg title="Settings" aria-label="Settings (disabled in preview)">
                   <svg width="13" height="13"><use href="#icon-gear"/></svg>
                 </button>
@@ -1622,7 +1622,7 @@ const i18n = {
     "hero.sub": "A native macOS terminal built on libghostty. Workspaces, tabs, and split panes for your repos — with live status for every Claude Code, OpenCode, and Codex session you run.",
     "hero.cta.download": "Download for macOS",
     "hero.cta.source": "View source",
-    "hero.meta.ver": "v0.5.0",
+    "hero.meta.ver": "v0.5.1",
     "sidebar.workspaces": "WORKSPACES",
     "preview.caption": "Live preview — + add workspace/tab · double-click to rename · drag to reorder · type a command and hit Enter",
     "why.kicker": "THREE IDEAS",
@@ -1726,7 +1726,7 @@ const i18n = {
     "term.agent.needs": "waiting for your approval on tool call",
     "term.agent.failedMsg": "tool error: typecheck failed",
     "term.neofetch.os": "macOS 14.4 · Apple Silicon",
-    "term.neofetch.term": "Mux0 v0.5.0 · libghostty · Metal",
+    "term.neofetch.term": "Mux0 v0.5.1 · libghostty · Metal",
     "term.neofetch.shell": "zsh 5.9",
     "term.neofetch.uptime": "uptime 1d 4h",
     "term.neofetch.theme": "nocturne · 200 ms hot-reload",
@@ -1747,7 +1747,7 @@ const i18n = {
     "hero.sub": "基于 libghostty 的原生 macOS 终端。为多仓库工作流而设计 —— 侧边栏实时显示每一个 Claude Code、OpenCode、Codex 会话的运行状态。",
     "hero.cta.download": "下载 macOS 版",
     "hero.cta.source": "查看源码",
-    "hero.meta.ver": "v0.5.0",
+    "hero.meta.ver": "v0.5.1",
     "sidebar.workspaces": "工作区",
     "preview.caption": "实时预览 —— + 新建工作区/标签 · 双击重命名 · 拖拽排序 · 输入命令回车执行",
     "why.kicker": "三个理念",
@@ -1851,7 +1851,7 @@ const i18n = {
     "term.agent.needs": "等待工具调用授权",
     "term.agent.failedMsg": "工具报错：typecheck 失败",
     "term.neofetch.os": "macOS 14.4 · Apple Silicon",
-    "term.neofetch.term": "Mux0 v0.5.0 · libghostty · Metal",
+    "term.neofetch.term": "Mux0 v0.5.1 · libghostty · Metal",
     "term.neofetch.shell": "zsh 5.9",
     "term.neofetch.uptime": "运行 1d 4h",
     "term.neofetch.theme": "nocturne · 200 ms 热重载",

--- a/mux0.xcodeproj/project.pbxproj
+++ b/mux0.xcodeproj/project.pbxproj
@@ -783,7 +783,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Vendor/ghostty/lib";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.3.0;
+				MARKETING_VERSION = 0.5.1;
 				MUX0_DISPLAY_NAME = Mux0;
 				OTHER_LDFLAGS = "-lghostty -lc++ -framework Carbon";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mux0.app;
@@ -908,7 +908,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Vendor/ghostty/lib";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.3.0;
+				MARKETING_VERSION = 0.5.1;
 				MUX0_DISPLAY_NAME = "Mux0 Dev";
 				OTHER_LDFLAGS = "-lghostty -lc++ -framework Carbon";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mux0.app.dev;

--- a/mux0/Ghostty/GhosttyTerminalView.swift
+++ b/mux0/Ghostty/GhosttyTerminalView.swift
@@ -148,7 +148,7 @@ final class GhosttyTerminalView: NSView, NSTextInputClient {
 
     /// 切换前台 terminal。
     /// - 把 `front` 设为唯一允许 draw / 接收事件的 surface
-    /// - 其它 surface: focus=false, occlusion=true, RELEASE 按键, 光标 park 到屏外
+    /// - 其它 surface: focus=false, visible=false, RELEASE 按键, 光标 park 到屏外
     /// - 不再发 click cycle（之前的 click cycle 反而在 ghostty 里建立了 selection anchor，
     ///   配合 ghostty 的 mouseLocation 轮询正好造成"鼠标飘到哪选到哪"）
     static func makeFrontmost(_ front: GhosttyTerminalView?) {
@@ -167,7 +167,15 @@ final class GhosttyTerminalView: NSView, NSTextInputClient {
             guard let s = v.surface else { continue }
             let isFront = (v === front)
             ghostty_surface_set_focus(s, isFront)
-            ghostty_surface_set_occlusion(s, !isFront)
+            // 函数名是 `set_occlusion` 但 ghostty C 形参的语义是 `visible` —— true
+            // 表示"surface 可见,内部 displayLink 跑、render thread 推帧"; false 表示
+            // "被遮挡,停 displayLink 省 GPU"（见上游 src/Surface.zig
+            // occlusionCallback 注释 + src/renderer/generic.zig setVisible）。
+            // mux0 早期照着函数名按 occluded 语义传 `!isFront`，结果"前台"被告知
+            // visible=false 而停渲染,"非前台"反而 visible=true 在 vsync —— 表现就是
+            // v0.5.0 release 上"必须切 tab 才出内容,切完打字又卡"的 bug。
+            // 这里按 ghostty 现在的契约: 前台 visible=true,非前台 visible=false。
+            ghostty_surface_set_occlusion(s, isFront)
             // 任何切换都对所有 surface 做一次 defensive RELEASE，
             // 防止前一次交互留下未配对的 PRESS。RELEASE 不会影响 ghostty 已提交的选区，
             // 仅清理 button 状态，所以是安全的。

--- a/project.yml
+++ b/project.yml
@@ -118,7 +118,7 @@ targets:
         CODE_SIGN_STYLE: Automatic
         CODE_SIGN_ENTITLEMENTS: mux0/mux0.entitlements
         ENABLE_HARDENED_RUNTIME: YES
-        MARKETING_VERSION: "0.5.0"
+        MARKETING_VERSION: "0.5.1"
         CURRENT_PROJECT_VERSION: "3"
       configs:
         # Debug 构建用独立 bundle id + display name，让 TCC / LaunchServices /


### PR DESCRIPTION
## Summary

修 v0.5.0 release 的渲染 regression：终端打开不刷新、交互不显示、必须切 tab/workspace 才出内容。

**根因**：ghostty 上游近期把 `ghostty_surface_set_occlusion(surface, bool)` 的 C 形参从 occluded 反转成 visible 语义（true=可见,内部 displayLink 跑、render thread 推帧；false=被遮挡,停 displayLink 省 GPU）。源码契约见 `src/Surface.zig` `occlusionCallback` 与 `src/renderer/generic.zig` `setVisible`。

mux0 早期按函数名当 occluded 语义传 `!isFront` → 新版下"前台被告知 visible=false 而停 render thread、后台 visible=true 反而 vsync"。加上新版 `ghostty_surface_draw` 带 `needs_redraw` 闸门（停摆后 draw 是 no-op）。切 tab 时新 tab 走 `set_size` 触发 `size_changed → needs_redraw → draw 一帧`，这就是"切完才刷"的精确触发。

**修复**：`makeFrontmost` 循环里 `ghostty_surface_set_occlusion(s, isFront)`，与新语义对齐。同步把 `Vendor/ghostty/include/ghostty.h` 跟进最新（4 行 diff，全是 mux0 没用到的字段）。版本 bump 0.5.0 → 0.5.1。