### PR TITLE
build(release): bump version to 0.5.2 (skip dangling v0.5.1 tag)

### DIFF
--- a/landing-page/index.html
+++ b/landing-page/index.html
@@ -1220,7 +1220,7 @@ kbd{
         <span data-i18n="hero.cta.source">View source</span>
         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17L17 7M9 7h8v8"/></svg>
       </a>
-      <span class="chip-meta"><span class="mono" data-i18n="hero.meta.ver">v0.5.1</span></span>
+      <span class="chip-meta"><span class="mono" data-i18n="hero.meta.ver">v0.5.2</span></span>
     </div>
 
     <!-- hero window (interactive) -->
@@ -1247,7 +1247,7 @@ kbd{
               </div>
               <div class="ws-list" id="ws-list"></div>
               <div class="sidebar-footer">
-                <span class="mono">v0.5.1</span>
+                <span class="mono">v0.5.2</span>
                 <button class="side-icon disabled" data-disabled-msg title="Settings" aria-label="Settings (disabled in preview)">
                   <svg width="13" height="13"><use href="#icon-gear"/></svg>
                 </button>
@@ -1622,7 +1622,7 @@ const i18n = {
     "hero.sub": "A native macOS terminal built on libghostty. Workspaces, tabs, and split panes for your repos — with live status for every Claude Code, OpenCode, and Codex session you run.",
     "hero.cta.download": "Download for macOS",
     "hero.cta.source": "View source",
-    "hero.meta.ver": "v0.5.1",
+    "hero.meta.ver": "v0.5.2",
     "sidebar.workspaces": "WORKSPACES",
     "preview.caption": "Live preview — + add workspace/tab · double-click to rename · drag to reorder · type a command and hit Enter",
     "why.kicker": "THREE IDEAS",
@@ -1726,7 +1726,7 @@ const i18n = {
     "term.agent.needs": "waiting for your approval on tool call",
     "term.agent.failedMsg": "tool error: typecheck failed",
     "term.neofetch.os": "macOS 14.4 · Apple Silicon",
-    "term.neofetch.term": "Mux0 v0.5.1 · libghostty · Metal",
+    "term.neofetch.term": "Mux0 v0.5.2 · libghostty · Metal",
     "term.neofetch.shell": "zsh 5.9",
     "term.neofetch.uptime": "uptime 1d 4h",
     "term.neofetch.theme": "nocturne · 200 ms hot-reload",
@@ -1747,7 +1747,7 @@ const i18n = {
     "hero.sub": "基于 libghostty 的原生 macOS 终端。为多仓库工作流而设计 —— 侧边栏实时显示每一个 Claude Code、OpenCode、Codex 会话的运行状态。",
     "hero.cta.download": "下载 macOS 版",
     "hero.cta.source": "查看源码",
-    "hero.meta.ver": "v0.5.1",
+    "hero.meta.ver": "v0.5.2",
     "sidebar.workspaces": "工作区",
     "preview.caption": "实时预览 —— + 新建工作区/标签 · 双击重命名 · 拖拽排序 · 输入命令回车执行",
     "why.kicker": "三个理念",
@@ -1851,7 +1851,7 @@ const i18n = {
     "term.agent.needs": "等待工具调用授权",
     "term.agent.failedMsg": "工具报错：typecheck 失败",
     "term.neofetch.os": "macOS 14.4 · Apple Silicon",
-    "term.neofetch.term": "Mux0 v0.5.1 · libghostty · Metal",
+    "term.neofetch.term": "Mux0 v0.5.2 · libghostty · Metal",
     "term.neofetch.shell": "zsh 5.9",
     "term.neofetch.uptime": "运行 1d 4h",
     "term.neofetch.theme": "nocturne · 200 ms 热重载",

--- a/mux0.xcodeproj/project.pbxproj
+++ b/mux0.xcodeproj/project.pbxproj
@@ -783,7 +783,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Vendor/ghostty/lib";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.5.1;
+				MARKETING_VERSION = 0.5.2;
 				MUX0_DISPLAY_NAME = Mux0;
 				OTHER_LDFLAGS = "-lghostty -lc++ -framework Carbon";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mux0.app;
@@ -908,7 +908,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Vendor/ghostty/lib";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.5.1;
+				MARKETING_VERSION = 0.5.2;
 				MUX0_DISPLAY_NAME = "Mux0 Dev";
 				OTHER_LDFLAGS = "-lghostty -lc++ -framework Carbon";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mux0.app.dev;

--- a/project.yml
+++ b/project.yml
@@ -118,7 +118,7 @@ targets:
         CODE_SIGN_STYLE: Automatic
         CODE_SIGN_ENTITLEMENTS: mux0/mux0.entitlements
         ENABLE_HARDENED_RUNTIME: YES
-        MARKETING_VERSION: "0.5.1"
+        MARKETING_VERSION: "0.5.2"
         CURRENT_PROJECT_VERSION: "3"
       configs:
         # Debug 构建用独立 bundle id + display name，让 TCC / LaunchServices /


### PR DESCRIPTION
## Summary

跳过 v0.5.1 —— PR #30 merge 后某次 release run 跑到 `Publish GitHub Release` 步 fail,但上一步 `Create and push git tag` 已经把 v0.5.1 tag push 到 remote 留下了悬空 tag(GitHub Release 不存在、dmg 没传)。后续 master push 触发的 release.yml 在 check job 看到"tag 已存在"直接 skip 整次 build,occlusion 修复(PR #30 b9e3201)实际没出 release dmg。

直接 bump 一个新版本号绕开,让 release.yml 重跑完整流程。