### PR TITLE
feat(tabcontent): mark agent status read on pane activity

### DIFF
--- a/mux0/Bridge/TabBridge.swift
+++ b/mux0/Bridge/TabBridge.swift
@@ -23,6 +23,7 @@ struct TabBridge: NSViewRepresentable {
     func makeNSView(context: Context) -> TabContentView {
         let view = TabContentView(frame: .zero)
         view.store = store
+        view.statusStore = statusStore
         view.pwdStore = pwdStore
         view.settingsStore = settings
         view.quickActionsStore = quickActionsStore
@@ -38,6 +39,7 @@ struct TabBridge: NSViewRepresentable {
     func updateNSView(_ nsView: TabContentView, context: Context) {
         _ = languageTick
         nsView.store = store
+        nsView.statusStore = statusStore
         nsView.pwdStore = pwdStore
         nsView.settingsStore = settings
         nsView.quickActionsStore = quickActionsStore

--- a/mux0/Ghostty/GhosttyTerminalView.swift
+++ b/mux0/Ghostty/GhosttyTerminalView.swift
@@ -101,6 +101,12 @@ final class GhosttyTerminalView: NSView, NSTextInputClient {
     /// SplitPaneView's `mouseDown` because this view consumes the event first.
     var onFocus: (() -> Void)?
 
+    /// Injected by TabContentView. Fired on direct user activity in this pane
+    /// (mouseDown / keyDown). Used to mark the per-terminal agent status as
+    /// read — same effect tab/workspace switching has, but per-pane and driven
+    /// by interaction rather than navigation.
+    var onUserActivity: (() -> Void)?
+
     /// Map from the opaque ghostty_surface_t pointer back to the owning view.
     /// The action callback only has a ghostty_target_s with the surface handle; this
     /// lookup is how we get back to Swift-land. Weak references so a freed surface
@@ -462,6 +468,7 @@ final class GhosttyTerminalView: NSView, NSTextInputClient {
 
     override func keyDown(with event: NSEvent) {
         guard let s = surface else { super.keyDown(with: event); return }
+        onUserActivity?()
 
         // 这是 ghostty macOS 上游采用的"先走 NSTextInputClient、再单次交付给 ghostty"协议：
         //
@@ -551,6 +558,7 @@ final class GhosttyTerminalView: NSView, NSTextInputClient {
         // This view consumes the event before SplitPaneView sees it, so notify
         // the owner here so `focusedTerminalId` tracks the actual user focus.
         onFocus?()
+        onUserActivity?()
         Self.makeFrontmost(self)
         window?.makeFirstResponder(self)
         guard let s = surface else { return }

--- a/mux0/TabContent/TabContentView.swift
+++ b/mux0/TabContent/TabContentView.swift
@@ -22,6 +22,11 @@ import AppKit
 final class TabContentView: NSView {
     var store: WorkspaceStore?
     var pwdStore: TerminalPwdStore?
+    /// Per-terminal agent status store. Used by `buildSplitPane` to wire
+    /// `GhosttyTerminalView.onUserActivity` → `markRead`, so clicking or
+    /// typing in a pane clears its solid status dot (same effect as switching
+    /// tabs, but scoped to just the interacted pane).
+    var statusStore: TerminalStatusStore?
     /// Used only by `terminalViewFor` to gate consumption of pending agent
     /// resume commands against the user's Settings → Agents → Resume toggle.
     var settingsStore: SettingsConfigStore?
@@ -248,6 +253,9 @@ final class TabContentView: NSView {
                 tv.onFocus = { [weak self] in
                     guard let self, let wsId = self.store?.selectedId else { return }
                     self.store?.updateFocusedTerminal(id: id, tabId: tabId, in: wsId)
+                }
+                tv.onUserActivity = { [weak self] in
+                    self?.statusStore?.markRead(terminalIds: [id])
                 }
                 return tv
             },


### PR DESCRIPTION
## Summary
- 在某个分屏 pane 里点击或敲键时，立即把该 pane 的 agent 状态打上 `readAt` 戳（实心圆点变空心），效果与切走再切回相同
- 新增 `GhosttyTerminalView.onUserActivity` 回调，从 `mouseDown` / `keyDown` 触发；`TabContentView` 在 `buildSplitPane` 里连到 `TerminalStatusStore.markRead`
- 只标用户实际交互的那一个 pane，分屏里同 tab 的另一个 pane 的状态保留；`.running` / `.idle` / `.needsInput` 不受影响（由 hook 自然推进）

🤖 Generated with [Claude Code](https://claude.com/claude-code)