### PR TITLE
feat: 自动 Tab 命名（agent 会话标题）+ v0.6.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ mux0/
 │   ├── TerminalStatus.swift       — 单终端运行状态枚举（running / idle / needsInput）
 │   ├── TerminalStatusStore.swift  — @Observable，终端状态聚合（供 sidebar / tab 图标读取）
 │   ├── TerminalPwdStore.swift     — @Observable，terminalId → pwd 映射（ghostty PWD action 喂入，sidebar git 分支读取）
+│   ├── TerminalSessionTitleStore.swift  — @Observable，terminalId → agent session title（hook 喂入，tab 标题读取）
 │   ├── HookDispatcher.swift       — 按 agent toggle 过滤 hook 事件 + 派生 status icon UI 主开关
 │   ├── HookMessage.swift          — agent/shell hook 的 JSON wire format
 │   └── HookSocketListener.swift   — Unix domain socket 监听，解析 HookMessage → statusStore
@@ -144,6 +145,7 @@ mux0/
 | 重新生成 Xcode 工程 | `xcodegen generate`（修改 `project.yml` 后执行）|
 | 检查文档漂移 | `./scripts/check-doc-drift.sh`（对比 Directory Structure 与真实 `mux0/` 目录；同时校验 landing 版本号与 `project.yml` 一致） |
 | 新增文案 / 支持新语言 | `mux0/Localization/Localizable.xcstrings`, `mux0/Localization/L10n.swift`, `mux0Tests/L10nSmokeTests.swift`, `docs/i18n.md` |
+| 修改 tab 自动命名行为（auto title 来源 / 锁定语义） | `Models/TerminalSessionTitleStore.swift`, `Models/Workspace.swift`（displayTitle）, `Models/HookDispatcher.swift`（路由）, `Resources/agent-hooks/agent-hook.py`（claude/codex 来源）, `Resources/agent-hooks/opencode-plugin/mux0-status.js`（opencode 来源） |
 
 ## Agent Permissions
 

--- a/Resources/agent-hooks/agent-hook.py
+++ b/Resources/agent-hooks/agent-hook.py
@@ -30,7 +30,11 @@ SUMMARY_MAXLEN = 200
 # into the persisted `initial_input`.
 SESSION_ID_RE = re.compile(r"\A[A-Za-z0-9_-]+\Z")
 
-CODEX_HOME = pathlib.Path("~/.codex").expanduser()
+# Honor the active CODEX_HOME (the mux0 codex wrapper exports an overlay path;
+# users may also set a custom one). The overlay symlinks `sessions/` back to
+# the user's real ~/.codex/sessions, so globbing through it still finds the
+# rollout. Falling back to ~/.codex covers native (non-wrapped) invocations.
+CODEX_HOME = pathlib.Path(os.environ.get("CODEX_HOME") or "~/.codex").expanduser()
 
 
 def parse_payload() -> dict:

--- a/Resources/agent-hooks/agent-hook.py
+++ b/Resources/agent-hooks/agent-hook.py
@@ -111,13 +111,17 @@ def read_transcript_summary(path: str) -> str:
 
 
 def read_ai_title(path: str) -> str:
-    """Read Claude transcript JSONL, return last `{"type":"ai-title","aiTitle":"..."}`
-    entry's title, truncated to SUMMARY_MAXLEN. Empty string on any error.
+    """Read Claude's session title from the transcript JSONL.
 
-    Claude Code persists an LLM-generated session title as repeated `ai-title`
-    rows throughout the transcript (typically same value each time once
-    generated). We reverse-scan and return the most recent one to pick up
-    title rewrites if any.
+    Claude persists two kinds of title rows:
+      - `{"type":"custom-title","customTitle":"..."}` — written by `/rename`
+        when the user explicitly names the session. User intent wins.
+      - `{"type":"ai-title","aiTitle":"..."}` — written asynchronously by
+        the LLM once a session has enough context. Fallback.
+
+    We single-pass forward-scan and remember the latest of each kind, then
+    return custom-title if any exists, otherwise ai-title. Truncated to
+    SUMMARY_MAXLEN. Empty string on any error.
     """
     if not path:
         return ""
@@ -126,16 +130,26 @@ def read_ai_title(path: str) -> str:
             lines = f.readlines()
     except (FileNotFoundError, IsADirectoryError, PermissionError, OSError):
         return ""
-    for line in reversed(lines):
+    custom = ""
+    ai = ""
+    for line in lines:
         try:
             d = json.loads(line)
         except json.JSONDecodeError:
             continue
-        if isinstance(d, dict) and d.get("type") == "ai-title":
-            title = d.get("aiTitle") or ""
-            if isinstance(title, str) and title:
-                return title[:SUMMARY_MAXLEN]
-    return ""
+        if not isinstance(d, dict):
+            continue
+        t = d.get("type")
+        if t == "custom-title":
+            val = d.get("customTitle") or ""
+            if isinstance(val, str) and val:
+                custom = val
+        elif t == "ai-title":
+            val = d.get("aiTitle") or ""
+            if isinstance(val, str) and val:
+                ai = val
+    chosen = custom or ai
+    return chosen[:SUMMARY_MAXLEN]
 
 
 def read_codex_title(session_id: str) -> str:

--- a/Resources/agent-hooks/agent-hook.py
+++ b/Resources/agent-hooks/agent-hook.py
@@ -17,6 +17,7 @@ Subcommands:
 import json
 import os
 import re
+import sqlite3
 import time
 import fcntl
 import socket
@@ -159,8 +160,9 @@ def read_codex_title(session_id: str) -> str:
         return ""
     db = candidates[-1]
     try:
-        import sqlite3
         # mode=ro + small timeout so we never block on Codex's write lock.
+        # sqlite3.OperationalError covers missing/inaccessible db files too,
+        # so the single sqlite3.Error catch below handles all failure modes.
         con = sqlite3.connect(f"file:{db}?mode=ro", uri=True, timeout=0.5)
         try:
             row = con.execute(

--- a/Resources/agent-hooks/agent-hook.py
+++ b/Resources/agent-hooks/agent-hook.py
@@ -110,14 +110,9 @@ def read_transcript_summary(path: str) -> str:
 
 
 def _extract_user_text_from_claude(d: dict) -> str:
-    """Pull plain-text content out of a Claude transcript user row, skipping
-    slash commands and meta-injections so the title reflects real
-    conversation rather than `/clear`-style noise.
-
-    Handles both string and typed-content-block
-    (`[{type:"text",text:"..."}, ...]`) shapes that Claude uses for user
-    messages.
-    """
+    """Plain-text content from a Claude transcript user row. Skips slash
+    commands and meta injections, handles both string and typed-content-block
+    (`[{type:"text",text:"..."}, ...]`) shapes."""
     if d.get("type") != "user" or d.get("isMeta"):
         return ""
     msg = d.get("message", {})
@@ -135,27 +130,20 @@ def _extract_user_text_from_claude(d: dict) -> str:
     return " ".join(text.split())
 
 
-def _extract_user_text_from_codex(d: dict) -> str:
-    """Pull plain-text out of a Codex rollout `event_msg` row whose
-    `payload.type == "user_message"`. Codex stores user prompts as
-    `{"type":"event_msg","payload":{"type":"user_message","message":"..."}}`.
-    """
-    if d.get("type") != "event_msg":
-        return ""
-    payload = d.get("payload", {})
-    if not isinstance(payload, dict) or payload.get("type") != "user_message":
-        return ""
-    msg = payload.get("message", "")
-    if not isinstance(msg, str):
-        return ""
-    text = msg.strip()
-    return " ".join(text.split()) if text else ""
+def read_claude_title(path: str) -> str:
+    """Read Claude's session title from the transcript JSONL with three-tier
+    priority (matches `claude --resume` picker semantics):
 
+      1. `{"type":"custom-title","customTitle":"..."}` — written by `/rename`,
+         explicit user intent.
+      2. `{"type":"ai-title","aiTitle":"..."}` — LLM-generated, async. Claude
+         only emits these once the session has enough content; short
+         exchanges never trigger one.
+      3. First non-meta, non-slash-command user message — universal fallback
+         so short sessions also get a meaningful label.
 
-def _first_user_prompt(path: str, extractor) -> str:
-    """Forward-scan `path` line by line, return the first non-empty user
-    prompt as extracted by `extractor(d)`. Truncated to SUMMARY_MAXLEN.
-    Empty string on any IO/parse error.
+    Single forward pass keeps the latest of each kind. Truncated to
+    SUMMARY_MAXLEN. Empty string on IO error.
     """
     if not path:
         return ""
@@ -164,6 +152,9 @@ def _first_user_prompt(path: str, extractor) -> str:
             lines = f.readlines()
     except (FileNotFoundError, IsADirectoryError, PermissionError, OSError):
         return ""
+    custom = ""
+    ai = ""
+    first_prompt = ""
     for line in lines:
         try:
             d = json.loads(line)
@@ -171,28 +162,29 @@ def _first_user_prompt(path: str, extractor) -> str:
             continue
         if not isinstance(d, dict):
             continue
-        text = extractor(d)
-        if text:
-            return text[:SUMMARY_MAXLEN]
-    return ""
-
-
-def read_claude_title(path: str) -> str:
-    """First real (non-slash-command, non-meta) user prompt from a Claude
-    transcript JSONL. Mirrors cmux's strategy: ignore Claude's optional
-    LLM-generated `ai-title` / `custom-title` rows and trust the user's
-    own first input as the stable per-session label.
-    """
-    return _first_user_prompt(path, _extract_user_text_from_claude)
+        t = d.get("type")
+        if t == "custom-title":
+            val = d.get("customTitle") or ""
+            if isinstance(val, str) and val:
+                custom = val
+        elif t == "ai-title":
+            val = d.get("aiTitle") or ""
+            if isinstance(val, str) and val:
+                ai = val
+        elif not first_prompt:
+            text = _extract_user_text_from_claude(d)
+            if text:
+                first_prompt = text
+    chosen = custom or ai or first_prompt
+    return chosen[:SUMMARY_MAXLEN]
 
 
 def _find_codex_rollout(session_id: str) -> str:
     """Locate the rollout JSONL for `session_id` under `CODEX_HOME / sessions`.
 
     Codex names rollouts `rollout-<timestamp>-<session_id>.jsonl` under a
-    nested `<year>/<month>/<day>/` tree. We glob for the session_id suffix
-    and take the most recent match (there should normally be exactly one).
-    Returns empty string if the id is malformed or no file is found.
+    nested `<year>/<month>/<day>/` tree. We glob the session_id suffix and
+    take the most recent match. Empty string on malformed id / no match.
     """
     if not session_id or not SESSION_ID_RE.match(session_id):
         return ""
@@ -204,13 +196,50 @@ def _find_codex_rollout(session_id: str) -> str:
 
 
 def read_codex_title(session_id: str) -> str:
-    """First user prompt from the Codex rollout JSONL for `session_id`.
-    Returns empty string when the rollout isn't available yet (e.g. the
-    first `prompt` hook fires before the file is flushed) or has no user
-    message.
+    """Read Codex's session title from the rollout JSONL with two-tier
+    priority:
+
+      1. `event_msg.thread_name_updated` `thread_name` — Codex LLM-generated
+         session title (same value Codex's own `resume` picker shows).
+      2. First `event_msg.user_message` — fallback when the LLM title hasn't
+         been written yet.
+
+    Both signals live in the same rollout file; reading it once gets both.
+    Truncated to SUMMARY_MAXLEN. Empty on IO/missing-rollout.
     """
-    return _first_user_prompt(_find_codex_rollout(session_id),
-                              _extract_user_text_from_codex)
+    path = _find_codex_rollout(session_id)
+    if not path:
+        return ""
+    try:
+        with open(path) as f:
+            lines = f.readlines()
+    except (FileNotFoundError, IsADirectoryError, PermissionError, OSError):
+        return ""
+    thread_name = ""
+    first_prompt = ""
+    for line in lines:
+        try:
+            d = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(d, dict) or d.get("type") != "event_msg":
+            continue
+        payload = d.get("payload", {})
+        if not isinstance(payload, dict):
+            continue
+        ptype = payload.get("type")
+        if ptype == "thread_name_updated":
+            name = payload.get("thread_name") or ""
+            if isinstance(name, str) and name:
+                thread_name = name
+        elif ptype == "user_message" and not first_prompt:
+            msg = payload.get("message") or ""
+            if isinstance(msg, str):
+                text = " ".join(msg.split())
+                if text:
+                    first_prompt = text
+    chosen = thread_name or first_prompt
+    return chosen[:SUMMARY_MAXLEN]
 
 
 def _session_title_for(agent: str, transcript_path: str, session_id: str) -> str:

--- a/Resources/agent-hooks/agent-hook.py
+++ b/Resources/agent-hooks/agent-hook.py
@@ -17,7 +17,6 @@ Subcommands:
 import json
 import os
 import re
-import sqlite3
 import time
 import fcntl
 import socket
@@ -110,10 +109,17 @@ def read_transcript_summary(path: str) -> str:
     return ""
 
 
-def _extract_user_text(d: dict) -> str:
-    """Pull plain-text content out of a transcript user row, skipping slash
-    commands like `<command-name>/rename</command-name>` so the fallback
-    title reflects real conversation rather than a meta-command."""
+def _extract_user_text_from_claude(d: dict) -> str:
+    """Pull plain-text content out of a Claude transcript user row, skipping
+    slash commands and meta-injections so the title reflects real
+    conversation rather than `/clear`-style noise.
+
+    Handles both string and typed-content-block
+    (`[{type:"text",text:"..."}, ...]`) shapes that Claude uses for user
+    messages.
+    """
+    if d.get("type") != "user" or d.get("isMeta"):
+        return ""
     msg = d.get("message", {})
     content = msg.get("content", "") if isinstance(msg, dict) else ""
     if isinstance(content, list):
@@ -129,21 +135,27 @@ def _extract_user_text(d: dict) -> str:
     return " ".join(text.split())
 
 
-def read_ai_title(path: str) -> str:
-    """Read Claude's session title from the transcript JSONL.
+def _extract_user_text_from_codex(d: dict) -> str:
+    """Pull plain-text out of a Codex rollout `event_msg` row whose
+    `payload.type == "user_message"`. Codex stores user prompts as
+    `{"type":"event_msg","payload":{"type":"user_message","message":"..."}}`.
+    """
+    if d.get("type") != "event_msg":
+        return ""
+    payload = d.get("payload", {})
+    if not isinstance(payload, dict) or payload.get("type") != "user_message":
+        return ""
+    msg = payload.get("message", "")
+    if not isinstance(msg, str):
+        return ""
+    text = msg.strip()
+    return " ".join(text.split()) if text else ""
 
-    Priority (claude's `/resume` picker uses the same order):
-      1. `{"type":"custom-title","customTitle":"..."}` — written by `/rename`,
-         user intent.
-      2. `{"type":"ai-title","aiTitle":"..."}` — async LLM output. Claude
-         only generates these once the session has enough content; short
-         exchanges like "hi"/"hello" never trigger it.
-      3. First real user prompt (truncated). Mirrors Codex's `first_user_message`
-         fallback so short Claude sessions still get a sensible tab name
-         before the LLM-derived title is available.
 
-    Single forward pass keeps the latest of each kind. Truncated to
-    SUMMARY_MAXLEN. Empty string on any error.
+def _first_user_prompt(path: str, extractor) -> str:
+    """Forward-scan `path` line by line, return the first non-empty user
+    prompt as extracted by `extractor(d)`. Truncated to SUMMARY_MAXLEN.
+    Empty string on any IO/parse error.
     """
     if not path:
         return ""
@@ -152,9 +164,6 @@ def read_ai_title(path: str) -> str:
             lines = f.readlines()
     except (FileNotFoundError, IsADirectoryError, PermissionError, OSError):
         return ""
-    custom = ""
-    ai = ""
-    first_prompt = ""
     for line in lines:
         try:
             d = json.loads(line)
@@ -162,70 +171,60 @@ def read_ai_title(path: str) -> str:
             continue
         if not isinstance(d, dict):
             continue
-        t = d.get("type")
-        if t == "custom-title":
-            val = d.get("customTitle") or ""
-            if isinstance(val, str) and val:
-                custom = val
-        elif t == "ai-title":
-            val = d.get("aiTitle") or ""
-            if isinstance(val, str) and val:
-                ai = val
-        elif t == "user" and not first_prompt and not d.get("isMeta"):
-            text = _extract_user_text(d)
-            if text:
-                first_prompt = text
-    chosen = custom or ai or first_prompt
-    return chosen[:SUMMARY_MAXLEN]
+        text = extractor(d)
+        if text:
+            return text[:SUMMARY_MAXLEN]
+    return ""
 
 
-def read_codex_title(session_id: str) -> str:
-    """Read Codex thread title from `~/.codex/state_*.sqlite` (newest schema
-    version), querying `threads.title WHERE id = ?`. Empty on any failure.
+def read_claude_title(path: str) -> str:
+    """First real (non-slash-command, non-meta) user prompt from a Claude
+    transcript JSONL. Mirrors cmux's strategy: ignore Claude's optional
+    LLM-generated `ai-title` / `custom-title` rows and trust the user's
+    own first input as the stable per-session label.
+    """
+    return _first_user_prompt(path, _extract_user_text_from_claude)
 
-    The `state_N.sqlite` filename embeds Codex's schema version (currently 5);
-    we glob and take the highest N so this survives future migrations without
-    a code change.
+
+def _find_codex_rollout(session_id: str) -> str:
+    """Locate the rollout JSONL for `session_id` under `CODEX_HOME / sessions`.
+
+    Codex names rollouts `rollout-<timestamp>-<session_id>.jsonl` under a
+    nested `<year>/<month>/<day>/` tree. We glob for the session_id suffix
+    and take the most recent match (there should normally be exactly one).
+    Returns empty string if the id is malformed or no file is found.
     """
     if not session_id or not SESSION_ID_RE.match(session_id):
         return ""
+    sessions_dir = CODEX_HOME / "sessions"
+    matches = sorted(sessions_dir.glob(f"**/rollout-*-{session_id}.jsonl"))
+    if not matches:
+        return ""
+    return str(matches[-1])
 
-    def _ver(p: pathlib.Path) -> int:
-        try:
-            return int(p.stem.split("_", 1)[1])
-        except (IndexError, ValueError):
-            return -1
 
-    candidates = sorted(CODEX_HOME.glob("state_*.sqlite"), key=_ver)
-    if not candidates:
-        return ""
-    db = candidates[-1]
-    try:
-        # mode=ro + small timeout so we never block on Codex's write lock.
-        # sqlite3.OperationalError covers missing/inaccessible db files too,
-        # so the single sqlite3.Error catch below handles all failure modes.
-        con = sqlite3.connect(f"file:{db}?mode=ro", uri=True, timeout=0.5)
-        try:
-            row = con.execute(
-                "SELECT title FROM threads WHERE id = ?", (session_id,)
-            ).fetchone()
-        finally:
-            con.close()
-    except sqlite3.Error:
-        return ""
-    if not row or not row[0]:
-        return ""
-    return str(row[0])[:SUMMARY_MAXLEN]
+def read_codex_title(session_id: str) -> str:
+    """First user prompt from the Codex rollout JSONL for `session_id`.
+    Returns empty string when the rollout isn't available yet (e.g. the
+    first `prompt` hook fires before the file is flushed) or has no user
+    message.
+    """
+    return _first_user_prompt(_find_codex_rollout(session_id),
+                              _extract_user_text_from_codex)
 
 
 def _session_title_for(agent: str, transcript_path: str, session_id: str) -> str:
-    """Read the human-readable session title for `agent`. Returns "" if not
-    available (LLM hasn't generated it yet, file missing, etc.)."""
+    """Read the first-user-prompt session title for `agent`. Returns "" when
+    the source file isn't readable yet.
+
+    OpenCode flows through its own JS plugin (mux0-status.js) which fills in
+    sessionTitle on the wire; this branch is unreachable for opencode in
+    practice but kept for parity.
+    """
     if agent == "claude":
-        return read_ai_title(transcript_path or "")
+        return read_claude_title(transcript_path or "")
     if agent == "codex":
         return read_codex_title(session_id)
-    # opencode flows through its own JS plugin; never reaches here.
     return ""
 
 

--- a/Resources/agent-hooks/agent-hook.py
+++ b/Resources/agent-hooks/agent-hook.py
@@ -30,6 +30,8 @@ SUMMARY_MAXLEN = 200
 # into the persisted `initial_input`.
 SESSION_ID_RE = re.compile(r"\A[A-Za-z0-9_-]+\Z")
 
+CODEX_HOME = pathlib.Path("~/.codex").expanduser()
+
 
 def parse_payload() -> dict:
     """Parse _MUX0_PAYLOAD env var as JSON. Returns {} on any error."""
@@ -104,6 +106,83 @@ def read_transcript_summary(path: str) -> str:
         content = " ".join(content.split())
         if content:
             return content[:SUMMARY_MAXLEN]
+    return ""
+
+
+def read_ai_title(path: str) -> str:
+    """Read Claude transcript JSONL, return last `{"type":"ai-title","aiTitle":"..."}`
+    entry's title, truncated to SUMMARY_MAXLEN. Empty string on any error.
+
+    Claude Code persists an LLM-generated session title as repeated `ai-title`
+    rows throughout the transcript (typically same value each time once
+    generated). We reverse-scan and return the most recent one to pick up
+    title rewrites if any.
+    """
+    if not path:
+        return ""
+    try:
+        with open(path) as f:
+            lines = f.readlines()
+    except (FileNotFoundError, IsADirectoryError, PermissionError, OSError):
+        return ""
+    for line in reversed(lines):
+        try:
+            d = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(d, dict) and d.get("type") == "ai-title":
+            title = d.get("aiTitle") or ""
+            if isinstance(title, str) and title:
+                return title[:SUMMARY_MAXLEN]
+    return ""
+
+
+def read_codex_title(session_id: str) -> str:
+    """Read Codex thread title from `~/.codex/state_*.sqlite` (newest schema
+    version), querying `threads.title WHERE id = ?`. Empty on any failure.
+
+    The `state_N.sqlite` filename embeds Codex's schema version (currently 5);
+    we glob and take the highest N so this survives future migrations without
+    a code change.
+    """
+    if not session_id or not SESSION_ID_RE.match(session_id):
+        return ""
+
+    def _ver(p: pathlib.Path) -> int:
+        try:
+            return int(p.stem.split("_", 1)[1])
+        except (IndexError, ValueError):
+            return -1
+
+    candidates = sorted(CODEX_HOME.glob("state_*.sqlite"), key=_ver)
+    if not candidates:
+        return ""
+    db = candidates[-1]
+    try:
+        import sqlite3
+        # mode=ro + small timeout so we never block on Codex's write lock.
+        con = sqlite3.connect(f"file:{db}?mode=ro", uri=True, timeout=0.5)
+        try:
+            row = con.execute(
+                "SELECT title FROM threads WHERE id = ?", (session_id,)
+            ).fetchone()
+        finally:
+            con.close()
+    except sqlite3.Error:
+        return ""
+    if not row or not row[0]:
+        return ""
+    return str(row[0])[:SUMMARY_MAXLEN]
+
+
+def _session_title_for(agent: str, transcript_path: str, session_id: str) -> str:
+    """Read the human-readable session title for `agent`. Returns "" if not
+    available (LLM hasn't generated it yet, file missing, etc.)."""
+    if agent == "claude":
+        return read_ai_title(transcript_path or "")
+    if agent == "codex":
+        return read_codex_title(session_id)
+    # opencode flows through its own JS plugin; never reaches here.
     return ""
 
 
@@ -223,6 +302,9 @@ def dispatch(subcmd: str, agent: str, payload: dict,
         resume = resume_command_for(agent, str(session_id))
         if resume:
             emit["resumeCommand"] = resume
+        title = _session_title_for(agent, entry.get("transcriptPath"), str(session_id))
+        if title:
+            emit["sessionTitle"] = title
 
     elif subcmd == "pretool":
         tool = payload.get("tool_name", "") or ""
@@ -249,6 +331,9 @@ def dispatch(subcmd: str, agent: str, payload: dict,
         emit = {"event": "finished", "at": now, "exitCode": exit_code}
         if summary:
             emit["summary"] = summary
+        title = _session_title_for(agent, entry.get("transcriptPath"), str(session_id))
+        if title:
+            emit["sessionTitle"] = title
         entries.pop(session_id, None)
 
     sessions_doc = gc_stale(sessions_doc, now)

--- a/Resources/agent-hooks/agent-hook.py
+++ b/Resources/agent-hooks/agent-hook.py
@@ -110,17 +110,39 @@ def read_transcript_summary(path: str) -> str:
     return ""
 
 
+def _extract_user_text(d: dict) -> str:
+    """Pull plain-text content out of a transcript user row, skipping slash
+    commands like `<command-name>/rename</command-name>` so the fallback
+    title reflects real conversation rather than a meta-command."""
+    msg = d.get("message", {})
+    content = msg.get("content", "") if isinstance(msg, dict) else ""
+    if isinstance(content, list):
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                content = block.get("text", "")
+                break
+    if not isinstance(content, str):
+        return ""
+    text = content.strip()
+    if not text or text.startswith("<command-") or text.startswith("<local-command-"):
+        return ""
+    return " ".join(text.split())
+
+
 def read_ai_title(path: str) -> str:
     """Read Claude's session title from the transcript JSONL.
 
-    Claude persists two kinds of title rows:
-      - `{"type":"custom-title","customTitle":"..."}` — written by `/rename`
-        when the user explicitly names the session. User intent wins.
-      - `{"type":"ai-title","aiTitle":"..."}` — written asynchronously by
-        the LLM once a session has enough context. Fallback.
+    Priority (claude's `/resume` picker uses the same order):
+      1. `{"type":"custom-title","customTitle":"..."}` — written by `/rename`,
+         user intent.
+      2. `{"type":"ai-title","aiTitle":"..."}` — async LLM output. Claude
+         only generates these once the session has enough content; short
+         exchanges like "hi"/"hello" never trigger it.
+      3. First real user prompt (truncated). Mirrors Codex's `first_user_message`
+         fallback so short Claude sessions still get a sensible tab name
+         before the LLM-derived title is available.
 
-    We single-pass forward-scan and remember the latest of each kind, then
-    return custom-title if any exists, otherwise ai-title. Truncated to
+    Single forward pass keeps the latest of each kind. Truncated to
     SUMMARY_MAXLEN. Empty string on any error.
     """
     if not path:
@@ -132,6 +154,7 @@ def read_ai_title(path: str) -> str:
         return ""
     custom = ""
     ai = ""
+    first_prompt = ""
     for line in lines:
         try:
             d = json.loads(line)
@@ -148,7 +171,11 @@ def read_ai_title(path: str) -> str:
             val = d.get("aiTitle") or ""
             if isinstance(val, str) and val:
                 ai = val
-    chosen = custom or ai
+        elif t == "user" and not first_prompt and not d.get("isMeta"):
+            text = _extract_user_text(d)
+            if text:
+                first_prompt = text
+    chosen = custom or ai or first_prompt
     return chosen[:SUMMARY_MAXLEN]
 
 

--- a/Resources/agent-hooks/opencode-plugin/mux0-status.js
+++ b/Resources/agent-hooks/opencode-plugin/mux0-status.js
@@ -134,7 +134,11 @@ export const Mux0StatusPlugin = async (_input) => ({
         if (!turn.startedAt) turn.startedAt = Date.now() / 1000;
         captureFirstPrompt(input?.sessionID, input?.message?.parts ?? input?.parts);
         const resumeCommand = resumeCommandFor(input?.sessionID);
-        const sessionTitle = firstPromptBySession.get(input?.sessionID) || "";
+        // Priority: opencode's LLM-generated session.title → cached first
+        // prompt. Mirrors the claude/codex hook tiers.
+        const sessionTitle = input?.session?.title
+            || firstPromptBySession.get(input?.sessionID)
+            || "";
         const payload = { event: "running" };
         if (resumeCommand) payload.resumeCommand = resumeCommand;
         if (sessionTitle) payload.sessionTitle = sessionTitle;
@@ -150,7 +154,9 @@ export const Mux0StatusPlugin = async (_input) => ({
         if (!turn.startedAt) turn.startedAt = Date.now() / 1000;
         const detail = describeOpencodeTool(input?.tool, output?.args);
         const resumeCommand = resumeCommandFor(input?.sessionID);
-        const sessionTitle = firstPromptBySession.get(input?.sessionID) || "";
+        const sessionTitle = input?.session?.title
+            || firstPromptBySession.get(input?.sessionID)
+            || "";
         const payload = { event: "running" };
         if (detail) payload.toolDetail = detail;
         if (resumeCommand) payload.resumeCommand = resumeCommand;

--- a/Resources/agent-hooks/opencode-plugin/mux0-status.js
+++ b/Resources/agent-hooks/opencode-plugin/mux0-status.js
@@ -103,8 +103,10 @@ export const Mux0StatusPlugin = async (_input) => ({
     "chat.message": async (input, _output) => {
         if (!turn.startedAt) turn.startedAt = Date.now() / 1000;
         const resumeCommand = resumeCommandFor(input?.sessionID);
+        const sessionTitle = input?.session?.title || "";
         const payload = { event: "running" };
         if (resumeCommand) payload.resumeCommand = resumeCommand;
+        if (sessionTitle) payload.sessionTitle = sessionTitle;
         emit(payload);
     },
 
@@ -117,9 +119,11 @@ export const Mux0StatusPlugin = async (_input) => ({
         if (!turn.startedAt) turn.startedAt = Date.now() / 1000;
         const detail = describeOpencodeTool(input?.tool, output?.args);
         const resumeCommand = resumeCommandFor(input?.sessionID);
+        const sessionTitle = input?.session?.title || "";
         const payload = { event: "running" };
         if (detail) payload.toolDetail = detail;
         if (resumeCommand) payload.resumeCommand = resumeCommand;
+        if (sessionTitle) payload.sessionTitle = sessionTitle;
         emit(payload);
     },
 

--- a/Resources/agent-hooks/opencode-plugin/mux0-status.js
+++ b/Resources/agent-hooks/opencode-plugin/mux0-status.js
@@ -17,6 +17,36 @@ const TID  = process.env.MUX0_TERMINAL_ID;
 // outlives the turn naturally (opencode keeps it alive across turns).
 let turn = { hadError: false, tool: null, startedAt: null };
 
+// First user prompt per opencode session, captured once on chat.message and
+// reused as the sessionTitle for every subsequent emit. Matches cmux's
+// "first user message as title" strategy across all three agents — we don't
+// trust the optional LLM-generated session.title field.
+const firstPromptBySession = new Map();
+
+function captureFirstPrompt(sessionID, parts) {
+    if (!sessionID || firstPromptBySession.has(sessionID)) return;
+    const text = extractUserText(parts);
+    if (text) firstPromptBySession.set(sessionID, text);
+}
+
+function extractUserText(parts) {
+    // chat.message input.parts is an array of typed content blocks.
+    // We only care about the text ones; the first non-empty text is the
+    // user's prompt.
+    if (!Array.isArray(parts)) {
+        if (typeof parts === "string") return parts.trim().slice(0, 200);
+        return "";
+    }
+    for (const p of parts) {
+        if (!p || typeof p !== "object") continue;
+        if (p.type === "text" && typeof p.text === "string") {
+            const t = p.text.trim();
+            if (t) return t.slice(0, 200);
+        }
+    }
+    return "";
+}
+
 function emit(msg) {
     if (!SOCK || !TID) return;
     const payload = JSON.stringify({
@@ -102,8 +132,9 @@ export const Mux0StatusPlugin = async (_input) => ({
     // calls (e.g. a quick chat answer with no Edit/Bash/Read).
     "chat.message": async (input, _output) => {
         if (!turn.startedAt) turn.startedAt = Date.now() / 1000;
+        captureFirstPrompt(input?.sessionID, input?.message?.parts ?? input?.parts);
         const resumeCommand = resumeCommandFor(input?.sessionID);
-        const sessionTitle = input?.session?.title || "";
+        const sessionTitle = firstPromptBySession.get(input?.sessionID) || "";
         const payload = { event: "running" };
         if (resumeCommand) payload.resumeCommand = resumeCommand;
         if (sessionTitle) payload.sessionTitle = sessionTitle;
@@ -119,7 +150,7 @@ export const Mux0StatusPlugin = async (_input) => ({
         if (!turn.startedAt) turn.startedAt = Date.now() / 1000;
         const detail = describeOpencodeTool(input?.tool, output?.args);
         const resumeCommand = resumeCommandFor(input?.sessionID);
-        const sessionTitle = input?.session?.title || "";
+        const sessionTitle = firstPromptBySession.get(input?.sessionID) || "";
         const payload = { event: "running" };
         if (detail) payload.toolDetail = detail;
         if (resumeCommand) payload.resumeCommand = resumeCommand;

--- a/Resources/agent-hooks/tests/test_agent_hook.py
+++ b/Resources/agent-hooks/tests/test_agent_hook.py
@@ -494,6 +494,20 @@ def test_read_codex_title_no_rollout(tmp_path, monkeypatch):
     assert agent_hook.read_codex_title("missing") == ""
 
 
+def test_codex_home_resolution_honors_env():
+    # When CODEX_HOME is set (mux0 wrapper overlay, or a user-custom home),
+    # the module-level constant must resolve to it rather than ~/.codex.
+    # Mirrors the expression used at import time in agent-hook.py.
+    resolved = pathlib.Path(
+        ({"CODEX_HOME": "/custom/codex"}).get("CODEX_HOME") or "~/.codex"
+    ).expanduser()
+    assert str(resolved) == "/custom/codex"
+    fallback = pathlib.Path(
+        ({}).get("CODEX_HOME") or "~/.codex"
+    ).expanduser()
+    assert str(fallback).endswith("/.codex")
+
+
 def test_read_codex_title_rejects_invalid_session_id(tmp_path, monkeypatch):
     monkeypatch.setattr(agent_hook, "CODEX_HOME", tmp_path)
     assert agent_hook.read_codex_title("bad; DROP TABLE") == ""

--- a/Resources/agent-hooks/tests/test_agent_hook.py
+++ b/Resources/agent-hooks/tests/test_agent_hook.py
@@ -386,6 +386,33 @@ def test_read_ai_title_skips_malformed_lines(tmp_path):
     assert agent_hook.read_ai_title(str(p)) == "Good"
 
 
+def test_read_ai_title_custom_title_wins_over_ai(tmp_path):
+    # User's /rename writes a custom-title row. That intent must beat the
+    # LLM-generated ai-title even if ai-title appears later in the file.
+    p = tmp_path / "t.jsonl"
+    p.write_text(
+        json.dumps({"type": "custom-title", "customTitle": "user named"}) + "\n" +
+        json.dumps({"type": "ai-title", "aiTitle": "LLM guessed"}) + "\n"
+    )
+    assert agent_hook.read_ai_title(str(p)) == "user named"
+
+
+def test_read_ai_title_falls_back_to_ai_when_no_custom(tmp_path):
+    p = tmp_path / "t.jsonl"
+    p.write_text(json.dumps({"type": "ai-title", "aiTitle": "LLM only"}) + "\n")
+    assert agent_hook.read_ai_title(str(p)) == "LLM only"
+
+
+def test_read_ai_title_picks_latest_custom_title(tmp_path):
+    # Multiple /rename calls write multiple custom-title rows; take the last.
+    p = tmp_path / "t.jsonl"
+    p.write_text(
+        json.dumps({"type": "custom-title", "customTitle": "first"}) + "\n" +
+        json.dumps({"type": "custom-title", "customTitle": "second"}) + "\n"
+    )
+    assert agent_hook.read_ai_title(str(p)) == "second"
+
+
 # ---------- read_codex_title ----------
 
 def test_read_codex_title_reads_from_db(tmp_path, monkeypatch):

--- a/Resources/agent-hooks/tests/test_agent_hook.py
+++ b/Resources/agent-hooks/tests/test_agent_hook.py
@@ -420,41 +420,71 @@ def test_read_claude_title_extracts_text_from_list_content(tmp_path):
     assert agent_hook.read_claude_title(str(p)) == "list-form content"
 
 
-def test_read_claude_title_ignores_ai_title_and_custom_title(tmp_path):
-    # We intentionally drop LLM-generated and /rename metadata rows in
-    # favor of the user's own first prompt — keeps behavior predictable
-    # across short sessions where claude never writes ai-title.
+def test_read_claude_title_custom_title_wins(tmp_path):
+    # /rename writes a custom-title row; it must beat both ai-title and the
+    # first user prompt fallback.
     p = tmp_path / "t.jsonl"
     p.write_text(
-        json.dumps({"type": "custom-title", "customTitle": "ignored"}) + "\n" +
-        json.dumps({"type": "ai-title", "aiTitle": "also ignored"}) + "\n" +
-        json.dumps({"type": "user", "message": {"content": "winner"}}) + "\n"
+        json.dumps({"type": "user", "message": {"content": "first prompt"}}) + "\n" +
+        json.dumps({"type": "ai-title", "aiTitle": "LLM derived"}) + "\n" +
+        json.dumps({"type": "custom-title", "customTitle": "user named"}) + "\n"
     )
-    assert agent_hook.read_claude_title(str(p)) == "winner"
+    assert agent_hook.read_claude_title(str(p)) == "user named"
+
+
+def test_read_claude_title_ai_title_beats_first_prompt(tmp_path):
+    # No /rename → ai-title wins over user prompt.
+    p = tmp_path / "t.jsonl"
+    p.write_text(
+        json.dumps({"type": "user", "message": {"content": "first prompt"}}) + "\n" +
+        json.dumps({"type": "ai-title", "aiTitle": "LLM derived"}) + "\n"
+    )
+    assert agent_hook.read_claude_title(str(p)) == "LLM derived"
+
+
+def test_read_claude_title_picks_latest_custom_title(tmp_path):
+    p = tmp_path / "t.jsonl"
+    p.write_text(
+        json.dumps({"type": "custom-title", "customTitle": "first"}) + "\n" +
+        json.dumps({"type": "custom-title", "customTitle": "second"}) + "\n"
+    )
+    assert agent_hook.read_claude_title(str(p)) == "second"
 
 
 # ---------- read_codex_title (first user_message from rollout) ----------
 
-def _write_codex_rollout(tmp_path, session_id, user_messages):
-    """Helper: build a CODEX_HOME-shaped rollout file for session_id."""
+def _write_codex_rollout(tmp_path, session_id, events):
+    """Helper: build a CODEX_HOME-shaped rollout file for session_id.
+    `events` is a list of dicts already shaped as `payload`."""
     sessions_dir = tmp_path / "sessions" / "2026" / "05" / "24"
     sessions_dir.mkdir(parents=True, exist_ok=True)
     f = sessions_dir / f"rollout-2026-05-24T00-00-00-{session_id}.jsonl"
-    lines = [
-        json.dumps({"type": "session_meta", "payload": {"id": session_id}}),
-    ]
-    for m in user_messages:
-        lines.append(json.dumps({
-            "type": "event_msg",
-            "payload": {"type": "user_message", "message": m},
-        }))
+    lines = [json.dumps({"type": "session_meta", "payload": {"id": session_id}})]
+    for ev in events:
+        lines.append(json.dumps({"type": "event_msg", "payload": ev}))
     f.write_text("\n".join(lines) + "\n")
     return f
 
 
-def test_read_codex_title_reads_first_user_message(tmp_path, monkeypatch):
+def _user_msg(text):
+    return {"type": "user_message", "message": text}
+
+
+def _thread_name(name):
+    return {"type": "thread_name_updated", "thread_name": name}
+
+
+def test_read_codex_title_thread_name_beats_user_message(tmp_path, monkeypatch):
     _write_codex_rollout(tmp_path, "abc-123",
-                          ["first prompt", "second prompt"])
+                          [_user_msg("first prompt"), _thread_name("Codex LLM name")])
+    monkeypatch.setattr(agent_hook, "CODEX_HOME", tmp_path)
+    assert agent_hook.read_codex_title("abc-123") == "Codex LLM name"
+
+
+def test_read_codex_title_falls_back_to_first_user_message(tmp_path, monkeypatch):
+    # No thread_name_updated → use the user's own first prompt.
+    _write_codex_rollout(tmp_path, "abc-123",
+                          [_user_msg("first prompt"), _user_msg("second prompt")])
     monkeypatch.setattr(agent_hook, "CODEX_HOME", tmp_path)
     assert agent_hook.read_codex_title("abc-123") == "first prompt"
 
@@ -470,12 +500,12 @@ def test_read_codex_title_rejects_invalid_session_id(tmp_path, monkeypatch):
 
 
 def test_read_codex_title_truncates_to_200(tmp_path, monkeypatch):
-    _write_codex_rollout(tmp_path, "abc-123", ["x" * 500])
+    _write_codex_rollout(tmp_path, "abc-123", [_thread_name("x" * 500)])
     monkeypatch.setattr(agent_hook, "CODEX_HOME", tmp_path)
     assert len(agent_hook.read_codex_title("abc-123")) == 200
 
 
-def test_read_codex_title_ignores_non_user_event_msg(tmp_path, monkeypatch):
+def test_read_codex_title_ignores_non_matching_event_msg(tmp_path, monkeypatch):
     sessions_dir = tmp_path / "sessions" / "2026" / "05" / "24"
     sessions_dir.mkdir(parents=True, exist_ok=True)
     f = sessions_dir / "rollout-2026-05-24T00-00-00-sid.jsonl"
@@ -487,29 +517,37 @@ def test_read_codex_title_ignores_non_user_event_msg(tmp_path, monkeypatch):
     assert agent_hook.read_codex_title("sid") == "real"
 
 
+def test_read_codex_title_picks_latest_thread_name(tmp_path, monkeypatch):
+    # Codex may rewrite thread_name later in the session; take the latest.
+    _write_codex_rollout(tmp_path, "abc-123",
+                          [_thread_name("First name"), _thread_name("Second name")])
+    monkeypatch.setattr(agent_hook, "CODEX_HOME", tmp_path)
+    assert agent_hook.read_codex_title("abc-123") == "Second name"
+
+
 # ---------- dispatch sessionTitle attachment ----------
 
 def test_dispatch_claude_prompt_attaches_session_title(tmp_path):
     sf = tmp_path / "sessions.json"
     transcript = tmp_path / "t.jsonl"
     transcript.write_text(
-        json.dumps({"type": "user", "message": {"content": "first user prompt"}}) + "\n"
+        json.dumps({"type": "ai-title", "aiTitle": "My session"}) + "\n"
     )
     emit = agent_hook.dispatch("prompt", "claude",
                                 {"session_id": "s1",
                                  "transcript_path": str(transcript)},
                                 "term1", sf, 1.0)
-    assert emit.get("sessionTitle") == "first user prompt"
+    assert emit.get("sessionTitle") == "My session"
 
 
 def test_dispatch_codex_prompt_attaches_session_title(tmp_path, monkeypatch):
-    _write_codex_rollout(tmp_path, "cdx-1", ["the codex prompt"])
+    _write_codex_rollout(tmp_path, "cdx-1", [_thread_name("Codex LLM name")])
     monkeypatch.setattr(agent_hook, "CODEX_HOME", tmp_path)
     sf = tmp_path / "sessions.json"
     emit = agent_hook.dispatch("prompt", "codex",
                                 {"session_id": "cdx-1"},
                                 "term-c", sf, 1.0)
-    assert emit.get("sessionTitle") == "the codex prompt"
+    assert emit.get("sessionTitle") == "Codex LLM name"
 
 
 def test_dispatch_no_session_title_when_empty(tmp_path):

--- a/Resources/agent-hooks/tests/test_agent_hook.py
+++ b/Resources/agent-hooks/tests/test_agent_hook.py
@@ -346,3 +346,132 @@ def test_dispatch_pretool_does_not_emit_resume_command(tmp_path):
                                  "tool_input": {"command": "ls"}},
                                 "t9", sf, 6_000_001.0)
     assert "resumeCommand" not in emit
+
+
+# ---------- read_ai_title ----------
+
+def test_read_ai_title_picks_last(tmp_path):
+    p = tmp_path / "t.jsonl"
+    p.write_text(
+        json.dumps({"type": "ai-title", "aiTitle": "Old title"}) + "\n" +
+        json.dumps({"type": "user", "content": "noise"}) + "\n" +
+        json.dumps({"type": "ai-title", "aiTitle": "Latest title"}) + "\n"
+    )
+    assert agent_hook.read_ai_title(str(p)) == "Latest title"
+
+
+def test_read_ai_title_truncates_to_200(tmp_path):
+    p = tmp_path / "t.jsonl"
+    long = "x" * 500
+    p.write_text(json.dumps({"type": "ai-title", "aiTitle": long}) + "\n")
+    assert len(agent_hook.read_ai_title(str(p))) == 200
+
+
+def test_read_ai_title_missing_file():
+    assert agent_hook.read_ai_title("/nonexistent/path.jsonl") == ""
+
+
+def test_read_ai_title_no_match(tmp_path):
+    p = tmp_path / "t.jsonl"
+    p.write_text(json.dumps({"type": "user", "content": "x"}) + "\n")
+    assert agent_hook.read_ai_title(str(p)) == ""
+
+
+def test_read_ai_title_skips_malformed_lines(tmp_path):
+    p = tmp_path / "t.jsonl"
+    p.write_text(
+        "not json\n" +
+        json.dumps({"type": "ai-title", "aiTitle": "Good"}) + "\n"
+    )
+    assert agent_hook.read_ai_title(str(p)) == "Good"
+
+
+# ---------- read_codex_title ----------
+
+def test_read_codex_title_reads_from_db(tmp_path, monkeypatch):
+    import sqlite3
+    db = tmp_path / "state_5.sqlite"
+    con = sqlite3.connect(db)
+    con.execute("CREATE TABLE threads (id TEXT PRIMARY KEY, title TEXT)")
+    con.execute("INSERT INTO threads VALUES (?, ?)",
+                ("abc-123", "Codex session name"))
+    con.commit()
+    con.close()
+    monkeypatch.setattr(agent_hook, "CODEX_HOME", tmp_path)
+    assert agent_hook.read_codex_title("abc-123") == "Codex session name"
+
+
+def test_read_codex_title_picks_newest_schema(tmp_path, monkeypatch):
+    import sqlite3
+    # Two DB schema versions; we should query state_99 (newest).
+    for ver, title in [(3, "Old"), (99, "New")]:
+        db = tmp_path / f"state_{ver}.sqlite"
+        con = sqlite3.connect(db)
+        con.execute("CREATE TABLE threads (id TEXT PRIMARY KEY, title TEXT)")
+        con.execute("INSERT INTO threads VALUES (?, ?)", ("sid", title))
+        con.commit()
+        con.close()
+    monkeypatch.setattr(agent_hook, "CODEX_HOME", tmp_path)
+    assert agent_hook.read_codex_title("sid") == "New"
+
+
+def test_read_codex_title_no_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(agent_hook, "CODEX_HOME", tmp_path)
+    assert agent_hook.read_codex_title("sid") == ""
+
+
+def test_read_codex_title_rejects_invalid_session_id(tmp_path, monkeypatch):
+    monkeypatch.setattr(agent_hook, "CODEX_HOME", tmp_path)
+    assert agent_hook.read_codex_title("bad; DROP TABLE") == ""
+
+
+def test_read_codex_title_truncates_to_200(tmp_path, monkeypatch):
+    import sqlite3
+    db = tmp_path / "state_5.sqlite"
+    con = sqlite3.connect(db)
+    con.execute("CREATE TABLE threads (id TEXT PRIMARY KEY, title TEXT)")
+    con.execute("INSERT INTO threads VALUES (?, ?)", ("sid", "x" * 500))
+    con.commit()
+    con.close()
+    monkeypatch.setattr(agent_hook, "CODEX_HOME", tmp_path)
+    assert len(agent_hook.read_codex_title("sid")) == 200
+
+
+# ---------- dispatch sessionTitle attachment ----------
+
+def test_dispatch_claude_prompt_attaches_session_title(tmp_path):
+    sf = tmp_path / "sessions.json"
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text(
+        json.dumps({"type": "ai-title", "aiTitle": "My session"}) + "\n"
+    )
+    emit = agent_hook.dispatch("prompt", "claude",
+                                {"session_id": "s1",
+                                 "transcript_path": str(transcript)},
+                                "term1", sf, 1.0)
+    assert emit.get("sessionTitle") == "My session"
+
+
+def test_dispatch_codex_prompt_attaches_session_title(tmp_path, monkeypatch):
+    import sqlite3
+    db = tmp_path / "state_5.sqlite"
+    con = sqlite3.connect(db)
+    con.execute("CREATE TABLE threads (id TEXT PRIMARY KEY, title TEXT)")
+    con.execute("INSERT INTO threads VALUES (?, ?)", ("cdx-1", "Codex name"))
+    con.commit()
+    con.close()
+    monkeypatch.setattr(agent_hook, "CODEX_HOME", tmp_path)
+    sf = tmp_path / "sessions.json"
+    emit = agent_hook.dispatch("prompt", "codex",
+                                {"session_id": "cdx-1"},
+                                "term-c", sf, 1.0)
+    assert emit.get("sessionTitle") == "Codex name"
+
+
+def test_dispatch_no_session_title_when_empty(tmp_path):
+    sf = tmp_path / "sessions.json"
+    # No transcript_path → read_ai_title returns ""
+    emit = agent_hook.dispatch("prompt", "claude",
+                                {"session_id": "s1"},
+                                "term1", sf, 1.0)
+    assert "sessionTitle" not in emit

--- a/Resources/agent-hooks/tests/test_agent_hook.py
+++ b/Resources/agent-hooks/tests/test_agent_hook.py
@@ -413,6 +413,71 @@ def test_read_ai_title_picks_latest_custom_title(tmp_path):
     assert agent_hook.read_ai_title(str(p)) == "second"
 
 
+def test_read_ai_title_falls_back_to_first_user_prompt(tmp_path):
+    # Short sessions never get an ai-title; we still want a useful tab name.
+    p = tmp_path / "t.jsonl"
+    p.write_text(
+        json.dumps({"type": "user", "message": {"content": "How do I sort an array in Swift?"}}) + "\n" +
+        json.dumps({"type": "assistant", "message": {"content": "..."}}) + "\n"
+    )
+    assert agent_hook.read_ai_title(str(p)) == "How do I sort an array in Swift?"
+
+
+def test_read_ai_title_first_prompt_skips_slash_commands(tmp_path):
+    # /clear and /rename rows are recorded as user rows with <command-...> content.
+    # They must not be picked up as the "first prompt".
+    p = tmp_path / "t.jsonl"
+    p.write_text(
+        json.dumps({"type": "user", "message": {"content": "<command-name>/clear</command-name>"}}) + "\n" +
+        json.dumps({"type": "user", "message": {"content": "real question"}}) + "\n"
+    )
+    assert agent_hook.read_ai_title(str(p)) == "real question"
+
+
+def test_read_ai_title_first_prompt_skips_meta(tmp_path):
+    # isMeta=true rows are e.g. hook context injections, not user input.
+    p = tmp_path / "t.jsonl"
+    p.write_text(
+        json.dumps({"type": "user", "isMeta": True, "message": {"content": "meta payload"}}) + "\n" +
+        json.dumps({"type": "user", "message": {"content": "first real"}}) + "\n"
+    )
+    assert agent_hook.read_ai_title(str(p)) == "first real"
+
+
+def test_read_ai_title_first_prompt_extracts_text_from_list_content(tmp_path):
+    # Claude sometimes stores content as [{type: text, text: ...}, ...].
+    p = tmp_path / "t.jsonl"
+    p.write_text(
+        json.dumps({
+            "type": "user",
+            "message": {"content": [
+                {"type": "text", "text": "list-form content"},
+                {"type": "image"},
+            ]},
+        }) + "\n"
+    )
+    assert agent_hook.read_ai_title(str(p)) == "list-form content"
+
+
+def test_read_ai_title_custom_beats_first_prompt(tmp_path):
+    # Even if a user prompt exists first, custom-title must still win.
+    p = tmp_path / "t.jsonl"
+    p.write_text(
+        json.dumps({"type": "user", "message": {"content": "real question"}}) + "\n" +
+        json.dumps({"type": "custom-title", "customTitle": "my name"}) + "\n"
+    )
+    assert agent_hook.read_ai_title(str(p)) == "my name"
+
+
+def test_read_ai_title_ai_beats_first_prompt(tmp_path):
+    p = tmp_path / "t.jsonl"
+    p.write_text(
+        json.dumps({"type": "user", "message": {"content": "first prompt"}}) + "\n" +
+        json.dumps({"type": "ai-title", "aiTitle": "LLM derived"}) + "\n"
+    )
+    assert agent_hook.read_ai_title(str(p)) == "LLM derived"
+
+
 # ---------- read_codex_title ----------
 
 def test_read_codex_title_reads_from_db(tmp_path, monkeypatch):

--- a/Resources/agent-hooks/tests/test_agent_hook.py
+++ b/Resources/agent-hooks/tests/test_agent_hook.py
@@ -348,103 +348,64 @@ def test_dispatch_pretool_does_not_emit_resume_command(tmp_path):
     assert "resumeCommand" not in emit
 
 
-# ---------- read_ai_title ----------
+# ---------- read_claude_title (first user prompt) ----------
 
-def test_read_ai_title_picks_last(tmp_path):
-    p = tmp_path / "t.jsonl"
-    p.write_text(
-        json.dumps({"type": "ai-title", "aiTitle": "Old title"}) + "\n" +
-        json.dumps({"type": "user", "content": "noise"}) + "\n" +
-        json.dumps({"type": "ai-title", "aiTitle": "Latest title"}) + "\n"
-    )
-    assert agent_hook.read_ai_title(str(p)) == "Latest title"
-
-
-def test_read_ai_title_truncates_to_200(tmp_path):
-    p = tmp_path / "t.jsonl"
-    long = "x" * 500
-    p.write_text(json.dumps({"type": "ai-title", "aiTitle": long}) + "\n")
-    assert len(agent_hook.read_ai_title(str(p))) == 200
-
-
-def test_read_ai_title_missing_file():
-    assert agent_hook.read_ai_title("/nonexistent/path.jsonl") == ""
-
-
-def test_read_ai_title_no_match(tmp_path):
-    p = tmp_path / "t.jsonl"
-    p.write_text(json.dumps({"type": "user", "content": "x"}) + "\n")
-    assert agent_hook.read_ai_title(str(p)) == ""
-
-
-def test_read_ai_title_skips_malformed_lines(tmp_path):
-    p = tmp_path / "t.jsonl"
-    p.write_text(
-        "not json\n" +
-        json.dumps({"type": "ai-title", "aiTitle": "Good"}) + "\n"
-    )
-    assert agent_hook.read_ai_title(str(p)) == "Good"
-
-
-def test_read_ai_title_custom_title_wins_over_ai(tmp_path):
-    # User's /rename writes a custom-title row. That intent must beat the
-    # LLM-generated ai-title even if ai-title appears later in the file.
-    p = tmp_path / "t.jsonl"
-    p.write_text(
-        json.dumps({"type": "custom-title", "customTitle": "user named"}) + "\n" +
-        json.dumps({"type": "ai-title", "aiTitle": "LLM guessed"}) + "\n"
-    )
-    assert agent_hook.read_ai_title(str(p)) == "user named"
-
-
-def test_read_ai_title_falls_back_to_ai_when_no_custom(tmp_path):
-    p = tmp_path / "t.jsonl"
-    p.write_text(json.dumps({"type": "ai-title", "aiTitle": "LLM only"}) + "\n")
-    assert agent_hook.read_ai_title(str(p)) == "LLM only"
-
-
-def test_read_ai_title_picks_latest_custom_title(tmp_path):
-    # Multiple /rename calls write multiple custom-title rows; take the last.
-    p = tmp_path / "t.jsonl"
-    p.write_text(
-        json.dumps({"type": "custom-title", "customTitle": "first"}) + "\n" +
-        json.dumps({"type": "custom-title", "customTitle": "second"}) + "\n"
-    )
-    assert agent_hook.read_ai_title(str(p)) == "second"
-
-
-def test_read_ai_title_falls_back_to_first_user_prompt(tmp_path):
-    # Short sessions never get an ai-title; we still want a useful tab name.
+def test_read_claude_title_picks_first_user_prompt(tmp_path):
     p = tmp_path / "t.jsonl"
     p.write_text(
         json.dumps({"type": "user", "message": {"content": "How do I sort an array in Swift?"}}) + "\n" +
-        json.dumps({"type": "assistant", "message": {"content": "..."}}) + "\n"
+        json.dumps({"type": "assistant", "message": {"content": "..."}}) + "\n" +
+        json.dumps({"type": "user", "message": {"content": "ignored later prompt"}}) + "\n"
     )
-    assert agent_hook.read_ai_title(str(p)) == "How do I sort an array in Swift?"
+    assert agent_hook.read_claude_title(str(p)) == "How do I sort an array in Swift?"
 
 
-def test_read_ai_title_first_prompt_skips_slash_commands(tmp_path):
+def test_read_claude_title_truncates_to_200(tmp_path):
+    p = tmp_path / "t.jsonl"
+    long = "x" * 500
+    p.write_text(json.dumps({"type": "user", "message": {"content": long}}) + "\n")
+    assert len(agent_hook.read_claude_title(str(p))) == 200
+
+
+def test_read_claude_title_missing_file():
+    assert agent_hook.read_claude_title("/nonexistent/path.jsonl") == ""
+
+
+def test_read_claude_title_no_user_row(tmp_path):
+    p = tmp_path / "t.jsonl"
+    p.write_text(json.dumps({"type": "assistant", "message": {"content": "only assistant"}}) + "\n")
+    assert agent_hook.read_claude_title(str(p)) == ""
+
+
+def test_read_claude_title_skips_malformed_lines(tmp_path):
+    p = tmp_path / "t.jsonl"
+    p.write_text(
+        "not json\n" +
+        json.dumps({"type": "user", "message": {"content": "Good"}}) + "\n"
+    )
+    assert agent_hook.read_claude_title(str(p)) == "Good"
+
+
+def test_read_claude_title_skips_slash_commands(tmp_path):
     # /clear and /rename rows are recorded as user rows with <command-...> content.
-    # They must not be picked up as the "first prompt".
     p = tmp_path / "t.jsonl"
     p.write_text(
         json.dumps({"type": "user", "message": {"content": "<command-name>/clear</command-name>"}}) + "\n" +
         json.dumps({"type": "user", "message": {"content": "real question"}}) + "\n"
     )
-    assert agent_hook.read_ai_title(str(p)) == "real question"
+    assert agent_hook.read_claude_title(str(p)) == "real question"
 
 
-def test_read_ai_title_first_prompt_skips_meta(tmp_path):
-    # isMeta=true rows are e.g. hook context injections, not user input.
+def test_read_claude_title_skips_meta(tmp_path):
     p = tmp_path / "t.jsonl"
     p.write_text(
         json.dumps({"type": "user", "isMeta": True, "message": {"content": "meta payload"}}) + "\n" +
         json.dumps({"type": "user", "message": {"content": "first real"}}) + "\n"
     )
-    assert agent_hook.read_ai_title(str(p)) == "first real"
+    assert agent_hook.read_claude_title(str(p)) == "first real"
 
 
-def test_read_ai_title_first_prompt_extracts_text_from_list_content(tmp_path):
+def test_read_claude_title_extracts_text_from_list_content(tmp_path):
     # Claude sometimes stores content as [{type: text, text: ...}, ...].
     p = tmp_path / "t.jsonl"
     p.write_text(
@@ -456,60 +417,51 @@ def test_read_ai_title_first_prompt_extracts_text_from_list_content(tmp_path):
             ]},
         }) + "\n"
     )
-    assert agent_hook.read_ai_title(str(p)) == "list-form content"
+    assert agent_hook.read_claude_title(str(p)) == "list-form content"
 
 
-def test_read_ai_title_custom_beats_first_prompt(tmp_path):
-    # Even if a user prompt exists first, custom-title must still win.
+def test_read_claude_title_ignores_ai_title_and_custom_title(tmp_path):
+    # We intentionally drop LLM-generated and /rename metadata rows in
+    # favor of the user's own first prompt — keeps behavior predictable
+    # across short sessions where claude never writes ai-title.
     p = tmp_path / "t.jsonl"
     p.write_text(
-        json.dumps({"type": "user", "message": {"content": "real question"}}) + "\n" +
-        json.dumps({"type": "custom-title", "customTitle": "my name"}) + "\n"
+        json.dumps({"type": "custom-title", "customTitle": "ignored"}) + "\n" +
+        json.dumps({"type": "ai-title", "aiTitle": "also ignored"}) + "\n" +
+        json.dumps({"type": "user", "message": {"content": "winner"}}) + "\n"
     )
-    assert agent_hook.read_ai_title(str(p)) == "my name"
+    assert agent_hook.read_claude_title(str(p)) == "winner"
 
 
-def test_read_ai_title_ai_beats_first_prompt(tmp_path):
-    p = tmp_path / "t.jsonl"
-    p.write_text(
-        json.dumps({"type": "user", "message": {"content": "first prompt"}}) + "\n" +
-        json.dumps({"type": "ai-title", "aiTitle": "LLM derived"}) + "\n"
-    )
-    assert agent_hook.read_ai_title(str(p)) == "LLM derived"
+# ---------- read_codex_title (first user_message from rollout) ----------
+
+def _write_codex_rollout(tmp_path, session_id, user_messages):
+    """Helper: build a CODEX_HOME-shaped rollout file for session_id."""
+    sessions_dir = tmp_path / "sessions" / "2026" / "05" / "24"
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+    f = sessions_dir / f"rollout-2026-05-24T00-00-00-{session_id}.jsonl"
+    lines = [
+        json.dumps({"type": "session_meta", "payload": {"id": session_id}}),
+    ]
+    for m in user_messages:
+        lines.append(json.dumps({
+            "type": "event_msg",
+            "payload": {"type": "user_message", "message": m},
+        }))
+    f.write_text("\n".join(lines) + "\n")
+    return f
 
 
-# ---------- read_codex_title ----------
-
-def test_read_codex_title_reads_from_db(tmp_path, monkeypatch):
-    import sqlite3
-    db = tmp_path / "state_5.sqlite"
-    con = sqlite3.connect(db)
-    con.execute("CREATE TABLE threads (id TEXT PRIMARY KEY, title TEXT)")
-    con.execute("INSERT INTO threads VALUES (?, ?)",
-                ("abc-123", "Codex session name"))
-    con.commit()
-    con.close()
+def test_read_codex_title_reads_first_user_message(tmp_path, monkeypatch):
+    _write_codex_rollout(tmp_path, "abc-123",
+                          ["first prompt", "second prompt"])
     monkeypatch.setattr(agent_hook, "CODEX_HOME", tmp_path)
-    assert agent_hook.read_codex_title("abc-123") == "Codex session name"
+    assert agent_hook.read_codex_title("abc-123") == "first prompt"
 
 
-def test_read_codex_title_picks_newest_schema(tmp_path, monkeypatch):
-    import sqlite3
-    # Two DB schema versions; we should query state_99 (newest).
-    for ver, title in [(3, "Old"), (99, "New")]:
-        db = tmp_path / f"state_{ver}.sqlite"
-        con = sqlite3.connect(db)
-        con.execute("CREATE TABLE threads (id TEXT PRIMARY KEY, title TEXT)")
-        con.execute("INSERT INTO threads VALUES (?, ?)", ("sid", title))
-        con.commit()
-        con.close()
+def test_read_codex_title_no_rollout(tmp_path, monkeypatch):
     monkeypatch.setattr(agent_hook, "CODEX_HOME", tmp_path)
-    assert agent_hook.read_codex_title("sid") == "New"
-
-
-def test_read_codex_title_no_db(tmp_path, monkeypatch):
-    monkeypatch.setattr(agent_hook, "CODEX_HOME", tmp_path)
-    assert agent_hook.read_codex_title("sid") == ""
+    assert agent_hook.read_codex_title("missing") == ""
 
 
 def test_read_codex_title_rejects_invalid_session_id(tmp_path, monkeypatch):
@@ -518,15 +470,21 @@ def test_read_codex_title_rejects_invalid_session_id(tmp_path, monkeypatch):
 
 
 def test_read_codex_title_truncates_to_200(tmp_path, monkeypatch):
-    import sqlite3
-    db = tmp_path / "state_5.sqlite"
-    con = sqlite3.connect(db)
-    con.execute("CREATE TABLE threads (id TEXT PRIMARY KEY, title TEXT)")
-    con.execute("INSERT INTO threads VALUES (?, ?)", ("sid", "x" * 500))
-    con.commit()
-    con.close()
+    _write_codex_rollout(tmp_path, "abc-123", ["x" * 500])
     monkeypatch.setattr(agent_hook, "CODEX_HOME", tmp_path)
-    assert len(agent_hook.read_codex_title("sid")) == 200
+    assert len(agent_hook.read_codex_title("abc-123")) == 200
+
+
+def test_read_codex_title_ignores_non_user_event_msg(tmp_path, monkeypatch):
+    sessions_dir = tmp_path / "sessions" / "2026" / "05" / "24"
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+    f = sessions_dir / "rollout-2026-05-24T00-00-00-sid.jsonl"
+    f.write_text(
+        json.dumps({"type": "event_msg", "payload": {"type": "task_started"}}) + "\n" +
+        json.dumps({"type": "event_msg", "payload": {"type": "user_message", "message": "real"}}) + "\n"
+    )
+    monkeypatch.setattr(agent_hook, "CODEX_HOME", tmp_path)
+    assert agent_hook.read_codex_title("sid") == "real"
 
 
 # ---------- dispatch sessionTitle attachment ----------
@@ -535,34 +493,28 @@ def test_dispatch_claude_prompt_attaches_session_title(tmp_path):
     sf = tmp_path / "sessions.json"
     transcript = tmp_path / "t.jsonl"
     transcript.write_text(
-        json.dumps({"type": "ai-title", "aiTitle": "My session"}) + "\n"
+        json.dumps({"type": "user", "message": {"content": "first user prompt"}}) + "\n"
     )
     emit = agent_hook.dispatch("prompt", "claude",
                                 {"session_id": "s1",
                                  "transcript_path": str(transcript)},
                                 "term1", sf, 1.0)
-    assert emit.get("sessionTitle") == "My session"
+    assert emit.get("sessionTitle") == "first user prompt"
 
 
 def test_dispatch_codex_prompt_attaches_session_title(tmp_path, monkeypatch):
-    import sqlite3
-    db = tmp_path / "state_5.sqlite"
-    con = sqlite3.connect(db)
-    con.execute("CREATE TABLE threads (id TEXT PRIMARY KEY, title TEXT)")
-    con.execute("INSERT INTO threads VALUES (?, ?)", ("cdx-1", "Codex name"))
-    con.commit()
-    con.close()
+    _write_codex_rollout(tmp_path, "cdx-1", ["the codex prompt"])
     monkeypatch.setattr(agent_hook, "CODEX_HOME", tmp_path)
     sf = tmp_path / "sessions.json"
     emit = agent_hook.dispatch("prompt", "codex",
                                 {"session_id": "cdx-1"},
                                 "term-c", sf, 1.0)
-    assert emit.get("sessionTitle") == "Codex name"
+    assert emit.get("sessionTitle") == "the codex prompt"
 
 
 def test_dispatch_no_session_title_when_empty(tmp_path):
     sf = tmp_path / "sessions.json"
-    # No transcript_path → read_ai_title returns ""
+    # No transcript_path → read_claude_title returns ""
     emit = agent_hook.dispatch("prompt", "claude",
                                 {"session_id": "s1"},
                                 "term1", sf, 1.0)

--- a/docs/agent-hooks.md
+++ b/docs/agent-hooks.md
@@ -16,11 +16,11 @@ mux0 通过注入到各 AI CLI 的生命周期钩子，把 `running` / `idle` / 
 
 | Agent | 来源 | 时机 |
 |-------|------|------|
-| Claude | transcript JSONL 第一条非 slash-command、非 meta 的 user message（typed-content-block 也展开） | `prompt` / `stop` |
-| Codex | `~/.codex/sessions/**/rollout-*-<session_id>.jsonl` 内第一条 `event_msg`/`user_message` | `prompt` / `stop` |
-| OpenCode | plugin 进程内缓存的"该 session 首条 chat.message 文本"（typed parts 展开） | `chat.message` / `tool.execute.before` |
+| Claude | `custom-title`（`/rename`）→ `ai-title`（LLM 异步生成）→ 第一条非 slash-command、非 meta 的 user message（typed-content-block 展开） | `prompt` / `stop` |
+| Codex | `event_msg.thread_name_updated` 的 `thread_name`（LLM 生成）→ 第一条 `event_msg.user_message`。两者都从 `~/.codex/sessions/**/rollout-*-<session_id>.jsonl` 单次扫描 | `prompt` / `stop` |
+| OpenCode | plugin `input.session?.title`（LLM 生成）→ plugin 进程内缓存的"该 session 首条 chat.message 文本"（typed parts 展开） | `chat.message` / `tool.execute.before` |
 
-三个 agent **统一以"第一条 user message"为标题**，刻意不读 Claude 的 `ai-title` / `custom-title` / Codex 的 `threads.title` SQLite 列 / OpenCode 的 LLM 生成 `session.title` —— 与 cmux 同款策略。理由：LLM 自动标题生成时机不可控（短对话不生成、首 turn 通常没拿到），用户首条 prompt 是即时、稳定、可预测的标识。每条 emit 都重读，文件还没 flush 时返回空字符串，Swift 端 `TerminalSessionTitleStore.update` 丢弃空字符串避免覆盖已知值。
+策略一致：**LLM-generated title 优先于 first user message fallback**，与各 agent 自己 `--resume` picker 的显示语义对齐。LLM title 生成是异步的——短对话或新 session 第一次 emit 可能没有，fallback 到首条 user prompt 保证 tab 仍有可辨识标签。Codex 的 thread_name 与 SQLite `threads.title` 是同一份 LLM 输出，我们走 JSONL 路径（与 thread_name_updated 事件来自同一文件，零额外 IO）。Claude 的 `/rename` 写入的 `custom-title` 是即时的，永远胜过稍后写出的 `ai-title`。Swift 端 `TerminalSessionTitleStore.update` 丢弃空字符串，避免文件还没 flush 时覆盖已知值。
 
 用户在 mux0 内 inline rename tab 后，`TerminalTab.userRenamed = true`，`displayTitle` 锁定不再吃 `sessionTitle`。右键菜单「Reset to auto title」清除锁定。
 

--- a/docs/agent-hooks.md
+++ b/docs/agent-hooks.md
@@ -10,6 +10,22 @@ mux0 通过注入到各 AI CLI 的生命周期钩子，把 `running` / `idle` / 
 - 消息格式：每行一个 JSON，`{"terminalId": "...", "event": "running|idle|needsInput|finished", "agent": "claude|opencode|codex", "at": <epoch>, "exitCode": <int>?, "toolDetail": <string>?, "summary": <string>?, "resumeCommand": <string>?}`。`exitCode` 仅在 `event=finished` 时携带（shell = 真实 `$?`；agent = 0/1 哨兵）；`toolDetail` 仅在 agent 的 `event=running` 时携带（如 "Edit Models/Foo.swift"）；`summary` 仅在 agent 的 `event=finished` 时携带（transcript 最后一条 assistant 消息，≤200 chars）；`resumeCommand` 仅在 Claude/Codex 的 prompt 触发的 `event=running` 时携带（恢复当前 session 的 CLI，如 `claude --resume <session_id>` / `codex resume <session_id>`，OpenCode 暂未支持）。
 - 监听端：`HookSocketListener`（DispatchSourceRead，accept 循环）
 
+## Session title
+
+每条 socket 消息可携带 `sessionTitle` —— 当前 agent 会话的人类可读名字，用于驱动 mux0 的 tab 自动命名（`TerminalSessionTitleStore`）。三个 agent 各自的来源：
+
+| Agent | 来源 | 时机 |
+|-------|------|------|
+| Claude | transcript JSONL 内反向扫到的最后一条 `{"type":"ai-title","aiTitle":"..."}` 条目 | `prompt` / `stop` |
+| Codex | `~/.codex/state_*.sqlite`（取最新 schema 版本）的 `threads.title WHERE id = <session_id>` | `prompt` / `stop` |
+| OpenCode | plugin `input.session?.title` | `chat.message` / `tool.execute.before` |
+
+三处都是 LLM 异步生成 → 新建 session 后第一次 emit 时可能为空字符串，下一个 turn 会填上。Swift 端 `TerminalSessionTitleStore.update` 丢弃空字符串，避免覆盖已知值。
+
+用户在 mux0 内 inline rename tab 后，`TerminalTab.userRenamed = true`，`displayTitle` 锁定不再吃 `sessionTitle`。右键菜单「Reset to auto title」清除锁定。
+
+`HookDispatcher` 路由 `sessionTitle` 时**不**走 `mux0-agent-status-<agent>` 门控 —— 只要插件 emit 了，tab 命名就跟上，与"是否显示状态图标"完全独立。
+
 ## Agent Turn 成败检测
 
 Agent turn 没有真实的 exit code，但 Claude Code / Codex 的 `PostToolUse` hook 和 OpenCode 的 `tool.execute.after` 插件事件都带结构化的 "tool 报错了吗" 字段。mux0 在每个 turn 内聚合这些 per-tool 信号到一个布尔 `turnHadError`，在 `Stop` / `session.idle` 时发 `finished` 事件，`exitCode` 设为 0（clean）或 1（had errors）。

--- a/docs/agent-hooks.md
+++ b/docs/agent-hooks.md
@@ -16,11 +16,11 @@ mux0 通过注入到各 AI CLI 的生命周期钩子，把 `running` / `idle` / 
 
 | Agent | 来源 | 时机 |
 |-------|------|------|
-| Claude | transcript JSONL 内反向扫到的最后一条 `{"type":"ai-title","aiTitle":"..."}` 条目 | `prompt` / `stop` |
+| Claude | transcript JSONL 内 `custom-title`（`/rename` 写入）优先；fallback 到 `ai-title`（LLM 异步生成） | `prompt` / `stop` |
 | Codex | `~/.codex/state_*.sqlite`（取最新 schema 版本）的 `threads.title WHERE id = <session_id>` | `prompt` / `stop` |
 | OpenCode | plugin `input.session?.title` | `chat.message` / `tool.execute.before` |
 
-三处都是 LLM 异步生成 → 新建 session 后第一次 emit 时可能为空字符串，下一个 turn 会填上。Swift 端 `TerminalSessionTitleStore.update` 丢弃空字符串，避免覆盖已知值。
+LLM 自动生成的 title 在新建 session 后第一次 emit 时可能为空字符串，下一个 turn 会填上。Swift 端 `TerminalSessionTitleStore.update` 丢弃空字符串，避免覆盖已知值。`/rename` 写入的 Claude `custom-title` 是即时的，永远优先于稍后由 LLM 写出的 `ai-title`。
 
 用户在 mux0 内 inline rename tab 后，`TerminalTab.userRenamed = true`，`displayTitle` 锁定不再吃 `sessionTitle`。右键菜单「Reset to auto title」清除锁定。
 

--- a/docs/agent-hooks.md
+++ b/docs/agent-hooks.md
@@ -16,11 +16,11 @@ mux0 通过注入到各 AI CLI 的生命周期钩子，把 `running` / `idle` / 
 
 | Agent | 来源 | 时机 |
 |-------|------|------|
-| Claude | transcript JSONL 内 `custom-title`（`/rename` 写入）优先；fallback 到 `ai-title`（LLM 异步生成） | `prompt` / `stop` |
+| Claude | `custom-title`（`/rename`）→ `ai-title`（LLM 异步生成）→ 第一条真实 user prompt（截断）| `prompt` / `stop` |
 | Codex | `~/.codex/state_*.sqlite`（取最新 schema 版本）的 `threads.title WHERE id = <session_id>` | `prompt` / `stop` |
 | OpenCode | plugin `input.session?.title` | `chat.message` / `tool.execute.before` |
 
-LLM 自动生成的 title 在新建 session 后第一次 emit 时可能为空字符串，下一个 turn 会填上。Swift 端 `TerminalSessionTitleStore.update` 丢弃空字符串，避免覆盖已知值。`/rename` 写入的 Claude `custom-title` 是即时的，永远优先于稍后由 LLM 写出的 `ai-title`。
+Claude 的三段回退顺序与 `claude --resume` picker 显示逻辑一致：用户 `/rename` 永远优先；LLM 在短对话（`hi` / `你好` 这类）下不生成 `ai-title`，所以 fallback 到第一条非 slash-command 的 user prompt（截断），让 tab 在新建短会话时也能有合理标题。OpenCode `session.title` 是 LLM 异步生成的——新建 session 第一次 emit 时可能为空字符串，下一个 turn 会填上。Swift 端 `TerminalSessionTitleStore.update` 丢弃空字符串，避免覆盖已知值。
 
 用户在 mux0 内 inline rename tab 后，`TerminalTab.userRenamed = true`，`displayTitle` 锁定不再吃 `sessionTitle`。右键菜单「Reset to auto title」清除锁定。
 

--- a/docs/agent-hooks.md
+++ b/docs/agent-hooks.md
@@ -16,11 +16,11 @@ mux0 通过注入到各 AI CLI 的生命周期钩子，把 `running` / `idle` / 
 
 | Agent | 来源 | 时机 |
 |-------|------|------|
-| Claude | `custom-title`（`/rename`）→ `ai-title`（LLM 异步生成）→ 第一条真实 user prompt（截断）| `prompt` / `stop` |
-| Codex | `~/.codex/state_*.sqlite`（取最新 schema 版本）的 `threads.title WHERE id = <session_id>` | `prompt` / `stop` |
-| OpenCode | plugin `input.session?.title` | `chat.message` / `tool.execute.before` |
+| Claude | transcript JSONL 第一条非 slash-command、非 meta 的 user message（typed-content-block 也展开） | `prompt` / `stop` |
+| Codex | `~/.codex/sessions/**/rollout-*-<session_id>.jsonl` 内第一条 `event_msg`/`user_message` | `prompt` / `stop` |
+| OpenCode | plugin 进程内缓存的"该 session 首条 chat.message 文本"（typed parts 展开） | `chat.message` / `tool.execute.before` |
 
-Claude 的三段回退顺序与 `claude --resume` picker 显示逻辑一致：用户 `/rename` 永远优先；LLM 在短对话（`hi` / `你好` 这类）下不生成 `ai-title`，所以 fallback 到第一条非 slash-command 的 user prompt（截断），让 tab 在新建短会话时也能有合理标题。OpenCode `session.title` 是 LLM 异步生成的——新建 session 第一次 emit 时可能为空字符串，下一个 turn 会填上。Swift 端 `TerminalSessionTitleStore.update` 丢弃空字符串，避免覆盖已知值。
+三个 agent **统一以"第一条 user message"为标题**，刻意不读 Claude 的 `ai-title` / `custom-title` / Codex 的 `threads.title` SQLite 列 / OpenCode 的 LLM 生成 `session.title` —— 与 cmux 同款策略。理由：LLM 自动标题生成时机不可控（短对话不生成、首 turn 通常没拿到），用户首条 prompt 是即时、稳定、可预测的标识。每条 emit 都重读，文件还没 flush 时返回空字符串，Swift 端 `TerminalSessionTitleStore.update` 丢弃空字符串避免覆盖已知值。
 
 用户在 mux0 内 inline rename tab 后，`TerminalTab.userRenamed = true`，`displayTitle` 锁定不再吃 `sessionTitle`。右键菜单「Reset to auto title」清除锁定。
 

--- a/docs/superpowers/plans/2026-05-24-auto-tab-naming.md
+++ b/docs/superpowers/plans/2026-05-24-auto-tab-naming.md
@@ -1,0 +1,1795 @@
+# Tab 自动命名（从 agent 会话标题）实现计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Tab 标题在用户未手动 rename 时自动跟随当前焦点 pane 的 agent 会话名（Claude / Codex / OpenCode），用户一次 rename 即永久锁定该 tab 名。
+
+**Architecture:** Hook 端（`agent-hook.py` 和 `opencode-plugin/mux0-status.js`）在已有的 socket emit 上附加 `sessionTitle` 字段；Swift 端新增 `TerminalSessionTitleStore` 接收并按 terminalId 持久化；`TerminalTab` 新增 `userRenamed: Bool` 锁定标志；`TabItemView` 渲染时按 `userRenamed → store → tab.title 兜底` 三段回退。
+
+**Tech Stack:** Swift / AppKit / SwiftUI / XCTest / Python 3 stdlib (`sqlite3`) / Node.js (opencode plugin) / pytest
+
+**Spec:** `docs/superpowers/specs/2026-05-24-auto-tab-naming-design.md`
+
+---
+
+## File Structure
+
+**Create:**
+- `mux0/Models/TerminalSessionTitleStore.swift` — `@Observable` store，`[UUID: String]` 映射，UserDefaults 持久化
+- `mux0Tests/TerminalSessionTitleStoreTests.swift` — store CRUD + 持久化往返
+- `mux0Tests/TerminalTabDisplayTitleTests.swift` — `displayTitle(store:)` 三段回退
+- `mux0Tests/HookDispatcherSessionTitleTests.swift` — 路由 sessionTitle 到 store
+
+**Modify:**
+- `mux0/Models/HookMessage.swift` — 加 `sessionTitle: String?`
+- `mux0/Models/Workspace.swift` — `TerminalTab` 加 `userRenamed: Bool = false` + `displayTitle(...)` helper
+- `mux0/Models/HookDispatcher.swift` — 收到 `sessionTitle` 时调 store.update
+- `mux0/Models/WorkspaceStore.swift` — `renameTab` 设 `userRenamed=true`；新增 `resetTabToAutoTitle`；`closeTerminal`/`removeTab`/`deleteWorkspace` 清 store；接收 store 引用
+- `mux0/ContentView.swift` — 实例化 `TerminalSessionTitleStore`，注入 `TabBridge`，`HookDispatcher.dispatch` 传 store
+- `mux0/Bridge/TabBridge.swift` — `@Bindable var sessionTitleStore` + 透传到 `TabContentView`
+- `mux0/TabContent/TabContentView.swift` — 接 `sessionTitleStore`，传给 `TabBarView`
+- `mux0/TabContent/TabBarView.swift` — `update(...)` 接 `sessionTitleStore`；`TabItemView` 渲染 `displayTitle`；右键菜单加「Reset to auto title」
+- `mux0/Localization/Localizable.xcstrings` — 加 `tab.row.resetAutoTitle`
+- `mux0/Localization/L10n.swift` — 加常量
+- `mux0Tests/HookMessageTests.swift` — 加 sessionTitle 解码测试
+- `mux0Tests/WorkspaceStoreTests.swift`（若存在）— rename 设锁定 + reset 解锁
+- `Resources/agent-hooks/agent-hook.py` — 新增 `read_ai_title()` / `read_codex_title()`；prompt + stop emit 附 `sessionTitle`
+- `Resources/agent-hooks/opencode-plugin/mux0-status.js` — `chat.message` / `tool.execute.before` emit 附 `sessionTitle`
+- `Resources/agent-hooks/tests/test_agent_hook.py` — read_ai_title / read_codex_title 测试
+- `docs/agent-hooks.md` — 加「Session title」节
+- `CLAUDE.md` — Directory Structure 加 `TerminalSessionTitleStore.swift`；Common Tasks 加「修改 tab 自动命名行为」
+- `AGENTS.md` — Directory Structure 同步
+
+**No-op:** `project.yml` 用 `path: mux0` glob，新增 Swift 文件由 `xcodegen generate` 自动捕获，不需要改。
+
+---
+
+## Task 1: HookMessage 加 sessionTitle 字段
+
+**Files:**
+- Modify: `mux0/Models/HookMessage.swift`
+- Modify: `mux0Tests/HookMessageTests.swift`
+
+- [ ] **Step 1: 读现有 HookMessageTests，添加失败测试**
+
+打开 `mux0Tests/HookMessageTests.swift`，在文件末尾加：
+
+```swift
+func testDecodesSessionTitle() throws {
+    let json = #"""
+    {"terminalId":"\#(UUID().uuidString)","event":"running","agent":"claude","at":1.0,"sessionTitle":"Implement auto-naming"}
+    """#
+    let msg = try JSONDecoder().decode(HookMessage.self, from: Data(json.utf8))
+    XCTAssertEqual(msg.sessionTitle, "Implement auto-naming")
+}
+
+func testSessionTitleMissingIsNil() throws {
+    let json = #"""
+    {"terminalId":"\#(UUID().uuidString)","event":"running","agent":"claude","at":1.0}
+    """#
+    let msg = try JSONDecoder().decode(HookMessage.self, from: Data(json.utf8))
+    XCTAssertNil(msg.sessionTitle)
+}
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+```bash
+xcodebuild test -project mux0.xcodeproj -scheme mux0Tests -only-testing:mux0Tests/HookMessageTests/testDecodesSessionTitle 2>&1 | tail -20
+```
+
+Expected: 编译失败，"value of type 'HookMessage' has no member 'sessionTitle'"
+
+- [ ] **Step 3: 在 HookMessage 加字段**
+
+在 `mux0/Models/HookMessage.swift` 中，`resumeCommand` 字段之后插入：
+
+```swift
+    /// Optional human-readable session title — e.g. Claude's `ai-title`
+    /// transcript entry, Codex's `threads.title` SQLite column, or
+    /// OpenCode's `session.title`. Emitted alongside `running` / `stop`
+    /// events. mux0 routes it into `TerminalSessionTitleStore`; empty
+    /// strings are dropped to avoid clobbering an already-known title with
+    /// a transient "title not yet generated" state.
+    let sessionTitle: String?
+```
+
+`Decodable` 合成自动支持新字段。
+
+- [ ] **Step 4: 跑测试确认通过**
+
+```bash
+xcodebuild test -project mux0.xcodeproj -scheme mux0Tests -only-testing:mux0Tests/HookMessageTests 2>&1 | tail -10
+```
+
+Expected: `** TEST SUCCEEDED **`，新两个 case 通过，老 case 不破。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mux0/Models/HookMessage.swift mux0Tests/HookMessageTests.swift
+git commit -m "$(cat <<'EOF'
+feat(models): add sessionTitle field to HookMessage
+
+Wire-format extension that lets each agent hook attach the current
+session's human-readable title alongside running/stop events.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: TerminalSessionTitleStore（@Observable + 持久化）
+
+**Files:**
+- Create: `mux0/Models/TerminalSessionTitleStore.swift`
+- Create: `mux0Tests/TerminalSessionTitleStoreTests.swift`
+
+- [ ] **Step 1: 写失败测试**
+
+新建 `mux0Tests/TerminalSessionTitleStoreTests.swift`：
+
+```swift
+import XCTest
+@testable import mux0
+
+final class TerminalSessionTitleStoreTests: XCTestCase {
+
+    func testDefaultIsEmpty() {
+        let store = TerminalSessionTitleStore(persistenceKey: "test-\(UUID())")
+        XCTAssertNil(store.title(for: UUID()))
+    }
+
+    func testUpdateStoresValue() {
+        let store = TerminalSessionTitleStore(persistenceKey: "test-\(UUID())")
+        let id = UUID()
+        store.update(terminalId: id, title: "Hello")
+        XCTAssertEqual(store.title(for: id), "Hello")
+    }
+
+    func testUpdateEmptyStringIsIgnored() {
+        let store = TerminalSessionTitleStore(persistenceKey: "test-\(UUID())")
+        let id = UUID()
+        store.update(terminalId: id, title: "Real title")
+        store.update(terminalId: id, title: "")
+        XCTAssertEqual(store.title(for: id), "Real title")
+    }
+
+    func testUpdateWhitespaceOnlyIsIgnored() {
+        let store = TerminalSessionTitleStore(persistenceKey: "test-\(UUID())")
+        let id = UUID()
+        store.update(terminalId: id, title: "Real")
+        store.update(terminalId: id, title: "   \n")
+        XCTAssertEqual(store.title(for: id), "Real")
+    }
+
+    func testClearRemovesValue() {
+        let store = TerminalSessionTitleStore(persistenceKey: "test-\(UUID())")
+        let id = UUID()
+        store.update(terminalId: id, title: "X")
+        store.clear(terminalId: id)
+        XCTAssertNil(store.title(for: id))
+    }
+
+    func testClearMultipleRemovesAll() {
+        let store = TerminalSessionTitleStore(persistenceKey: "test-\(UUID())")
+        let a = UUID(); let b = UUID(); let c = UUID()
+        store.update(terminalId: a, title: "A")
+        store.update(terminalId: b, title: "B")
+        store.update(terminalId: c, title: "C")
+        store.clear(terminalIds: [a, c])
+        XCTAssertNil(store.title(for: a))
+        XCTAssertEqual(store.title(for: b), "B")
+        XCTAssertNil(store.title(for: c))
+    }
+
+    func testPersistenceRoundtrip() {
+        let key = "test-\(UUID())"
+        let id = UUID()
+        let store = TerminalSessionTitleStore(persistenceKey: key)
+        store.update(terminalId: id, title: "Persisted")
+        store.flushSaveForTesting()
+
+        let store2 = TerminalSessionTitleStore(persistenceKey: key)
+        XCTAssertEqual(store2.title(for: id), "Persisted")
+        UserDefaults.standard.removeObject(forKey: key)
+    }
+}
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+```bash
+xcodebuild test -project mux0.xcodeproj -scheme mux0Tests -only-testing:mux0Tests/TerminalSessionTitleStoreTests 2>&1 | tail -10
+```
+
+Expected: 编译失败，"cannot find 'TerminalSessionTitleStore' in scope"
+
+- [ ] **Step 3: 创建 store 实现**
+
+新建 `mux0/Models/TerminalSessionTitleStore.swift`：
+
+```swift
+import Foundation
+import Observation
+
+/// Per-terminal human-readable agent session title, keyed by terminal UUID.
+/// Populated by `HookDispatcher` when an agent hook emits a `sessionTitle`
+/// field; consumed by `TabItemView` via `TerminalTab.displayTitle(store:)`.
+///
+/// Persisted to UserDefaults under `mux0.sessionTitles.v1` so that on app
+/// restart each tab can keep showing its previous title until the next hook
+/// emit refreshes it. Writes are debounced (300 ms) to match `TerminalPwdStore`'s
+/// pattern — title arrival typically happens once per turn, not per keystroke,
+/// but keeping the same debouncer keeps both stores' UserDefaults patterns aligned.
+@Observable
+final class TerminalSessionTitleStore {
+    private var storage: [String: String] = [:]
+    private let persistenceKey: String
+    private var saveWorkItem: DispatchWorkItem?
+
+    init(persistenceKey: String = "mux0.sessionTitles.v1") {
+        self.persistenceKey = persistenceKey
+        load()
+    }
+
+    func title(for terminalId: UUID) -> String? {
+        storage[terminalId.uuidString]
+    }
+
+    /// Write `title` for `terminalId`. Empty or whitespace-only inputs are
+    /// dropped — agents emit empty strings before the LLM-generated title is
+    /// materialized, and we don't want a transient empty state to wipe out
+    /// the previously known title.
+    func update(terminalId: UUID, title: String) {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        guard storage[terminalId.uuidString] != trimmed else { return }
+        storage[terminalId.uuidString] = trimmed
+        scheduleSave()
+    }
+
+    func clear(terminalId: UUID) {
+        guard storage.removeValue(forKey: terminalId.uuidString) != nil else { return }
+        scheduleSave()
+    }
+
+    func clear(terminalIds: [UUID]) {
+        var changed = false
+        for id in terminalIds {
+            if storage.removeValue(forKey: id.uuidString) != nil { changed = true }
+        }
+        if changed { scheduleSave() }
+    }
+
+    // MARK: - Persistence
+
+    #if DEBUG
+    func flushSaveForTesting() {
+        saveWorkItem?.cancel()
+        saveWorkItem = nil
+        save()
+    }
+    #endif
+
+    private func scheduleSave() {
+        saveWorkItem?.cancel()
+        let item = DispatchWorkItem { [weak self] in self?.save() }
+        saveWorkItem = item
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: item)
+    }
+
+    private func save() {
+        guard let data = try? JSONEncoder().encode(storage) else { return }
+        UserDefaults.standard.set(data, forKey: persistenceKey)
+    }
+
+    private func load() {
+        guard let data = UserDefaults.standard.data(forKey: persistenceKey),
+              let decoded = try? JSONDecoder().decode([String: String].self, from: data)
+        else { return }
+        storage = decoded
+    }
+}
+```
+
+- [ ] **Step 4: 重生成 Xcode 工程 + 跑测试**
+
+```bash
+xcodegen generate && xcodebuild test -project mux0.xcodeproj -scheme mux0Tests -only-testing:mux0Tests/TerminalSessionTitleStoreTests 2>&1 | tail -10
+```
+
+Expected: 所有 7 个 case 通过。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mux0/Models/TerminalSessionTitleStore.swift mux0Tests/TerminalSessionTitleStoreTests.swift
+git commit -m "$(cat <<'EOF'
+feat(models): add TerminalSessionTitleStore for per-terminal session titles
+
+@Observable store keyed by terminal UUID with UserDefaults persistence,
+mirroring TerminalPwdStore's shape. Empty/whitespace updates are dropped so
+agent hooks can emit unconditionally without clobbering known titles.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: TerminalTab 加 userRenamed + displayTitle helper
+
+**Files:**
+- Modify: `mux0/Models/Workspace.swift`
+- Create: `mux0Tests/TerminalTabDisplayTitleTests.swift`
+
+- [ ] **Step 1: 写失败测试**
+
+新建 `mux0Tests/TerminalTabDisplayTitleTests.swift`：
+
+```swift
+import XCTest
+@testable import mux0
+
+final class TerminalTabDisplayTitleTests: XCTestCase {
+
+    private func makeStore() -> TerminalSessionTitleStore {
+        TerminalSessionTitleStore(persistenceKey: "test-\(UUID())")
+    }
+
+    func testFallsBackToTabTitleWhenStoreEmpty() {
+        let termId = UUID()
+        var tab = TerminalTab(title: "Terminal 1", terminalId: termId)
+        tab.focusedTerminalId = termId
+        let store = makeStore()
+        XCTAssertEqual(tab.displayTitle(sessionTitleStore: store), "Terminal 1")
+    }
+
+    func testUsesStoreTitleForFocusedTerminal() {
+        let termId = UUID()
+        var tab = TerminalTab(title: "claude", terminalId: termId)
+        tab.focusedTerminalId = termId
+        let store = makeStore()
+        store.update(terminalId: termId, title: "Implement feature X")
+        XCTAssertEqual(tab.displayTitle(sessionTitleStore: store), "Implement feature X")
+    }
+
+    func testUserRenamedOverridesStore() {
+        let termId = UUID()
+        var tab = TerminalTab(title: "My Tab", terminalId: termId)
+        tab.focusedTerminalId = termId
+        tab.userRenamed = true
+        let store = makeStore()
+        store.update(terminalId: termId, title: "Should not show")
+        XCTAssertEqual(tab.displayTitle(sessionTitleStore: store), "My Tab")
+    }
+
+    func testTracksFocusedTerminalAcrossPanes() {
+        // Two-pane tab: focus the second; only second's title should be used.
+        let leftId = UUID()
+        let rightId = UUID()
+        var tab = TerminalTab(title: "split tab", terminalId: leftId)
+        tab.layout = .split(UUID(), .vertical, 0.5,
+                            .terminal(leftId), .terminal(rightId))
+        tab.focusedTerminalId = rightId
+        let store = makeStore()
+        store.update(terminalId: leftId, title: "Left pane session")
+        store.update(terminalId: rightId, title: "Right pane session")
+        XCTAssertEqual(tab.displayTitle(sessionTitleStore: store), "Right pane session")
+    }
+
+    func testCodableDefaultsUserRenamedToFalse() throws {
+        // Legacy tab data without `userRenamed` key must decode with default false.
+        let json = #"""
+        {"id":"\#(UUID().uuidString)","title":"old","layout":{"type":"terminal","terminalId":"\#(UUID().uuidString)"},"focusedTerminalId":"\#(UUID().uuidString)"}
+        """#
+        let tab = try JSONDecoder().decode(TerminalTab.self, from: Data(json.utf8))
+        XCTAssertFalse(tab.userRenamed)
+    }
+
+    func testCodableRoundtripPreservesUserRenamed() throws {
+        let termId = UUID()
+        var tab = TerminalTab(title: "X", terminalId: termId)
+        tab.userRenamed = true
+        let data = try JSONEncoder().encode(tab)
+        let decoded = try JSONDecoder().decode(TerminalTab.self, from: data)
+        XCTAssertTrue(decoded.userRenamed)
+    }
+}
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+```bash
+xcodebuild test -project mux0.xcodeproj -scheme mux0Tests -only-testing:mux0Tests/TerminalTabDisplayTitleTests 2>&1 | tail -10
+```
+
+Expected: 编译失败，提示 `userRenamed` / `displayTitle` 未定义。
+
+- [ ] **Step 3: 修改 TerminalTab**
+
+打开 `mux0/Models/Workspace.swift`，替换 `TerminalTab` 整个 struct 为：
+
+```swift
+struct TerminalTab: Codable, Identifiable, Equatable {
+    let id: UUID
+    var title: String
+    var layout: SplitNode
+    var focusedTerminalId: UUID
+    /// Quick Action binding for this tab. nil = ordinary terminal tab.
+    /// Non-nil values match either a `BuiltinQuickAction.id` (e.g.
+    /// `"gitui"`, `"claude"`) or a custom action's UUID. When the tab's
+    /// first terminal opens, `TabContentView.resolvedStartupCommand` resolves
+    /// this id via `QuickActionsStore.command(for:)` and injects the result
+    /// as the surface's initial_input.
+    var quickActionId: String? = nil
+    /// True once the user has manually renamed this tab (inline rename UI).
+    /// When true, `displayTitle` returns `title` unconditionally — auto
+    /// session titles from `TerminalSessionTitleStore` are ignored. Reset
+    /// via `WorkspaceStore.resetTabToAutoTitle` (right-click → "Reset to
+    /// auto title"). Defaults to false; old persisted data without this
+    /// field decodes as false (legacy tabs re-enter auto mode).
+    var userRenamed: Bool = false
+
+    init(id: UUID = UUID(), title: String, terminalId: UUID = UUID(),
+         quickActionId: String? = nil, userRenamed: Bool = false) {
+        self.id = id
+        self.title = title
+        self.layout = .terminal(terminalId)
+        self.focusedTerminalId = terminalId
+        self.quickActionId = quickActionId
+        self.userRenamed = userRenamed
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, title, layout, focusedTerminalId, quickActionId, userRenamed
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try c.decode(UUID.self, forKey: .id)
+        self.title = try c.decode(String.self, forKey: .title)
+        self.layout = try c.decode(SplitNode.self, forKey: .layout)
+        self.focusedTerminalId = try c.decode(UUID.self, forKey: .focusedTerminalId)
+        self.quickActionId = try c.decodeIfPresent(String.self, forKey: .quickActionId)
+        self.userRenamed = try c.decodeIfPresent(Bool.self, forKey: .userRenamed) ?? false
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(id, forKey: .id)
+        try c.encode(title, forKey: .title)
+        try c.encode(layout, forKey: .layout)
+        try c.encode(focusedTerminalId, forKey: .focusedTerminalId)
+        try c.encodeIfPresent(quickActionId, forKey: .quickActionId)
+        try c.encode(userRenamed, forKey: .userRenamed)
+    }
+
+    /// Resolve the title shown in the tab bar. Priority:
+    /// 1. User manually renamed → `title` (hard lock, ignores store)
+    /// 2. `sessionTitleStore[focusedTerminalId]` is non-nil → that
+    /// 3. Fallback → `title` (creation-time default like "Terminal 1" /
+    ///    quick action displayName)
+    ///
+    /// Tracks the focused pane, so split tabs switch label as the user
+    /// moves focus between panes. Shell pane (no agent session) falls
+    /// through to step 3 rather than retaining the previous agent pane's title.
+    func displayTitle(sessionTitleStore: TerminalSessionTitleStore) -> String {
+        if userRenamed { return title }
+        if let auto = sessionTitleStore.title(for: focusedTerminalId), !auto.isEmpty {
+            return auto
+        }
+        return title
+    }
+}
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+```bash
+xcodebuild test -project mux0.xcodeproj -scheme mux0Tests -only-testing:mux0Tests/TerminalTabDisplayTitleTests 2>&1 | tail -10
+```
+
+Expected: 全部 6 case 通过。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mux0/Models/Workspace.swift mux0Tests/TerminalTabDisplayTitleTests.swift
+git commit -m "$(cat <<'EOF'
+feat(models): add userRenamed lock + displayTitle helper to TerminalTab
+
+userRenamed=true permanently locks the tab to its user-given title;
+displayTitle falls back through store→tab.title so unlock + agent-driven
+auto-naming work uniformly. Codable migration: legacy tabs decode with
+userRenamed=false.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: HookDispatcher 路由 sessionTitle
+
+**Files:**
+- Modify: `mux0/Models/HookDispatcher.swift`
+- Create: `mux0Tests/HookDispatcherSessionTitleTests.swift`
+
+- [ ] **Step 1: 写失败测试**
+
+新建 `mux0Tests/HookDispatcherSessionTitleTests.swift`（沿用 `HookDispatcherTests` 的 JSON-roundtrip 构造 + tmp file SettingsConfigStore 模式）：
+
+```swift
+import XCTest
+@testable import mux0
+
+final class HookDispatcherSessionTitleTests: XCTestCase {
+
+    private var tmpConfigPath: String!
+    private var settings: SettingsConfigStore!
+    private var statusStore: TerminalStatusStore!
+    private var titleStore: TerminalSessionTitleStore!
+    private let tid = UUID()
+
+    override func setUpWithError() throws {
+        tmpConfigPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mux0-dispatch-\(UUID().uuidString).conf").path
+        settings = SettingsConfigStore(filePath: tmpConfigPath)
+        statusStore = TerminalStatusStore()
+        titleStore = TerminalSessionTitleStore(persistenceKey: "test-\(UUID())")
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(atPath: tmpConfigPath)
+    }
+
+    private func makeMsg(sessionTitle: String?) -> HookMessage {
+        var fields = #"{"terminalId":"\#(tid.uuidString)","event":"running","agent":"claude","at":1.0"#
+        if let t = sessionTitle {
+            // JSON-escape minimally — tests use plain ASCII titles.
+            fields += #","sessionTitle":"\#(t)""#
+        }
+        fields += "}"
+        return try! JSONDecoder().decode(HookMessage.self, from: Data(fields.utf8))
+    }
+
+    func testRoutesSessionTitleWhenAgentEnabled() {
+        settings.set(HookMessage.Agent.claude.settingsKey, "true")
+        settings.save()
+        HookDispatcher.dispatch(makeMsg(sessionTitle: "Doing the thing"),
+                                settings: settings, store: statusStore,
+                                sessionTitleStore: titleStore)
+        XCTAssertEqual(titleStore.title(for: tid), "Doing the thing")
+    }
+
+    func testRoutesSessionTitleEvenWhenStatusAgentDisabled() {
+        // Title is independent of the per-agent "status notifications" toggle —
+        // tab naming is unconditional once the field arrives.
+        // (No settings.set — agent NOT enabled.)
+        HookDispatcher.dispatch(makeMsg(sessionTitle: "Still applies"),
+                                settings: settings, store: statusStore,
+                                sessionTitleStore: titleStore)
+        XCTAssertEqual(titleStore.title(for: tid), "Still applies")
+    }
+
+    func testSkipsWhenSessionTitleNil() {
+        settings.set(HookMessage.Agent.claude.settingsKey, "true")
+        settings.save()
+        titleStore.update(terminalId: tid, title: "Previous")
+        HookDispatcher.dispatch(makeMsg(sessionTitle: nil),
+                                settings: settings, store: statusStore,
+                                sessionTitleStore: titleStore)
+        XCTAssertEqual(titleStore.title(for: tid), "Previous",
+                       "nil sessionTitle should not clobber existing value")
+    }
+}
+```
+
+> Note: 使用 JSON-roundtrip 构造 `HookMessage` 与现有 `HookDispatcherTests.makeMsg(...)` 模式一致 —— 不依赖 synthesized memberwise init（安全），也保证 Decodable 字段路径被实际测试到。
+
+- [ ] **Step 2: 跑测试确认失败**
+
+```bash
+xcodebuild test -project mux0.xcodeproj -scheme mux0Tests -only-testing:mux0Tests/HookDispatcherSessionTitleTests 2>&1 | tail -15
+```
+
+Expected: 编译失败，"missing argument 'sessionTitleStore' in call" 或 "extra argument 'sessionTitleStore' in call"
+
+- [ ] **Step 3: 修改 HookDispatcher**
+
+打开 `mux0/Models/HookDispatcher.swift`，把 `dispatch` 签名改为：
+
+```swift
+    static func dispatch(_ msg: HookMessage,
+                         settings: SettingsConfigStore,
+                         store: TerminalStatusStore,
+                         workspaceStore: WorkspaceStore? = nil,
+                         sessionTitleStore: TerminalSessionTitleStore? = nil) {
+        // Session title is independent of status / resume gating — once any
+        // agent hook emits it, the tab name follows. Title-only tabs (user
+        // disabled notifications but still wants auto-naming) are a real use
+        // case; we don't second-guess.
+        if let title = msg.sessionTitle, let titleStore = sessionTitleStore {
+            titleStore.update(terminalId: msg.terminalId, title: title)
+        }
+
+        // (Existing resumeCommand block — keep unchanged)
+        if let cmd = msg.resumeCommand, let ws = workspaceStore,
+           settings.get(msg.agent.resumeSettingsKey) == "true" {
+            ws.recordResumeCommand(terminalId: msg.terminalId, command: cmd)
+        }
+        guard settings.get(msg.agent.settingsKey) == "true" else { return }
+        // ... rest unchanged
+```
+
+确保参数顺序与现有调用方兼容（`workspaceStore` 之后加可选 `sessionTitleStore`，调用方按需透传）。
+
+- [ ] **Step 4: 跑测试确认通过**
+
+```bash
+xcodebuild test -project mux0.xcodeproj -scheme mux0Tests -only-testing:mux0Tests/HookDispatcherSessionTitleTests 2>&1 | tail -10
+```
+
+Expected: 3 case 全过。同时确认旧的 `HookDispatcherTests` 仍通过：
+
+```bash
+xcodebuild test -project mux0.xcodeproj -scheme mux0Tests -only-testing:mux0Tests/HookDispatcherTests 2>&1 | tail -10
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mux0/Models/HookDispatcher.swift mux0Tests/HookDispatcherSessionTitleTests.swift
+git commit -m "$(cat <<'EOF'
+feat(models): route HookMessage.sessionTitle into TerminalSessionTitleStore
+
+New optional `sessionTitleStore` arg on dispatch — gated independently
+from the per-agent status toggle so title-only mode works.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: WorkspaceStore — rename 设锁定 + reset 解锁 + 清理 store
+
+**Files:**
+- Modify: `mux0/Models/WorkspaceStore.swift`
+- Modify or Create: `mux0Tests/WorkspaceStoreTests.swift`
+
+- [ ] **Step 1: 写失败测试**
+
+如果 `mux0Tests/WorkspaceStoreTests.swift` 不存在则创建；否则在末尾追加。完整文件内容（如新建）：
+
+```swift
+import XCTest
+@testable import mux0
+
+final class WorkspaceStoreRenameLockTests: XCTestCase {
+
+    private func makeStore() -> WorkspaceStore {
+        WorkspaceStore(persistenceKey: "test-\(UUID())")
+    }
+
+    func testRenameTabSetsUserRenamedTrue() {
+        let ws = makeStore()
+        let wsId = ws.workspaces[0].id
+        let (tabId, _) = ws.addTab(to: wsId)!
+        ws.renameTab(id: tabId, in: wsId, to: "My Custom Name")
+        let tab = ws.workspaces[0].tabs.first { $0.id == tabId }!
+        XCTAssertEqual(tab.title, "My Custom Name")
+        XCTAssertTrue(tab.userRenamed)
+    }
+
+    func testResetTabToAutoTitleClearsLock() {
+        let ws = makeStore()
+        let wsId = ws.workspaces[0].id
+        let (tabId, _) = ws.addTab(to: wsId)!
+        ws.renameTab(id: tabId, in: wsId, to: "Locked")
+        ws.resetTabToAutoTitle(tabId: tabId, in: wsId)
+        let tab = ws.workspaces[0].tabs.first { $0.id == tabId }!
+        XCTAssertFalse(tab.userRenamed)
+        // title field unchanged — fallback path will continue to show it
+        // until next hook emit overrides via the store.
+        XCTAssertEqual(tab.title, "Locked")
+    }
+
+    func testCloseTerminalClearsSessionTitleStore() {
+        let ws = makeStore()
+        let titleStore = TerminalSessionTitleStore(persistenceKey: "test-\(UUID())")
+        ws.sessionTitleStore = titleStore
+        let wsId = ws.workspaces[0].id
+        let (tabId, termId) = ws.addTab(to: wsId)!
+        // Split so close doesn't auto-remove the tab.
+        let newTermId = ws.splitTerminal(id: termId, in: wsId, tabId: tabId,
+                                         direction: .vertical)!
+        titleStore.update(terminalId: termId, title: "Left")
+        titleStore.update(terminalId: newTermId, title: "Right")
+        ws.closeTerminal(id: termId, in: wsId, tabId: tabId)
+        XCTAssertNil(titleStore.title(for: termId))
+        XCTAssertEqual(titleStore.title(for: newTermId), "Right")
+    }
+
+    func testRemoveTabClearsAllItsTerminalsInStore() {
+        let ws = makeStore()
+        let titleStore = TerminalSessionTitleStore(persistenceKey: "test-\(UUID())")
+        ws.sessionTitleStore = titleStore
+        let wsId = ws.workspaces[0].id
+        let (tabId, termId) = ws.addTab(to: wsId)!
+        let split2 = ws.splitTerminal(id: termId, in: wsId, tabId: tabId,
+                                       direction: .horizontal)!
+        titleStore.update(terminalId: termId, title: "A")
+        titleStore.update(terminalId: split2, title: "B")
+        ws.removeTab(id: tabId, from: wsId)
+        XCTAssertNil(titleStore.title(for: termId))
+        XCTAssertNil(titleStore.title(for: split2))
+    }
+}
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+```bash
+xcodebuild test -project mux0.xcodeproj -scheme mux0Tests -only-testing:mux0Tests/WorkspaceStoreRenameLockTests 2>&1 | tail -15
+```
+
+Expected: 编译失败，"value of type 'WorkspaceStore' has no member 'resetTabToAutoTitle'" 等。
+
+- [ ] **Step 3: 修改 WorkspaceStore**
+
+打开 `mux0/Models/WorkspaceStore.swift`：
+
+**(a)** 在 class 顶部字段加：
+
+```swift
+    /// Optional weak link to the session title store so close/remove paths
+    /// can purge stale terminalId → title mappings. Wired by `ContentView`
+    /// at app startup. Optional + weak-style (held strong here, but set
+    /// post-init) so unit tests can construct a store without the title
+    /// store; production injection is guaranteed.
+    weak var sessionTitleStore: TerminalSessionTitleStore?
+```
+
+> Reason for `weak`: matches the live-injection pattern used by `pwdStoreRef` in `TabContentView`; lets tests omit the store without ARC retain cycles. The `TerminalSessionTitleStore` is owned by `ContentView` for the app's lifetime, so `weak` is safe.
+
+**(b)** 修改 `renameTab` —— 在 title 赋值后加 `userRenamed = true`：
+
+```swift
+    func renameTab(id: UUID, in workspaceId: UUID, to newTitle: String) {
+        let trimmed = newTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              let wsIdx = wsIndex(workspaceId),
+              let tIdx = tabIndex(id, in: wsIdx) else { return }
+        // Always set userRenamed=true (even if title unchanged) — the user
+        // explicitly hit enter on the rename UI, signaling intent to lock.
+        var changed = false
+        if workspaces[wsIdx].tabs[tIdx].title != trimmed {
+            workspaces[wsIdx].tabs[tIdx].title = trimmed
+            changed = true
+        }
+        if !workspaces[wsIdx].tabs[tIdx].userRenamed {
+            workspaces[wsIdx].tabs[tIdx].userRenamed = true
+            changed = true
+        }
+        if changed { save() }
+    }
+```
+
+**(c)** 加 `resetTabToAutoTitle`（紧挨 `renameTab` 后面）：
+
+```swift
+    /// Clear the manual-rename lock on a tab. After this, the tab falls
+    /// back to the auto title chain (`TerminalSessionTitleStore[focused]`
+    /// → tab.title). `title` itself is left as-is; next agent hook emit
+    /// will overwrite the displayed value via the store.
+    func resetTabToAutoTitle(tabId: UUID, in workspaceId: UUID) {
+        guard let wsIdx = wsIndex(workspaceId),
+              let tIdx = tabIndex(tabId, in: wsIdx),
+              workspaces[wsIdx].tabs[tIdx].userRenamed else { return }
+        workspaces[wsIdx].tabs[tIdx].userRenamed = false
+        save()
+    }
+```
+
+**(d)** `closeTerminal` 末尾在 `save()` 之前调 `sessionTitleStore?.clear(terminalId:)`：
+
+```swift
+    func closeTerminal(id terminalId: UUID, in workspaceId: UUID, tabId: UUID) {
+        guard let wsIdx = wsIndex(workspaceId),
+              let tIdx = tabIndex(tabId, in: wsIdx) else { return }
+        let tab = workspaces[wsIdx].tabs[tIdx]
+        if let newLayout = tab.layout.removing(terminalId: terminalId) {
+            workspaces[wsIdx].tabs[tIdx].layout = newLayout
+            workspaces[wsIdx].pendingPrefills.removeValue(forKey: terminalId.uuidString)
+            sessionTitleStore?.clear(terminalId: terminalId)
+            if tab.focusedTerminalId == terminalId {
+                workspaces[wsIdx].tabs[tIdx].focusedTerminalId =
+                    newLayout.allTerminalIds()[0]
+            }
+            save()
+        } else {
+            removeTab(id: tabId, from: workspaceId)
+        }
+    }
+```
+
+**(e)** `removeTab` 在 pendingPrefills 清理后加 sessionTitleStore 清理：
+
+```swift
+    func removeTab(id: UUID, from workspaceId: UUID) {
+        guard let wsIdx = wsIndex(workspaceId) else { return }
+        let closedIdx = workspaces[wsIdx].tabs.firstIndex(where: { $0.id == id })
+        if let tIdx = closedIdx {
+            let leafIds = workspaces[wsIdx].tabs[tIdx].layout.allTerminalIds()
+            for tid in leafIds {
+                workspaces[wsIdx].pendingPrefills.removeValue(forKey: tid.uuidString)
+            }
+            sessionTitleStore?.clear(terminalIds: leafIds)
+        }
+        // ... rest unchanged
+```
+
+**(f)** `deleteWorkspace` 顶部加：
+
+```swift
+    func deleteWorkspace(id: UUID) {
+        if let wsIdx = wsIndex(id) {
+            let allLeaves = workspaces[wsIdx].tabs.flatMap { $0.layout.allTerminalIds() }
+            sessionTitleStore?.clear(terminalIds: allLeaves)
+        }
+        workspaces.removeAll { $0.id == id }
+        if selectedId == id { selectedId = workspaces.first?.id }
+        save()
+    }
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+```bash
+xcodebuild test -project mux0.xcodeproj -scheme mux0Tests -only-testing:mux0Tests/WorkspaceStoreRenameLockTests 2>&1 | tail -15
+```
+
+Expected: 4 case 全过。再跑全套 `mux0Tests` 确认没有回归：
+
+```bash
+xcodebuild test -project mux0.xcodeproj -scheme mux0Tests 2>&1 | tail -20
+```
+
+Expected: `** TEST SUCCEEDED **`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mux0/Models/WorkspaceStore.swift mux0Tests/WorkspaceStoreTests.swift
+git commit -m "$(cat <<'EOF'
+feat(models): wire WorkspaceStore to TerminalSessionTitleStore lifecycle
+
+renameTab now flips userRenamed=true; resetTabToAutoTitle clears it.
+closeTerminal/removeTab/deleteWorkspace purge stale terminalId entries
+from the session title store, mirroring pendingPrefills cleanup.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: agent-hook.py — Claude ai-title + Codex SQLite
+
+**Files:**
+- Modify: `Resources/agent-hooks/agent-hook.py`
+- Modify: `Resources/agent-hooks/tests/test_agent_hook.py`
+
+- [ ] **Step 1: 写失败测试**
+
+在 `Resources/agent-hooks/tests/test_agent_hook.py` 末尾追加：
+
+```python
+# ---------- read_ai_title ----------
+
+def test_read_ai_title_picks_last(tmp_path):
+    p = tmp_path / "t.jsonl"
+    p.write_text(
+        json.dumps({"type": "ai-title", "aiTitle": "Old title"}) + "\n" +
+        json.dumps({"type": "user", "content": "noise"}) + "\n" +
+        json.dumps({"type": "ai-title", "aiTitle": "Latest title"}) + "\n"
+    )
+    assert agent_hook.read_ai_title(str(p)) == "Latest title"
+
+
+def test_read_ai_title_truncates_to_200(tmp_path):
+    p = tmp_path / "t.jsonl"
+    long = "x" * 500
+    p.write_text(json.dumps({"type": "ai-title", "aiTitle": long}) + "\n")
+    assert len(agent_hook.read_ai_title(str(p))) == 200
+
+
+def test_read_ai_title_missing_file():
+    assert agent_hook.read_ai_title("/nonexistent/path.jsonl") == ""
+
+
+def test_read_ai_title_no_match(tmp_path):
+    p = tmp_path / "t.jsonl"
+    p.write_text(json.dumps({"type": "user", "content": "x"}) + "\n")
+    assert agent_hook.read_ai_title(str(p)) == ""
+
+
+def test_read_ai_title_skips_malformed_lines(tmp_path):
+    p = tmp_path / "t.jsonl"
+    p.write_text(
+        "not json\n" +
+        json.dumps({"type": "ai-title", "aiTitle": "Good"}) + "\n"
+    )
+    assert agent_hook.read_ai_title(str(p)) == "Good"
+
+
+# ---------- read_codex_title ----------
+
+def test_read_codex_title_reads_from_db(tmp_path, monkeypatch):
+    import sqlite3
+    db = tmp_path / "state_5.sqlite"
+    con = sqlite3.connect(db)
+    con.execute("CREATE TABLE threads (id TEXT PRIMARY KEY, title TEXT)")
+    con.execute("INSERT INTO threads VALUES (?, ?)",
+                ("abc-123", "Codex session name"))
+    con.commit()
+    con.close()
+    monkeypatch.setattr(agent_hook, "CODEX_HOME", tmp_path)
+    assert agent_hook.read_codex_title("abc-123") == "Codex session name"
+
+
+def test_read_codex_title_picks_newest_schema(tmp_path, monkeypatch):
+    import sqlite3
+    # Two DB schema versions; we should query state_99 (newest).
+    for ver, title in [(3, "Old"), (99, "New")]:
+        db = tmp_path / f"state_{ver}.sqlite"
+        con = sqlite3.connect(db)
+        con.execute("CREATE TABLE threads (id TEXT PRIMARY KEY, title TEXT)")
+        con.execute("INSERT INTO threads VALUES (?, ?)", ("sid", title))
+        con.commit()
+        con.close()
+    monkeypatch.setattr(agent_hook, "CODEX_HOME", tmp_path)
+    assert agent_hook.read_codex_title("sid") == "New"
+
+
+def test_read_codex_title_no_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(agent_hook, "CODEX_HOME", tmp_path)
+    assert agent_hook.read_codex_title("sid") == ""
+
+
+def test_read_codex_title_rejects_invalid_session_id(tmp_path, monkeypatch):
+    monkeypatch.setattr(agent_hook, "CODEX_HOME", tmp_path)
+    assert agent_hook.read_codex_title("bad; DROP TABLE") == ""
+
+
+def test_read_codex_title_truncates_to_200(tmp_path, monkeypatch):
+    import sqlite3
+    db = tmp_path / "state_5.sqlite"
+    con = sqlite3.connect(db)
+    con.execute("CREATE TABLE threads (id TEXT PRIMARY KEY, title TEXT)")
+    con.execute("INSERT INTO threads VALUES (?, ?)", ("sid", "x" * 500))
+    con.commit()
+    con.close()
+    monkeypatch.setattr(agent_hook, "CODEX_HOME", tmp_path)
+    assert len(agent_hook.read_codex_title("sid")) == 200
+
+
+# ---------- dispatch sessionTitle attachment ----------
+
+def test_dispatch_claude_prompt_attaches_session_title(tmp_path):
+    sf = tmp_path / "sessions.json"
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text(
+        json.dumps({"type": "ai-title", "aiTitle": "My session"}) + "\n"
+    )
+    emit = agent_hook.dispatch("prompt", "claude",
+                                {"session_id": "s1",
+                                 "transcript_path": str(transcript)},
+                                "term1", sf, 1.0)
+    assert emit.get("sessionTitle") == "My session"
+
+
+def test_dispatch_codex_prompt_attaches_session_title(tmp_path, monkeypatch):
+    import sqlite3
+    db = tmp_path / "state_5.sqlite"
+    con = sqlite3.connect(db)
+    con.execute("CREATE TABLE threads (id TEXT PRIMARY KEY, title TEXT)")
+    con.execute("INSERT INTO threads VALUES (?, ?)", ("cdx-1", "Codex name"))
+    con.commit()
+    con.close()
+    monkeypatch.setattr(agent_hook, "CODEX_HOME", tmp_path)
+    sf = tmp_path / "sessions.json"
+    emit = agent_hook.dispatch("prompt", "codex",
+                                {"session_id": "cdx-1"},
+                                "term-c", sf, 1.0)
+    assert emit.get("sessionTitle") == "Codex name"
+
+
+def test_dispatch_no_session_title_when_empty(tmp_path):
+    sf = tmp_path / "sessions.json"
+    # No transcript_path → read_ai_title returns ""
+    emit = agent_hook.dispatch("prompt", "claude",
+                                {"session_id": "s1"},
+                                "term1", sf, 1.0)
+    assert "sessionTitle" not in emit
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+```bash
+python3 -m pytest Resources/agent-hooks/tests/test_agent_hook.py -v 2>&1 | tail -30
+```
+
+Expected: 多个 `AttributeError: module 'agent_hook' has no attribute 'read_ai_title'` 等。
+
+- [ ] **Step 3: 修改 agent-hook.py**
+
+在 `Resources/agent-hooks/agent-hook.py` 顶部 imports 之后加：
+
+```python
+CODEX_HOME = pathlib.Path("~/.codex").expanduser()
+```
+
+在 `read_transcript_summary` 之后插入：
+
+```python
+def read_ai_title(path: str) -> str:
+    """Read Claude transcript JSONL, return last `{"type":"ai-title","aiTitle":"..."}`
+    entry's title, truncated to SUMMARY_MAXLEN. Empty string on any error.
+
+    Claude Code persists an LLM-generated session title as repeated `ai-title`
+    rows throughout the transcript (typically same value each time once
+    generated). We reverse-scan and return the most recent one to pick up
+    title rewrites if any.
+    """
+    if not path:
+        return ""
+    try:
+        with open(path) as f:
+            lines = f.readlines()
+    except (FileNotFoundError, IsADirectoryError, PermissionError, OSError):
+        return ""
+    for line in reversed(lines):
+        try:
+            d = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(d, dict) and d.get("type") == "ai-title":
+            title = d.get("aiTitle") or ""
+            if isinstance(title, str) and title:
+                return title[:SUMMARY_MAXLEN]
+    return ""
+
+
+def read_codex_title(session_id: str) -> str:
+    """Read Codex thread title from `~/.codex/state_*.sqlite` (newest schema
+    version), querying `threads.title WHERE id = ?`. Empty on any failure.
+
+    The `state_N.sqlite` filename embeds Codex's schema version (currently 5);
+    we glob and take the highest N so this survives future migrations without
+    a code change.
+    """
+    if not session_id or not SESSION_ID_RE.match(session_id):
+        return ""
+    candidates = sorted(CODEX_HOME.glob("state_*.sqlite"))
+    if not candidates:
+        return ""
+    db = candidates[-1]
+    try:
+        import sqlite3
+        # mode=ro + small timeout so we never block on Codex's write lock.
+        con = sqlite3.connect(f"file:{db}?mode=ro", uri=True, timeout=0.5)
+        try:
+            row = con.execute(
+                "SELECT title FROM threads WHERE id = ?", (session_id,)
+            ).fetchone()
+        finally:
+            con.close()
+    except sqlite3.Error:
+        return ""
+    if not row or not row[0]:
+        return ""
+    return str(row[0])[:SUMMARY_MAXLEN]
+```
+
+在 `dispatch` 的 `prompt` 分支末尾（`resume = ...` 之前或之后均可），attach sessionTitle：
+
+```python
+    if subcmd == "prompt":
+        entry["turnStartedAt"] = now
+        entry["turnHadError"] = False
+        entry["currentToolName"] = None
+        entry["currentToolDetail"] = None
+        tp = payload.get("transcript_path")
+        if tp:
+            entry["transcriptPath"] = tp
+        emit = {"event": "running", "at": now}
+        resume = resume_command_for(agent, str(session_id))
+        if resume:
+            emit["resumeCommand"] = resume
+        title = _session_title_for(agent, entry.get("transcriptPath"), str(session_id))
+        if title:
+            emit["sessionTitle"] = title
+```
+
+在 `dispatch` 的 `stop` 分支同样附加：
+
+```python
+    elif subcmd == "stop":
+        exit_code = 1 if entry.get("turnHadError") else 0
+        summary = read_transcript_summary(entry.get("transcriptPath") or "")
+        emit = {"event": "finished", "at": now, "exitCode": exit_code}
+        if summary:
+            emit["summary"] = summary
+        title = _session_title_for(agent, entry.get("transcriptPath"), str(session_id))
+        if title:
+            emit["sessionTitle"] = title
+        entries.pop(session_id, None)
+```
+
+在文件靠近 `dispatch` 上方加：
+
+```python
+def _session_title_for(agent: str, transcript_path: str, session_id: str) -> str:
+    """Read the human-readable session title for `agent`. Returns "" if not
+    available (LLM hasn't generated it yet, file missing, etc.)."""
+    if agent == "claude":
+        return read_ai_title(transcript_path or "")
+    if agent == "codex":
+        return read_codex_title(session_id)
+    return ""   # opencode flows through its own JS plugin; never reaches here
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+```bash
+python3 -m pytest Resources/agent-hooks/tests/test_agent_hook.py -v 2>&1 | tail -30
+```
+
+Expected: 全部新增 case + 原有 case 全过。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Resources/agent-hooks/agent-hook.py Resources/agent-hooks/tests/test_agent_hook.py
+git commit -m "$(cat <<'EOF'
+feat(agent-hooks): emit sessionTitle from Claude transcript + Codex DB
+
+Claude: scan transcript JSONL backwards for last {"type":"ai-title"}.
+Codex: query ~/.codex/state_*.sqlite (newest schema) threads.title.
+Attached to prompt/stop emits; empty values are dropped.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: opencode plugin — attach sessionTitle
+
+**Files:**
+- Modify: `Resources/agent-hooks/opencode-plugin/mux0-status.js`
+
+> No JS unit tests in repo for this plugin — we rely on smoke testing in Task 12. Keep the change small.
+
+- [ ] **Step 1: 改 chat.message + tool.execute.before**
+
+在 `Resources/agent-hooks/opencode-plugin/mux0-status.js`，先看 chat.message 的 input shape。opencode plugin 调用方传 `input` 含 `sessionID` 与（可能的）`session` 对象。修改两处 emit：
+
+`chat.message` block 改为：
+
+```javascript
+    "chat.message": async (input, _output) => {
+        if (!turn.startedAt) turn.startedAt = Date.now() / 1000;
+        const resumeCommand = resumeCommandFor(input?.sessionID);
+        const sessionTitle = input?.session?.title || "";
+        const payload = { event: "running" };
+        if (resumeCommand) payload.resumeCommand = resumeCommand;
+        if (sessionTitle) payload.sessionTitle = sessionTitle;
+        emit(payload);
+    },
+```
+
+`tool.execute.before` block 改为：
+
+```javascript
+    "tool.execute.before": async (input, output) => {
+        turn.tool = input?.tool;
+        if (!turn.startedAt) turn.startedAt = Date.now() / 1000;
+        const detail = describeOpencodeTool(input?.tool, output?.args);
+        const resumeCommand = resumeCommandFor(input?.sessionID);
+        const sessionTitle = input?.session?.title || "";
+        const payload = { event: "running" };
+        if (detail) payload.toolDetail = detail;
+        if (resumeCommand) payload.resumeCommand = resumeCommand;
+        if (sessionTitle) payload.sessionTitle = sessionTitle;
+        emit(payload);
+    },
+```
+
+> **Fallback if `input.session` is not exposed by the plugin runtime:** read from `~/.local/share/opencode/storage/session/<projectHash>/<sessionId>.json`. To find the projectHash without globbing, walk up from `cwd` to discover the opencode project root, or just glob — performance is fine, file is tiny. Reserve this fallback for Task 12 smoke test; first try the inline `input.session.title` path which is simpler.
+
+- [ ] **Step 2: 手动 smoke test 准备**
+
+无 unit test 阶段；下一步在 Task 12 手动验证。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Resources/agent-hooks/opencode-plugin/mux0-status.js
+git commit -m "$(cat <<'EOF'
+feat(agent-hooks): attach sessionTitle from opencode session in chat/tool emits
+
+OpenCode plugin API surfaces session.title on chat.message and
+tool.execute.before inputs; forward to the socket so mux0 can name the
+tab the same way Claude/Codex do.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: ContentView 实例化 store + 注入 dispatcher
+
+**Files:**
+- Modify: `mux0/ContentView.swift`
+
+- [ ] **Step 1: 加 store 字段**
+
+打开 `mux0/ContentView.swift`。在 line 7 (`@State private var pwdStore = TerminalPwdStore()`) 之后插入：
+
+```swift
+    @State private var sessionTitleStore = TerminalSessionTitleStore()
+```
+
+- [ ] **Step 2: 注入 WorkspaceStore**
+
+ContentView 中 `@State private var store = WorkspaceStore()`（line 5）是 WorkspaceStore 引用，参数名一律叫 `store`。在 ContentView body 的外层 `.task` / `.onAppear` 块中加（如已有 onAppear 用之，否则在最外层 view 末尾追加）：
+
+```swift
+        .onAppear {
+            store.sessionTitleStore = sessionTitleStore
+        }
+```
+
+- [ ] **Step 3: 调用 dispatcher 时透传**
+
+定位到 line 196-201（hook listener `onMessage` 注册）。在 closure 内的 dispatch 调用上方加一行 capture：
+
+```swift
+                    let sessionTitleStoreRef = self.sessionTitleStore
+```
+
+然后修改 dispatch 调用：
+
+```swift
+                    listener.onMessage = { msg in
+                        HookDispatcher.dispatch(msg,
+                                                settings: settingsStoreRef,
+                                                store: store,
+                                                workspaceStore: workspaceStoreRef,
+                                                sessionTitleStore: sessionTitleStoreRef)
+                    }
+```
+
+- [ ] **Step 4: 把 sessionTitleStore 透传给 TabBridge**
+
+ContentView line ~64-65 构造 `TabBridge(...)`，已有 `statusStore: statusStore, pwdStore: pwdStore`。在 `pwdStore:` 行下面加：
+
+```swift
+                        sessionTitleStore: sessionTitleStore,
+```
+
+（同样在 line ~80-81 第二处 TabBridge 构造也加）。
+
+- [ ] **Step 5: Defer commit to Task 9**
+
+不单独 commit，因为编译需要 Task 9 的 TabBridge 改动配套。先继续 Task 9。
+
+---
+
+## Task 9: TabBridge / TabContentView 透传 sessionTitleStore
+
+**Files:**
+- Modify: `mux0/Bridge/TabBridge.swift`
+- Modify: `mux0/TabContent/TabContentView.swift`
+- Modify: `mux0/ContentView.swift`（commit 在此处一起做）
+
+- [ ] **Step 1: TabBridge 加字段 + 透传**
+
+打开 `mux0/Bridge/TabBridge.swift`，在 `@Bindable var pwdStore: TerminalPwdStore` 下面加：
+
+```swift
+    @Bindable var sessionTitleStore: TerminalSessionTitleStore
+```
+
+在 `makeNSView` 和 `updateNSView` 把 `nsView.sessionTitleStore = sessionTitleStore` 加上（紧挨 `pwdStore` 那行下面）。
+
+- [ ] **Step 2: TabContentView 加字段 + 透传到 TabBarView**
+
+打开 `mux0/TabContent/TabContentView.swift`，在 `var pwdStore: TerminalPwdStore?` 下面加：
+
+```swift
+    var sessionTitleStore: TerminalSessionTitleStore?
+```
+
+找到 `loadWorkspace(...)` 内部所有调 `tabBar.update(tabs:selectedTabId:theme:...)` 的地方，把 `sessionTitleStore: sessionTitleStore` 也透传过去（Task 10 加 TabBarView 参数）。
+
+- [ ] **Step 3: 编译占位**
+
+```bash
+xcodebuild build -project mux0.xcodeproj -scheme mux0 -configuration Debug 2>&1 | tail -20
+```
+
+Expected: 暂时编译失败（TabBarView 还没收 sessionTitleStore 参数）。继续 Task 10。
+
+---
+
+## Task 10: TabBarView 渲染 displayTitle + Reset 菜单项
+
+**Files:**
+- Modify: `mux0/TabContent/TabBarView.swift`
+- Modify: `mux0/Localization/Localizable.xcstrings`
+- Modify: `mux0/Localization/L10n.swift`
+
+- [ ] **Step 1: 加 L10n 常量**
+
+打开 `mux0/Localization/L10n.swift`，找到 `Tab` 命名空间（或 `tab.row.*` 集中处），加：
+
+```swift
+        static let resetAutoTitle = LocalizedStringResource("tab.row.resetAutoTitle")
+```
+
+打开 `mux0/Localization/Localizable.xcstrings`，加新键。可以用 grep 找到现有 `tab.row.rename` 条目对照格式，模仿插一条 `tab.row.resetAutoTitle`：
+- en source: "Reset to auto title"
+- zh-Hans: "重置为自动标题"
+
+如果 .xcstrings 文件难手编，运行下面的 Python 脚本 patch（保险）：
+
+```bash
+python3 <<'PY'
+import json, pathlib
+p = pathlib.Path("mux0/Localization/Localizable.xcstrings")
+doc = json.loads(p.read_text())
+doc.setdefault("strings", {})["tab.row.resetAutoTitle"] = {
+    "extractionState": "manual",
+    "localizations": {
+        "en": {"stringUnit": {"state": "translated", "value": "Reset to auto title"}},
+        "zh-Hans": {"stringUnit": {"state": "translated", "value": "重置为自动标题"}},
+    }
+}
+p.write_text(json.dumps(doc, indent=2, ensure_ascii=False))
+PY
+```
+
+- [ ] **Step 2: TabBarView.update 加参数 + 透传**
+
+打开 `mux0/TabContent/TabBarView.swift`：
+
+`update(...)` 函数签名加参数：
+
+```swift
+    func update(tabs: [TerminalTab],
+                selectedTabId: UUID?,
+                theme: AppTheme,
+                statuses: [UUID: TerminalStatus] = [:],
+                sessionTitles: [UUID: String] = [:],
+                backgroundOpacity: CGFloat = 1.0,
+                showStatusIndicators: Bool = false) {
+```
+
+存到字段：
+
+```swift
+    private var sessionTitles: [UUID: String] = [:]
+```
+
+并在 `update` 中 `self.sessionTitles = sessionTitles`。
+
+在 `rebuildTabItems` / 原地刷新分支里，把 `tab.title` 替换为通过显示规则计算的 title。在 TabBarView 内加一个本地 helper（避免循环引用 store）：
+
+```swift
+    /// Display title with same priority as `TerminalTab.displayTitle(store:)`,
+    /// but reads from the snapshot dictionary we receive in `update`.
+    /// Kept inline here so AppKit views don't need to hold a store reference.
+    private func displayTitle(for tab: TerminalTab) -> String {
+        if tab.userRenamed { return tab.title }
+        if let auto = sessionTitles[tab.focusedTerminalId], !auto.isEmpty {
+            return auto
+        }
+        return tab.title
+    }
+```
+
+`TabItemView.refresh(...)` 和初始化时，把传给 `titleLabel.stringValue` 的值改为 `displayTitle(for: tab)`。即在 `rebuildTabItems` 的 "原地刷新" 分支：
+
+```swift
+            for item in existing {
+                let isSel = item.tabId == selectedTabId
+                if let tab = tabs.first(where: { $0.id == item.tabId }) {
+                    let tabStatus = TerminalStatus.aggregate(
+                        tab.layout.allTerminalIds().map { statuses[$0] ?? .neverRan }
+                    )
+                    item.refresh(tab: tab, isSelected: isSel, theme: theme,
+                                 canClose: canCloseNow, status: tabStatus,
+                                 backgroundOpacity: backgroundOpacity,
+                                 showStatusIndicators: showStatusIndicators,
+                                 displayTitle: displayTitle(for: tab))
+                }
+            }
+```
+
+完整重建分支：
+
+```swift
+        for tab in tabs {
+            let tabStatus = TerminalStatus.aggregate(
+                tab.layout.allTerminalIds().map { statuses[$0] ?? .neverRan }
+            )
+            let item = TabItemView(tab: tab, isSelected: tab.id == selectedTabId,
+                                   theme: theme, status: tabStatus,
+                                   backgroundOpacity: backgroundOpacity,
+                                   showStatusIndicators: showStatusIndicators,
+                                   quickActionsStore: quickActionsStore,
+                                   displayTitle: displayTitle(for: tab))
+            // ... rest unchanged
+        }
+```
+
+修改 `TabItemView.init` 和 `refresh` 接受 `displayTitle: String` 参数，并在内部用它代替 `tab.title` 给 titleLabel 赋值。**保留** `tab.title` 作为 originalTitle 的来源（rename UI 编辑框的 placeholder 仍展示用户已设值；用户没设值时 placeholder 就是兜底文本 = `tab.title`）。
+
+```swift
+    init(tab: TerminalTab, isSelected: Bool, theme: AppTheme,
+         status: TerminalStatus = .neverRan,
+         backgroundOpacity: CGFloat = 1.0,
+         showStatusIndicators: Bool = false,
+         quickActionsStore: QuickActionsStore? = nil,
+         displayTitle: String) {
+        // ... existing
+        titleLabel.stringValue = displayTitle
+        // ...
+    }
+
+    func refresh(tab: TerminalTab, isSelected: Bool, theme: AppTheme,
+                 canClose: Bool, status: TerminalStatus = .neverRan,
+                 backgroundOpacity: CGFloat = 1.0,
+                 showStatusIndicators: Bool = false,
+                 displayTitle: String) {
+        // ... existing
+        if titleLabel.stringValue != displayTitle && !isRenaming {
+            titleLabel.stringValue = displayTitle
+        }
+        // ...
+    }
+```
+
+在 `beginRenameAction` 用 `tab.title`（用户已设）当 edit field 初值；如果想优先显示当前的 displayTitle 也可以，但 spec 没要求 —— 保持简单：用 `titleLabel.stringValue` 当 originalTitle，让 rename UI 自然展示当前显示的名字。
+
+`originalTitle = titleLabel.stringValue` 已经在原始代码里，保留即可。
+
+- [ ] **Step 3: 加 Reset 菜单项 + onResetAutoTitle callback**
+
+在 `TabBarView` 顶部加：
+
+```swift
+    var onResetAutoTitle: ((UUID) -> Void)?
+```
+
+在 `rebuildTabItems` 完整重建分支创建 `item` 之后：
+
+```swift
+            item.onResetAutoTitle = { [weak self] in self?.onResetAutoTitle?(tab.id) }
+            item.userRenamed = tab.userRenamed
+```
+
+在 `TabItemView` 顶部加：
+
+```swift
+    var onResetAutoTitle: (() -> Void)?
+    var userRenamed: Bool = false
+```
+
+修改 `refresh` 设置 `userRenamed`：
+
+```swift
+        self.userRenamed = tab.userRenamed
+```
+
+在 `rightMouseDown` 的 menu 中（Close 之前或 separator 之后）加：
+
+```swift
+        if userRenamed {
+            menu.addItem(.separator())
+            let resetItem = NSMenuItem(title: L10n.string("tab.row.resetAutoTitle"),
+                                       action: #selector(resetAutoTitleTapped),
+                                       keyEquivalent: "")
+            resetItem.target = self
+            menu.addItem(resetItem)
+        }
+```
+
+加 callback selector：
+
+```swift
+    @objc private func resetAutoTitleTapped() { onResetAutoTitle?() }
+```
+
+- [ ] **Step 4: TabContentView 接 onResetAutoTitle**
+
+打开 `mux0/TabContent/TabContentView.swift`，找到现有的 `tabBar.onRenameTab = { ... }` 旁边加：
+
+```swift
+        tabBar.onResetAutoTitle = { [weak self] tabId in
+            guard let self, let ws = self.store?.selectedWorkspace else { return }
+            self.store?.resetTabToAutoTitle(tabId: tabId, in: ws.id)
+        }
+```
+
+并在 `loadWorkspace`（实际调 `tabBar.update`）里，把 `sessionTitles:` 透传：
+
+```swift
+        tabBar.update(
+            tabs: ws.tabs,
+            selectedTabId: ws.selectedTabId,
+            theme: currentTheme,
+            statuses: statuses,
+            sessionTitles: sessionTitleStore?.titlesSnapshot() ?? [:],
+            backgroundOpacity: backgroundOpacity,
+            showStatusIndicators: showStatusIndicators
+        )
+```
+
+在 `TerminalSessionTitleStore` 加 `titlesSnapshot()` 工具方法（如果还没有）。修改 `mux0/Models/TerminalSessionTitleStore.swift`：
+
+```swift
+    func titlesSnapshot() -> [UUID: String] {
+        var out: [UUID: String] = [:]
+        for (k, v) in storage {
+            if let id = UUID(uuidString: k) { out[id] = v }
+        }
+        return out
+    }
+```
+
+- [ ] **Step 5: TabBridge 透传 sessionTitles 给 update**
+
+打开 `mux0/Bridge/TabBridge.swift`，已有 `statuses: statusStore.statusesSnapshot()`。改为：
+
+```swift
+            view.loadWorkspace(ws,
+                               statuses: statusStore.statusesSnapshot(),
+                               showStatusIndicators: showStatusIndicators)
+```
+
+> Note: `loadWorkspace` 在 `TabContentView` 内部已经拿到 `sessionTitleStore`，自己读 snapshot 即可（Step 4 已经实现）。TabBridge 这边不需要再传 snapshot。
+
+实际上需要确认 `loadWorkspace` 当前签名是否接 statuses：是接的（既有代码 line 33）。我们让 `TabContentView` 在 `loadWorkspace` 里自己从 `sessionTitleStore?` 拿 snapshot 即可。
+
+- [ ] **Step 6: 编译 + 跑全套测试**
+
+```bash
+xcodegen generate
+xcodebuild build -project mux0.xcodeproj -scheme mux0 -configuration Debug 2>&1 | tail -20
+```
+
+Expected: build succeeded。
+
+```bash
+xcodebuild test -project mux0.xcodeproj -scheme mux0Tests 2>&1 | tail -20
+```
+
+Expected: 全套测试通过。
+
+- [ ] **Step 7: Commit (Task 8 + 9 + 10 一起)**
+
+```bash
+git add mux0/ContentView.swift mux0/Bridge/TabBridge.swift mux0/TabContent/TabContentView.swift mux0/TabContent/TabBarView.swift mux0/Models/TerminalSessionTitleStore.swift mux0/Localization/Localizable.xcstrings mux0/Localization/L10n.swift
+git commit -m "$(cat <<'EOF'
+feat(tabcontent): render auto session titles + add reset-to-auto menu
+
+Tab labels now derive from TerminalSessionTitleStore via
+TerminalTab.displayTitle priority chain. Right-click menu gains "Reset
+to auto title" when the tab is locked by a manual rename.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 11: L10n smoke test 包含新键
+
+**Files:**
+- Modify: `mux0Tests/L10nSmokeTests.swift`
+
+- [ ] **Step 1: 加测试**
+
+打开 `mux0Tests/L10nSmokeTests.swift`，按现有模式加一条：
+
+```swift
+    func testResetAutoTitle() {
+        XCTAssertFalse(L10n.string("tab.row.resetAutoTitle").isEmpty)
+    }
+```
+
+- [ ] **Step 2: 跑测试确认通过**
+
+```bash
+xcodebuild test -project mux0.xcodeproj -scheme mux0Tests -only-testing:mux0Tests/L10nSmokeTests 2>&1 | tail -10
+```
+
+Expected: 通过（依赖 Task 10 已加 key）。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mux0Tests/L10nSmokeTests.swift
+git commit -m "$(cat <<'EOF'
+test(i18n): smoke-check tab.row.resetAutoTitle is wired up
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 12: 文档同步
+
+**Files:**
+- Modify: `docs/agent-hooks.md`
+- Modify: `CLAUDE.md`
+- Modify: `AGENTS.md`
+
+- [ ] **Step 1: docs/agent-hooks.md 加 Session title 章节**
+
+在 `docs/agent-hooks.md` 的 `## IPC` 章节末尾、`## Agent Turn 成败检测` 章节之前，插入：
+
+```markdown
+## Session title
+
+Each socket message may carry `sessionTitle` —— 当前 agent 会话的人类可读名字，用于驱动 mux0 的 tab 自动命名（`TerminalSessionTitleStore`）。三个 agent 各自的来源：
+
+| Agent | 来源 | 时机 |
+|-------|------|------|
+| Claude | transcript JSONL 内反向扫到的最后一条 `{"type":"ai-title","aiTitle":"..."}` 条目 | `prompt` / `stop` |
+| Codex | `~/.codex/state_*.sqlite`（取最新 schema 版本）的 `threads.title WHERE id = <session_id>` | `prompt` / `stop` |
+| OpenCode | plugin `input.session?.title` | `chat.message` / `tool.execute.before` |
+
+LLM 异步生成 → 新建 session 后第一次 emit 可能为空字符串，下一个 turn 会填上。Swift 端 `TerminalSessionTitleStore.update` 丢弃空字符串，避免覆盖已知值。
+
+用户在 mux0 内 inline rename tab 后，`TerminalTab.userRenamed = true`，`displayTitle` 锁定不再吃 `sessionTitle`。右键菜单「Reset to auto title」清除锁定。
+```
+
+- [ ] **Step 2: CLAUDE.md Directory Structure 加 store**
+
+在 CLAUDE.md 的 Directory Structure → Models 节，按字母顺序在 `TerminalPwdStore.swift` 行附近加：
+
+```
+│   ├── TerminalSessionTitleStore.swift — @Observable，terminalId → agent session title（hook 喂入，tab 标题读取）
+```
+
+`docs/conventions.md` 或 `docs/architecture.md` 若引用 store 列表也同步加。
+
+- [ ] **Step 3: CLAUDE.md Common Tasks 加新任务**
+
+在 Common Tasks 表加一行：
+
+```
+| 修改 tab 自动命名行为（auto title 来源 / 锁定语义） | `Models/TerminalSessionTitleStore.swift`, `Models/Workspace.swift`（displayTitle）, `Models/HookDispatcher.swift`（路由）, `Resources/agent-hooks/agent-hook.py`（claude/codex 来源）, `Resources/agent-hooks/opencode-plugin/mux0-status.js`（opencode 来源） |
+```
+
+- [ ] **Step 4: AGENTS.md 同步 Directory Structure**
+
+在 AGENTS.md 的相同 Directory Structure 节加同一条 `TerminalSessionTitleStore.swift` 行。
+
+- [ ] **Step 5: 跑文档漂移检查**
+
+```bash
+./scripts/check-doc-drift.sh
+```
+
+Expected: 通过。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/agent-hooks.md CLAUDE.md AGENTS.md
+git commit -m "$(cat <<'EOF'
+docs: document Session title hook field + TerminalSessionTitleStore
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 13: 端到端 smoke test（手动）
+
+**Files:** (none modified — this is a verification task)
+
+- [ ] **Step 1: 构建并启动**
+
+```bash
+xcodebuild build -project mux0.xcodeproj -scheme mux0 -configuration Debug 2>&1 | tail -5
+```
+
+提示用户重启 mux0.app（不主动 killall）。
+
+- [ ] **Step 2: Claude 验证**
+
+在 mux0 新开 tab → quick action "claude"。发一条 prompt（如 "say hi"）。等待 ~2-5 秒 LLM 生成 ai-title。期望：tab 标题从 "claude" 变为 LLM 生成的会话名（如 "Hello greeting"）。
+
+- [ ] **Step 3: Codex 验证**
+
+同上 quick action "codex"。期望：第一次 prompt 后 tab 显示 first_user_message（如 "hello"），后续 turn 后变为 LLM title。
+
+- [ ] **Step 4: OpenCode 验证**
+
+quick action "opencode" → 发 prompt。期望：tab 显示 session.title（≥ 第二次 turn）。
+
+> 若 OpenCode 的 plugin input 不含 `session.title`（API 形态不同），把 Task 7 的 fallback 实施掉：在 plugin 里读 `~/.local/share/opencode/storage/session/<projectHash>/<sessionId>.json`。
+
+- [ ] **Step 5: 锁定语义验证**
+
+任一 agent tab 上：
+1. 右键 → Rename → 输入 "MyName" → Enter
+2. 期望：tab 显示 "MyName"
+3. 发新 prompt，agent 生成新 ai-title
+4. 期望：tab 仍显示 "MyName"（锁定生效）
+5. 右键 → 应出现 "Reset to auto title"
+6. 点击
+7. 期望：tab 立即恢复显示 agent session title
+
+- [ ] **Step 6: Split pane focus 验证**
+
+1. 在 claude tab 里 split 一个 shell pane
+2. 焦点切到 shell pane（点击）
+3. 期望：tab 标题回退到 tab.title（默认 "claude" 或 "Terminal"）
+4. 焦点切回 claude pane
+5. 期望：tab 标题变回 agent session title
+
+- [ ] **Step 7: 重启持久化验证**
+
+退出 mux0，重新启动。期望：所有 tab 立即显示上次的 session title（来自 UserDefaults），无需等 hook 再触发。
+
+- [ ] **Step 8: Final sanity — 全套测试**
+
+```bash
+xcodebuild test -project mux0.xcodeproj -scheme mux0Tests 2>&1 | tail -15
+python3 -m pytest Resources/agent-hooks/tests/ -v 2>&1 | tail -10
+./scripts/check-doc-drift.sh
+```
+
+Expected: 全部通过。
+
+- [ ] **Step 9: PR 创建（人工触发）**
+
+不自动 push，提示用户审阅本地 commits 并自行决定是否 `git push -u origin agent/auto-tab-naming` 后 `gh pr create`。
+
+---
+
+## Self-review checklist
+
+实施时按顺序勾掉以上 task 即可。完成后再核对：
+
+- [ ] Spec 的每条「改动清单」项目都有对应 task
+- [ ] 没有 TBD / "implement later" / 占位
+- [ ] 类型/方法名跨 task 一致（`displayTitle`、`sessionTitleStore`、`userRenamed`、`resetTabToAutoTitle`）
+- [ ] 三个 agent 数据源都有实测 case
+- [ ] 兜底 / 锁定 / 解锁 / 持久化 都有 unit / smoke 覆盖
+- [ ] 文档同步任务出现在最后（不在头几个 task 里干扰核心实现）

--- a/docs/superpowers/specs/2026-05-24-auto-tab-naming-design.md
+++ b/docs/superpowers/specs/2026-05-24-auto-tab-naming-design.md
@@ -1,0 +1,167 @@
+# Tab 自动命名（从 agent 会话标题）
+
+## 背景
+
+目前 `TerminalTab.title` 只有两种状态：创建时的兜底字符串（"Terminal" / quick action displayName 如 "claude"），或用户手动 inline rename 后的字符串。当用户在 tab 里跑 Claude Code / Codex / OpenCode 时，agent 端已经为 session 生成了人类可读的标题（如 `claude --resume` / `codex resume` 列表展示的那个），但 mux0 完全没用上。
+
+本设计让 tab 名自动跟随当前 agent session 的标题，同时保留"用户重命名永久优先"的语义。
+
+## 三个 agent 的会话标题来源
+
+| Agent | 数据源 | 类型 |
+|-------|--------|------|
+| Claude Code | transcript JSONL（`UserPromptSubmit` payload 已带 `transcript_path`）内 `{"type":"ai-title","aiTitle":"..."}` 条目（取最后一条） | LLM 异步生成；首 turn 可能未生成 |
+| Codex | `~/.codex/state_*.sqlite` 的 `threads.title` 列，按 `id = <session_id>` 查询 | LLM 异步生成；首 turn 内 fallback 到 `first_user_message` |
+| OpenCode | plugin context 的 `session.title` 字段（持久化在 `~/.local/share/opencode/storage/session/<projectHash>/<sessionId>.json`） | LLM 异步生成 |
+
+三者都是 LLM 异步生成 → 新建 session 后第一次 emit 时可能为空字符串，下一个 turn 会填上。mux0 端只要 idempotent 收最新值即可。
+
+## Tab title 渲染规则
+
+```
+displayTitle(tab, sessionTitleStore):
+  if tab.userRenamed       → tab.title
+  if sessionTitleStore[tab.focusedTerminalId] is non-empty
+                           → sessionTitleStore[tab.focusedTerminalId]
+  else                     → tab.title    // 兜底，沿用现有默认 ("Terminal" / quick action displayName)
+```
+
+**焦点 pane = 焦点终端**（`TerminalTab.focusedTerminalId`），随 split pane 内焦点切换实时更新；焦点 pane 是 shell（store 里查不到）时回退到 `tab.title`，**不**保留上次 agent pane 的标题。
+
+**用户重命名 = 永久锁定。** 一次 inline rename 之后无视后续 session 变化。提供右键菜单「Reset to auto title」解锁（仅 `userRenamed = true` 时显示）。
+
+## 数据流
+
+```
+agent 写 session title 到自家 store
+  ↓
+agent hook 触发 (prompt / stop / tool.execute.before)
+  ↓ 读 session title
+  ↓ emit HookMessage { ..., sessionTitle: "..." }
+  ↓ Unix socket
+HookSocketListener (Swift)
+  ↓ decode HookMessage
+HookDispatcher
+  ↓ if sessionTitle != nil → TerminalSessionTitleStore.update(terminalId, title)
+TerminalSessionTitleStore (@Observable, [UUID: String])
+  ↓ 触发 SwiftUI 失效
+TabBarView / TabItemView
+  ↓ 渲染 tab.displayTitle(sessionTitleStore:)
+```
+
+## 改动清单
+
+### Wire format（`HookMessage` + 三个 hook 端）
+
+`HookMessage` 新增字段：
+
+```swift
+let sessionTitle: String?
+```
+
+可选；为空 / nil 时不更新 store（避免空字符串覆盖已有值）。
+
+### Hook 端
+
+**`Resources/agent-hooks/agent-hook.py`**：在 `dispatch` 的 `prompt` 和 `stop` 分支里附加 `sessionTitle`。
+
+- Claude：新增 `read_ai_title(path)`，反向扫 transcript JSONL 找最后一条 `{"type":"ai-title","aiTitle":"..."}`，截到 `SUMMARY_MAXLEN`（200 字符）。Stop 子命令已扫一次 transcript 拿 summary，可在同一遍扫描里顺带拿 title。
+- Codex：新增 `read_codex_title(session_id)`，glob `~/.codex/state_*.sqlite` 取最新一个，`SELECT title FROM threads WHERE id = ?` 查询。`mode=ro` + `timeout=0.5` URI 打开，防止 codex 写时阻塞 hook。`sqlite3` 模块来自 python stdlib，无新依赖。
+
+**`Resources/agent-hooks/opencode-plugin/mux0-status.js`**：在 `tool.execute.before` 已有的 `running` socket emit 上附 `sessionTitle`，优先用 plugin context 的 `session.title`，fallback 到读 session JSON 文件。
+
+**Session id 校验** 复用已有的 `SESSION_ID_RE`（`[A-Za-z0-9_-]+` 白名单），防止 SQLite 查询拼接被注入。
+
+### Swift 端
+
+**`mux0/Models/TerminalSessionTitleStore.swift`**（新文件）：
+
+```swift
+@Observable
+final class TerminalSessionTitleStore {
+    private(set) var titles: [UUID: String] = [:]
+
+    func update(terminalId: UUID, title: String) { ... }   // 空字符串视为无效，跳过
+    func clear(terminalId: UUID) { ... }
+    func clear(terminalIds: [UUID]) { ... }
+}
+```
+
+参考已有的 `TerminalPwdStore` / `TerminalStatusStore` 形态，持久化到 UserDefaults（key 模式与 PwdStore 同构）。
+
+**`mux0/Models/Workspace.swift`**：`TerminalTab` 加字段：
+
+```swift
+var userRenamed: Bool = false
+```
+
+Codable 兼容：旧持久化数据没这个字段时按默认 `false` 解码。
+
+**`mux0/Models/HookMessage.swift`**：新增 `sessionTitle: String?`，`init(from:)` 用 `decodeIfPresent`。
+
+**`mux0/Models/HookDispatcher.swift`**：处理 HookMessage 时如果 `sessionTitle` 非 nil 且非空，调 `sessionTitleStore.update`。
+
+**`mux0/Models/WorkspaceStore.swift`**：
+- `closeTerminal(_:)` → 调 `sessionTitleStore.clear(terminalId:)`
+- `removeTab(_:)` → 调 `clear(terminalIds:)` 遍历所有 leaf
+- `removeWorkspace(_:)` → 同上
+- 已有的 `renameTab` 路径里把目标 tab 的 `userRenamed` 置为 `true`
+- 新增 `resetTabToAutoTitle(tabId:in:)`：把 `userRenamed` 置为 `false`，title 不动（恢复兜底文本，等 hook 重新 emit 覆盖）
+
+**`mux0/TabContent/TabBarView.swift`**：
+- `TabItemView.refresh` / 初始化时 title 来源改为 `tab.displayTitle(store:)`
+- 右键菜单加「Reset to auto title」项，仅 `tab.userRenamed = true` 时显示
+- TabBarView `update(...)` 签名加 `sessionTitleStore` 参数；调用方（`TabBridge` → `TabContentView`）注入
+
+**`mux0/Bridge/TabBridge.swift`** + **`mux0/TabContent/TabContentView.swift`**：把 `TerminalSessionTitleStore` 一并传给 TabBarView，与现有 status / pwd store 路径一致。
+
+**`mux0/mux0App.swift`**：实例化 `TerminalSessionTitleStore` 单例，注入 environment + WorkspaceStore。
+
+### i18n
+
+`mux0/Localization/Localizable.xcstrings` + `Localization/L10n.swift`：
+- `tab.row.resetAutoTitle` —— en: "Reset to auto title"，zh-Hans: "重置为自动标题"
+
+### 文档
+
+- `docs/agent-hooks.md`：新增「Session title」一节，描述 `sessionTitle` wire field + 三个 agent 各自读取来源
+- `CLAUDE.md` + `AGENTS.md` Directory Structure：Models 节加 `TerminalSessionTitleStore.swift`
+- `CLAUDE.md` Common Tasks：新增「修改 tab 自动命名行为」条目，指向 store / dispatcher / hook 三处
+
+## 持久化策略
+
+- `TerminalTab.userRenamed`：随 `Workspace` Codable 一起持久化（UserDefaults，已有路径）
+- `TerminalSessionTitleStore.titles`：持久化到 UserDefaults（独立 key）。重启后 tab 立即显示上次会话名，hook 重新 emit 后覆盖
+- 旧版本数据：`userRenamed` 缺失按 false 解码 → 全部 tab 进入 auto 模式（即使之前手动 rename 过）。可接受的一次性迁移代价（用户重新 rename 一次即恢复锁定）
+
+## 边界 / 失败模式
+
+| 场景 | 行为 |
+|------|------|
+| Agent 还未生成 title（首 turn 内） | hook emit 空字符串 → store 跳过 → tab 显示兜底 |
+| Codex SQLite 被锁 / IO 错误 | hook 静默捕获，emit 不带 sessionTitle |
+| Transcript 文件不存在 / 损坏 | 同上 |
+| 用户跨重启 | titles 从 UserDefaults 恢复，hook 重新 emit 覆盖 |
+| 用户手动 rename 后 agent session 变了 | tab 仍显示用户名（锁定） |
+| 用户 reset auto title 后 store 是空 | 显示兜底，下个 turn hook emit 时填上 |
+| Shell pane focus | 显示兜底 `tab.title`，不保留上次 agent pane 的会话名 |
+| Hook 端 session id 含非法字符 | `SESSION_ID_RE` 拒绝，不查 SQLite，emit 不带 sessionTitle |
+
+## 测试策略
+
+- `mux0Tests/`：
+  - `TerminalSessionTitleStore` 的 update / clear / 持久化往返
+  - `TerminalTab.displayTitle` 在 `userRenamed` × `store` 各种组合下的返回值
+  - `HookDispatcher` 路由 sessionTitle 到 store
+  - `HookMessage` JSON 解码兼容（无 sessionTitle 字段时 nil）
+- Hook 端 Python 单测（`Resources/agent-hooks/tests/`）：
+  - `read_ai_title` 命中 / 缺失 / 文件损坏
+  - `read_codex_title` 命中 / 无表 / 非法 session_id
+- 手动 smoke test（每个 agent 各开一个 tab，发一条 prompt，等 LLM title 生成，看 tab 名是否更新）
+
+## 非目标
+
+- **不**在 mux0 端缓存 SQLite / file watcher / 轮询三个 agent 的 store（一切走 hook-driven）
+- **不**做"跨 tab 同步 session title"（每个 terminal 独立维护）
+- **不**在 sidebar workspace 行展示 agent session title（侧边栏已有 git 分支 / PR 状态，再叠加 session title 信息过载）
+- **不**改 `tab.title` 字段名（兼容旧 Codable，仅新增 `userRenamed`）

--- a/landing-page/index.html
+++ b/landing-page/index.html
@@ -1220,7 +1220,7 @@ kbd{
         <span data-i18n="hero.cta.source">View source</span>
         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17L17 7M9 7h8v8"/></svg>
       </a>
-      <span class="chip-meta"><span class="mono" data-i18n="hero.meta.ver">v0.5.3</span></span>
+      <span class="chip-meta"><span class="mono" data-i18n="hero.meta.ver">v0.6.0</span></span>
     </div>
 
     <!-- hero window (interactive) -->
@@ -1247,7 +1247,7 @@ kbd{
               </div>
               <div class="ws-list" id="ws-list"></div>
               <div class="sidebar-footer">
-                <span class="mono">v0.5.3</span>
+                <span class="mono">v0.6.0</span>
                 <button class="side-icon disabled" data-disabled-msg title="Settings" aria-label="Settings (disabled in preview)">
                   <svg width="13" height="13"><use href="#icon-gear"/></svg>
                 </button>
@@ -1622,7 +1622,7 @@ const i18n = {
     "hero.sub": "A native macOS terminal built on libghostty. Workspaces, tabs, and split panes for your repos — with live status for every Claude Code, OpenCode, and Codex session you run.",
     "hero.cta.download": "Download for macOS",
     "hero.cta.source": "View source",
-    "hero.meta.ver": "v0.5.3",
+    "hero.meta.ver": "v0.6.0",
     "sidebar.workspaces": "WORKSPACES",
     "preview.caption": "Live preview — + add workspace/tab · double-click to rename · drag to reorder · type a command and hit Enter",
     "why.kicker": "THREE IDEAS",
@@ -1726,7 +1726,7 @@ const i18n = {
     "term.agent.needs": "waiting for your approval on tool call",
     "term.agent.failedMsg": "tool error: typecheck failed",
     "term.neofetch.os": "macOS 14.4 · Apple Silicon",
-    "term.neofetch.term": "Mux0 v0.5.3 · libghostty · Metal",
+    "term.neofetch.term": "Mux0 v0.6.0 · libghostty · Metal",
     "term.neofetch.shell": "zsh 5.9",
     "term.neofetch.uptime": "uptime 1d 4h",
     "term.neofetch.theme": "nocturne · 200 ms hot-reload",
@@ -1747,7 +1747,7 @@ const i18n = {
     "hero.sub": "基于 libghostty 的原生 macOS 终端。为多仓库工作流而设计 —— 侧边栏实时显示每一个 Claude Code、OpenCode、Codex 会话的运行状态。",
     "hero.cta.download": "下载 macOS 版",
     "hero.cta.source": "查看源码",
-    "hero.meta.ver": "v0.5.3",
+    "hero.meta.ver": "v0.6.0",
     "sidebar.workspaces": "工作区",
     "preview.caption": "实时预览 —— + 新建工作区/标签 · 双击重命名 · 拖拽排序 · 输入命令回车执行",
     "why.kicker": "三个理念",
@@ -1851,7 +1851,7 @@ const i18n = {
     "term.agent.needs": "等待工具调用授权",
     "term.agent.failedMsg": "工具报错：typecheck 失败",
     "term.neofetch.os": "macOS 14.4 · Apple Silicon",
-    "term.neofetch.term": "Mux0 v0.5.3 · libghostty · Metal",
+    "term.neofetch.term": "Mux0 v0.6.0 · libghostty · Metal",
     "term.neofetch.shell": "zsh 5.9",
     "term.neofetch.uptime": "运行 1d 4h",
     "term.neofetch.theme": "nocturne · 200 ms 热重载",

--- a/mux0.xcodeproj/project.pbxproj
+++ b/mux0.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		12741E8B51DEF437A6AE697F /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B0F181545CE8CDC275225D8B /* Metal.framework */; };
 		1469033158736BF0DDBA9BFD /* TerminalSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 674574CDF31582712885AF2A /* TerminalSectionView.swift */; };
 		14AEF17B71B6F1844E5D983D /* L10nSmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB9513EB0F425DDEDAFA246 /* L10nSmokeTests.swift */; };
+		165D2011AB095BD31B714719 /* TerminalSessionTitleStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A688F7137F6F5369E3FCDB0C /* TerminalSessionTitleStore.swift */; };
 		17AC1B4B029D77A9517D843A /* TerminalStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CB4EED723871B4BD4813083 /* TerminalStatusTests.swift */; };
 		19BD6175DF11D2A4F682D037 /* NotificationNamesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 829BFF63567D2305C599651B /* NotificationNamesTests.swift */; };
 		1ACA82D8830D139B5869BCB2 /* SidebarListBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55F0C6038D23FE4472512A6 /* SidebarListBridge.swift */; };
@@ -41,6 +42,7 @@
 		58D74F52D38ADED476431033 /* GhosttyTerminalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9A8823EC09C8201A18A8CCE /* GhosttyTerminalView.swift */; };
 		5AB61AD35E457A1232CDA29A /* L10n.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A7AEDAAD045DC4A400322C /* L10n.swift */; };
 		5C5C2F39FAD6D937EBCEFCD4 /* TerminalStatusStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A56725925248FD6CAB92C5 /* TerminalStatusStoreTests.swift */; };
+		5CCE5836621069FDE33156A4 /* TerminalSessionTitleStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C44043B923CC4EF74123D4 /* TerminalSessionTitleStoreTests.swift */; };
 		620938F8EA5927DD270C9E4D /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FC595B7F0A7BC1E449FCC999 /* AppKit.framework */; };
 		684789E3C67497DD5A45DC6B /* ThemeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C43A714AAB5B2FF59F5C935 /* ThemeManager.swift */; };
 		6986FB2583059FEABBCDCBD1 /* HookDispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D68BE3B4BF39A66486E169B9 /* HookDispatcherTests.swift */; };
@@ -57,6 +59,7 @@
 		8548616652B7ABFDA2934C4D /* SparkleBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DBE7B66FAEB36EEB42A4857 /* SparkleBridge.swift */; };
 		8B3D073E458F9DE52D98643E /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = B6B4582F8BE1C8707A83868E /* Sparkle */; };
 		8D92A0B981408874C548B7CE /* MetadataRefresher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 105802CACA1ABC48684A2F0C /* MetadataRefresher.swift */; };
+		90046182C84C2256BD81C5B1 /* TerminalTabDisplayTitleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC3751AC033CB9420517920E /* TerminalTabDisplayTitleTests.swift */; };
 		915558F09223486690E05227 /* SettingsConfigStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E705AF49A322B7ECB5700BB /* SettingsConfigStoreTests.swift */; };
 		92F3509A81CD73816C10356C /* UpdateState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81CD12FFB88B2BE6DFCE9F2A /* UpdateState.swift */; };
 		9688B5112BE4CAA8A86ACC76 /* FontPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00418F118F44EEF00CFBDE8 /* FontPickerView.swift */; };
@@ -116,6 +119,7 @@
 		036836909C5E414F3E9B95DC /* SettingsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSection.swift; sourceTree = "<group>"; };
 		04EE67FE969E31DA1B40FA42 /* StartupCommandResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupCommandResolver.swift; sourceTree = "<group>"; };
 		0520C77C17845C086A5E597A /* StartupCommandResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupCommandResolverTests.swift; sourceTree = "<group>"; };
+		08C44043B923CC4EF74123D4 /* TerminalSessionTitleStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSessionTitleStoreTests.swift; sourceTree = "<group>"; };
 		0B75BC1D38F67C220D3F82A8 /* TerminalStatusIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalStatusIconView.swift; sourceTree = "<group>"; };
 		105802CACA1ABC48684A2F0C /* MetadataRefresher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataRefresher.swift; sourceTree = "<group>"; };
 		107354077329DDFCCA716A4D /* QuickActionsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickActionsStore.swift; sourceTree = "<group>"; };
@@ -169,6 +173,7 @@
 		9B2155A2A87792B1482ABD95 /* UpdateStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateStoreTests.swift; sourceTree = "<group>"; };
 		9DBE7B66FAEB36EEB42A4857 /* SparkleBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparkleBridge.swift; sourceTree = "<group>"; };
 		A5F940956C8E5C463DA771CE /* PasteboardTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteboardTypes.swift; sourceTree = "<group>"; };
+		A688F7137F6F5369E3FCDB0C /* TerminalSessionTitleStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSessionTitleStore.swift; sourceTree = "<group>"; };
 		AF17311B1358A9ECB083D3A4 /* WorkspaceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceStore.swift; sourceTree = "<group>"; };
 		B0C4FA9E98058C4E9936EC48 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		B0F181545CE8CDC275225D8B /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = System/Library/Frameworks/Metal.framework; sourceTree = SDKROOT; };
@@ -194,6 +199,7 @@
 		E70BE85ECC3CB933E795354E /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		E7EFC41E34E76ABACF864F59 /* GhosttyBridgeCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyBridgeCommandTests.swift; sourceTree = "<group>"; };
 		EA1BC853B2A74058D4E3EDC4 /* LanguageStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageStoreTests.swift; sourceTree = "<group>"; };
+		EC3751AC033CB9420517920E /* TerminalTabDisplayTitleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTabDisplayTitleTests.swift; sourceTree = "<group>"; };
 		ED0076717C7D5AA4FF63A948 /* TerminalPwdStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalPwdStore.swift; sourceTree = "<group>"; };
 		EE58F1D0F1F79A6A03712FD9 /* DesignTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignTokens.swift; sourceTree = "<group>"; };
 		EF52B8A70429B8C4F21259E8 /* TabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
@@ -386,9 +392,11 @@
 				0520C77C17845C086A5E597A /* StartupCommandResolverTests.swift */,
 				CC7EFDC8D28B1681B068CE01 /* StatusIndicatorGateTests.swift */,
 				821BF7B943BBA8650E8769A4 /* TerminalPwdStoreTests.swift */,
+				08C44043B923CC4EF74123D4 /* TerminalSessionTitleStoreTests.swift */,
 				CC8D978AA26C3DD97EF58200 /* TerminalStatusIconViewTests.swift */,
 				E6A56725925248FD6CAB92C5 /* TerminalStatusStoreTests.swift */,
 				3CB4EED723871B4BD4813083 /* TerminalStatusTests.swift */,
+				EC3751AC033CB9420517920E /* TerminalTabDisplayTitleTests.swift */,
 				FF6D78DE69EFABF9BD88975E /* ThemeCatalogTests.swift */,
 				70BBA11237B9EA46D6D3FFD6 /* ThemeManagerTests.swift */,
 				9B2155A2A87792B1482ABD95 /* UpdateStoreTests.swift */,
@@ -448,6 +456,7 @@
 				DB6F2650B84DBA28A06D938D /* QuickAction.swift */,
 				107354077329DDFCCA716A4D /* QuickActionsStore.swift */,
 				ED0076717C7D5AA4FF63A948 /* TerminalPwdStore.swift */,
+				A688F7137F6F5369E3FCDB0C /* TerminalSessionTitleStore.swift */,
 				8F9A0D6FCA49BEE08183E290 /* TerminalStatus.swift */,
 				D3274889470A660788D30183 /* TerminalStatusStore.swift */,
 				D0B13F4CC99C28EAC76B51D6 /* Workspace.swift */,
@@ -623,9 +632,11 @@
 				39B56550E6DE3A7BF8E95160 /* StartupCommandResolverTests.swift in Sources */,
 				D795617034323AC803958EEE /* StatusIndicatorGateTests.swift in Sources */,
 				A88A524A7FCB090037E7DB2C /* TerminalPwdStoreTests.swift in Sources */,
+				5CCE5836621069FDE33156A4 /* TerminalSessionTitleStoreTests.swift in Sources */,
 				6AA362AD3255878AD318860E /* TerminalStatusIconViewTests.swift in Sources */,
 				5C5C2F39FAD6D937EBCEFCD4 /* TerminalStatusStoreTests.swift in Sources */,
 				17AC1B4B029D77A9517D843A /* TerminalStatusTests.swift in Sources */,
+				90046182C84C2256BD81C5B1 /* TerminalTabDisplayTitleTests.swift in Sources */,
 				02FAB26ED84EBD1383C3A116 /* ThemeCatalogTests.swift in Sources */,
 				DB016E38F7C00CC8547F99A6 /* ThemeManagerTests.swift in Sources */,
 				F9531EDE3A2F664B292EF6D5 /* UpdateStoreTests.swift in Sources */,
@@ -679,6 +690,7 @@
 				D05BE2086B9B665D781C3876 /* TabContentView.swift in Sources */,
 				0EEDBAC571AE7A5E39EC0EF7 /* TerminalPwdStore.swift in Sources */,
 				1469033158736BF0DDBA9BFD /* TerminalSectionView.swift in Sources */,
+				165D2011AB095BD31B714719 /* TerminalSessionTitleStore.swift in Sources */,
 				BA96FADF69CB3C0BFB863419 /* TerminalStatus.swift in Sources */,
 				CD42EBB5354AB53833B78ADE /* TerminalStatusIconView.swift in Sources */,
 				C5CD2EEA37E5011FE575727D /* TerminalStatusStore.swift in Sources */,
@@ -783,7 +795,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Vendor/ghostty/lib";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.5.2;
+				MARKETING_VERSION = 0.5.3;
 				MUX0_DISPLAY_NAME = Mux0;
 				OTHER_LDFLAGS = "-lghostty -lc++ -framework Carbon";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mux0.app;
@@ -908,7 +920,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Vendor/ghostty/lib";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.5.2;
+				MARKETING_VERSION = 0.5.3;
 				MUX0_DISPLAY_NAME = "Mux0 Dev";
 				OTHER_LDFLAGS = "-lghostty -lc++ -framework Carbon";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mux0.app.dev;

--- a/mux0.xcodeproj/project.pbxproj
+++ b/mux0.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		BE855766F2E7E0E965AE4335 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E70BE85ECC3CB933E795354E /* ContentView.swift */; };
 		C25EEE04D310E199A62D191C /* PasteboardTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F940956C8E5C463DA771CE /* PasteboardTypes.swift */; };
 		C28ABD6B7567A65D82A4610B /* WorkspaceMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF8258EE99E420704586A50D /* WorkspaceMetadata.swift */; };
+		C49A697E5CE9EA92414F8C19 /* HookDispatcherSessionTitleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C8D71111463899481471BE2 /* HookDispatcherSessionTitleTests.swift */; };
 		C5CD2EEA37E5011FE575727D /* TerminalStatusStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3274889470A660788D30183 /* TerminalStatusStore.swift */; };
 		CD42EBB5354AB53833B78ADE /* TerminalStatusIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B75BC1D38F67C220D3F82A8 /* TerminalStatusIconView.swift */; };
 		D05BE2086B9B665D781C3876 /* TabContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84326382AC1806C28810AF31 /* TabContentView.swift */; };
@@ -142,6 +143,7 @@
 		4FDF42AF7F6C7FA8512527BF /* QuickActionIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickActionIconView.swift; sourceTree = "<group>"; };
 		500DC5FBA84EA82E83A79C79 /* PlaceholderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceholderTests.swift; sourceTree = "<group>"; };
 		531109F006EA4DC2299C7FC2 /* DraggedSnapshotShadow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraggedSnapshotShadow.swift; sourceTree = "<group>"; };
+		5C8D71111463899481471BE2 /* HookDispatcherSessionTitleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookDispatcherSessionTitleTests.swift; sourceTree = "<group>"; };
 		5DEC02C6A3912B9FFA44F2E2 /* SurfaceScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceScrollView.swift; sourceTree = "<group>"; };
 		6172CA48D21FC80F732CB23A /* HookSocketListenerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookSocketListenerTests.swift; sourceTree = "<group>"; };
 		65EACD3F08D21F717F82A9A0 /* ThemedTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemedTextField.swift; sourceTree = "<group>"; };
@@ -376,6 +378,7 @@
 			children = (
 				E7EFC41E34E76ABACF864F59 /* GhosttyBridgeCommandTests.swift */,
 				E5347252E77411776BBE4282 /* GhosttyTerminalViewPwdTests.swift */,
+				5C8D71111463899481471BE2 /* HookDispatcherSessionTitleTests.swift */,
 				D68BE3B4BF39A66486E169B9 /* HookDispatcherTests.swift */,
 				399D6E84F70926B48FDB254D /* HookMessageTests.swift */,
 				6172CA48D21FC80F732CB23A /* HookSocketListenerTests.swift */,
@@ -616,6 +619,7 @@
 			files = (
 				D6C6838185488C7EDEA33E97 /* GhosttyBridgeCommandTests.swift in Sources */,
 				B87CA03C3EDF66D3B0D2C8AF /* GhosttyTerminalViewPwdTests.swift in Sources */,
+				C49A697E5CE9EA92414F8C19 /* HookDispatcherSessionTitleTests.swift in Sources */,
 				6986FB2583059FEABBCDCBD1 /* HookDispatcherTests.swift in Sources */,
 				B35766C44967278D296440C0 /* HookMessageTests.swift in Sources */,
 				D78733DF393F151691E97AF0 /* HookSocketListenerTests.swift in Sources */,

--- a/mux0.xcodeproj/project.pbxproj
+++ b/mux0.xcodeproj/project.pbxproj
@@ -799,7 +799,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Vendor/ghostty/lib";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.5.3;
+				MARKETING_VERSION = 0.6.0;
 				MUX0_DISPLAY_NAME = Mux0;
 				OTHER_LDFLAGS = "-lghostty -lc++ -framework Carbon";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mux0.app;
@@ -924,7 +924,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Vendor/ghostty/lib";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.5.3;
+				MARKETING_VERSION = 0.6.0;
 				MUX0_DISPLAY_NAME = "Mux0 Dev";
 				OTHER_LDFLAGS = "-lghostty -lc++ -framework Carbon";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mux0.app.dev;

--- a/mux0/Bridge/TabBridge.swift
+++ b/mux0/Bridge/TabBridge.swift
@@ -5,6 +5,7 @@ struct TabBridge: NSViewRepresentable {
     @Bindable var store: WorkspaceStore
     @Bindable var statusStore: TerminalStatusStore
     @Bindable var pwdStore: TerminalPwdStore
+    @Bindable var sessionTitleStore: TerminalSessionTitleStore
     @Bindable var settings: SettingsConfigStore
     @Bindable var quickActionsStore: QuickActionsStore
     var theme: AppTheme
@@ -25,6 +26,7 @@ struct TabBridge: NSViewRepresentable {
         view.store = store
         view.statusStore = statusStore
         view.pwdStore = pwdStore
+        view.sessionTitleStore = sessionTitleStore
         view.settingsStore = settings
         view.quickActionsStore = quickActionsStore
         view.applyTheme(theme, backgroundOpacity: backgroundOpacity, locale: locale)
@@ -41,6 +43,7 @@ struct TabBridge: NSViewRepresentable {
         nsView.store = store
         nsView.statusStore = statusStore
         nsView.pwdStore = pwdStore
+        nsView.sessionTitleStore = sessionTitleStore
         nsView.settingsStore = settings
         nsView.quickActionsStore = quickActionsStore
         nsView.applyTheme(theme, backgroundOpacity: backgroundOpacity, locale: locale)

--- a/mux0/ContentView.swift
+++ b/mux0/ContentView.swift
@@ -5,6 +5,7 @@ struct ContentView: View {
     @State private var store = WorkspaceStore()
     @State private var statusStore = TerminalStatusStore()
     @State private var pwdStore = TerminalPwdStore()
+    @State private var sessionTitleStore = TerminalSessionTitleStore()
     @State private var settingsStore: SettingsConfigStore
     @State private var quickActionsStore: QuickActionsStore
     @State private var sidebarCollapsed: Bool = false
@@ -79,6 +80,7 @@ struct ContentView: View {
                         store: store,
                         statusStore: statusStore,
                         pwdStore: pwdStore,
+                        sessionTitleStore: sessionTitleStore,
                         settings: settingsStore,
                         quickActionsStore: quickActionsStore,
                         theme: themeManager.theme,
@@ -186,6 +188,9 @@ struct ContentView: View {
                 themeManager.refresh()
                 applyUnfocusedOpacityFromSettings()
             }
+            // Inject the session title store into WorkspaceStore so rename-lock
+            // cleanup can clear titles when a tab is closed or a terminal is split.
+            store.sessionTitleStore = sessionTitleStore
             if hookListener == nil {
                 let path = HookSocketListener.defaultPath
                 do {
@@ -193,11 +198,13 @@ struct ContentView: View {
                     let store = self.statusStore
                     let settingsStoreRef = self.settingsStore
                     let workspaceStoreRef = self.store
+                    let sessionTitleStoreRef = self.sessionTitleStore
                     listener.onMessage = { msg in
                         HookDispatcher.dispatch(msg,
                                                 settings: settingsStoreRef,
                                                 store: store,
-                                                workspaceStore: workspaceStoreRef)
+                                                workspaceStore: workspaceStoreRef,
+                                                sessionTitleStore: sessionTitleStoreRef)
                     }
                     try listener.start()
                     hookListener = listener

--- a/mux0/Ghostty/GhosttyTerminalView.swift
+++ b/mux0/Ghostty/GhosttyTerminalView.swift
@@ -7,6 +7,16 @@ final class GhosttyTerminalView: NSView, NSTextInputClient {
     private var displayLink: CVDisplayLink?
     private var backingObserver: NSObjectProtocol?
 
+    /// While set and in the future, this (otherwise non-frontmost) surface is
+    /// drawn by the displayLink so it can repaint after a size change — ghostty
+    /// needs several frames to reflow, which a single manual draw can't provide.
+    /// Cleared (and the surface re-occluded) by the displayLink once it lapses.
+    /// See `setFrameSize`. Touched only on the main queue.
+    private var redrawBurstDeadline: Date?
+    /// How long a post-resize redraw burst lasts. Generous enough to cover
+    /// ghostty's grid reflow; a one-time cost paid only on actual size changes.
+    private static let burstSeconds: TimeInterval = 0.4
+
     // MARK: NSTextInputClient state
     /// 本轮 keyDown 中由 `insertText` 收集到的已提交文本。随 keyDown 开始清空、结束读取。
     private var keyTextAccumulator: String = ""
@@ -356,11 +366,27 @@ final class GhosttyTerminalView: NSView, NSTextInputClient {
             let retained = Unmanaged.passRetained(view)
             DispatchQueue.main.async {
                 let v = retained.takeRetainedValue()
-                // 关键：只有当前前台 surface 才 draw。
+                guard let s = v.surface else { return }
+                let isFront = GhosttyTerminalView.currentFrontmost === v
+                // A non-frontmost pane draws only during its post-resize redraw
+                // burst (see setFrameSize). When the burst window closes, re-occlude
+                // it so we go back to the steady state of "only the frontmost pane
+                // renders" — the gate that kills ghostty's mouseLocation-driven
+                // "selection follows the mouse" loop for background panes.
+                var burst = false
+                if let deadline = v.redrawBurstDeadline {
+                    if Date() < deadline {
+                        burst = true
+                    } else {
+                        v.redrawBurstDeadline = nil
+                        if !isFront { ghostty_surface_set_occlusion(s, false) }
+                    }
+                }
+                // 关键：稳态下只有当前前台 surface 才 draw。
                 // libghostty 在 draw 内部会 +[NSEvent mouseLocation] 主动读全局光标，
                 // 不让它 draw 就不让它读，从根源切断"鼠标飘到哪选到哪"的循环。
-                guard GhosttyTerminalView.currentFrontmost === v else { return }
-                if let s = v.surface { ghostty_surface_draw(s) }
+                guard isFront || burst else { return }
+                ghostty_surface_draw(s)
             }
             return kCVReturnSuccess
         }, Unmanaged.passUnretained(self).toOpaque())
@@ -385,21 +411,27 @@ final class GhosttyTerminalView: NSView, NSTextInputClient {
         // ghostty tears down its Metal renderer and the surface comes back blank
         // (black screen) even after the real size arrives on the next pass.
         syncSurfaceGeometry(to: newSize)
-        // Non-frontmost surfaces never enter the displayLink draw branch (the
-        // CVDisplayLink callback's `currentFrontmost === self` guard rejects
-        // them), so a real size change here would otherwise leave ghostty's
-        // Metal layer presenting its pre-resize frame until the user clicks
-        // to refocus the pane. Typical trigger: ⌘D split moves focus to the
-        // new pane, leaving the original pane non-frontmost with a fresh
-        // surface size but a stale on-screen frame. Push a one-shot draw so
-        // the layer flips to a matching frame in the same runloop pass.
-        // Safe vs. the mouseLocation-polling concern that motivated the
-        // frontmost-only gate: makeFrontmost has already released every mouse
-        // button and parked the cursor at (-1, -1) for non-frontmost surfaces,
-        // so a single draw cannot accumulate a phantom selection.
+        // A non-frontmost surface is excluded from the displayLink draw branch
+        // (the callback's `currentFrontmost === self` guard) AND was told
+        // set_occlusion(false) by makeFrontmost, so ghostty stops rendering it.
+        // After a real size change it would therefore keep presenting its
+        // pre-resize frame until the user clicks to refocus the pane. Typical
+        // trigger: ⌘D split shifts focus to the new pane, leaving the original
+        // non-frontmost with a fresh surface size but a stale on-screen frame.
+        //
+        // A single manual draw is NOT enough: ghostty's renderer needs several
+        // frames after a resize to reflow the grid and settle, so one frame
+        // paints a half-finished result. Instead we open a short "redraw burst":
+        // mark the surface visible again and let the already-running displayLink
+        // feed it frames for `burstSeconds`, exactly like a frontmost pane, then
+        // re-occlude. Safe vs. the mouseLocation-polling concern behind the
+        // frontmost-only gate — makeFrontmost has released every mouse button
+        // and parked the cursor at (-1, -1) for non-frontmost surfaces, so the
+        // burst can only ever render a transient hover, never a selection.
         if oldSize != newSize, newSize.width > 0, newSize.height > 0,
            let s = surface, Self.currentFrontmost !== self {
-            ghostty_surface_draw(s)
+            ghostty_surface_set_occlusion(s, true)
+            redrawBurstDeadline = Date().addingTimeInterval(Self.burstSeconds)
         }
     }
 

--- a/mux0/Ghostty/GhosttyTerminalView.swift
+++ b/mux0/Ghostty/GhosttyTerminalView.swift
@@ -377,6 +377,7 @@ final class GhosttyTerminalView: NSView, NSTextInputClient {
     // MARK: - Layout
 
     override func setFrameSize(_ newSize: NSSize) {
+        let oldSize = frame.size
         super.setFrameSize(newSize)
         // Ignore transient zero-sized frames. These happen when the enclosing
         // SplitPaneView is being swapped out and briefly leaves subviews at .zero
@@ -384,6 +385,22 @@ final class GhosttyTerminalView: NSView, NSTextInputClient {
         // ghostty tears down its Metal renderer and the surface comes back blank
         // (black screen) even after the real size arrives on the next pass.
         syncSurfaceGeometry(to: newSize)
+        // Non-frontmost surfaces never enter the displayLink draw branch (the
+        // CVDisplayLink callback's `currentFrontmost === self` guard rejects
+        // them), so a real size change here would otherwise leave ghostty's
+        // Metal layer presenting its pre-resize frame until the user clicks
+        // to refocus the pane. Typical trigger: ⌘D split moves focus to the
+        // new pane, leaving the original pane non-frontmost with a fresh
+        // surface size but a stale on-screen frame. Push a one-shot draw so
+        // the layer flips to a matching frame in the same runloop pass.
+        // Safe vs. the mouseLocation-polling concern that motivated the
+        // frontmost-only gate: makeFrontmost has already released every mouse
+        // button and parked the cursor at (-1, -1) for non-frontmost surfaces,
+        // so a single draw cannot accumulate a phantom selection.
+        if oldSize != newSize, newSize.width > 0, newSize.height > 0,
+           let s = surface, Self.currentFrontmost !== self {
+            ghostty_surface_draw(s)
+        }
     }
 
     override func viewDidChangeBackingProperties() {

--- a/mux0/Localization/L10n.swift
+++ b/mux0/Localization/L10n.swift
@@ -75,11 +75,10 @@ enum L10n {
 
     enum Tab {
         static let newTabTooltip        = LocalizedStringResource("tab.newTab")
-        // Row rename/close/reset (context menu) and close-tab alert strings are resolved
-        // at runtime via L10n.string("tab.row.rename") etc. — they live only in
-        // AppKit call sites (NSMenuItem, NSAlert), so no typed constant is needed.
-        // See Strings.xcstrings for the full key list.
-        static let resetAutoTitle       = LocalizedStringResource("tab.row.resetAutoTitle")
+        // Row rename/close/resetAutoTitle (context menu) and close-tab alert
+        // strings are resolved at runtime via L10n.string("tab.row.rename")
+        // etc. — they live only in AppKit call sites (NSMenuItem, NSAlert), so
+        // no typed constant is needed. See Strings.xcstrings for the full key list.
     }
 
     // MARK: - QuickActions

--- a/mux0/Localization/L10n.swift
+++ b/mux0/Localization/L10n.swift
@@ -75,10 +75,11 @@ enum L10n {
 
     enum Tab {
         static let newTabTooltip        = LocalizedStringResource("tab.newTab")
-        // Row rename/close (context menu) and close-tab alert strings are resolved
+        // Row rename/close/reset (context menu) and close-tab alert strings are resolved
         // at runtime via L10n.string("tab.row.rename") etc. — they live only in
         // AppKit call sites (NSMenuItem, NSAlert), so no typed constant is needed.
         // See Strings.xcstrings for the full key list.
+        static let resetAutoTitle       = LocalizedStringResource("tab.row.resetAutoTitle")
     }
 
     // MARK: - QuickActions

--- a/mux0/Localization/Localizable.xcstrings
+++ b/mux0/Localization/Localizable.xcstrings
@@ -1,930 +1,2267 @@
 {
-  "sourceLanguage" : "en",
-  "strings" : {
-    "app.ghostty.notFound.detail" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Mux0 requires Ghostty to be installed.\nRun scripts/build-vendor.sh first, then relaunch." } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "Mux0 需要安装 Ghostty。请先运行 scripts/build-vendor.sh，然后重新启动。" } }
-      }
-    },
-    "app.ghostty.notFound.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Ghostty not found" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "未找到 Ghostty" } }
-      }
-    },
-    "menu.closePane" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Close Pane" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "关闭窗格" } }
-      }
-    },
-    "menu.copy" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Copy" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "拷贝" } }
-      }
-    },
-    "menu.editConfig" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Edit Config File…" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "编辑配置文件…" } }
-      }
-    },
-    "menu.focusNextPane" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Focus Next Pane" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "聚焦下一窗格" } }
-      }
-    },
-    "menu.focusPrevPane" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Focus Previous Pane" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "聚焦上一窗格" } }
-      }
-    },
-    "menu.help" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Mux0 Help" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "Mux0 帮助" } }
-      }
-    },
-    "menu.newTab" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "New Tab" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "新建 Tab" } }
-      }
-    },
-    "menu.newWorkspace" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "New Workspace" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "新建 Workspace" } }
-      }
-    },
-    "menu.paste" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Paste" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "粘贴" } }
-      }
-    },
-    "menu.selectAll" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Select All" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "全选" } }
-      }
-    },
-    "menu.selectNextTab" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Select Next Tab" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "下一个 Tab" } }
-      }
-    },
-    "menu.selectPrevTab" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Select Previous Tab" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "上一个 Tab" } }
-      }
-    },
-    "menu.selectTab %lld" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Select Tab %lld" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "切换到第 %lld 个 Tab" } }
-      }
-    },
-    "menu.selectWorkspace %lld" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Select Workspace %lld" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "切换到第 %lld 个工作区" } }
-      }
-    },
-    "menu.settings" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Settings…" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "设置…" } }
-      }
-    },
-    "menu.splitHorizontal" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Split Horizontally (Top/Bottom)" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "水平分割（上/下）" } }
-      }
-    },
-    "menu.splitVertical" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Split Vertically (Left/Right)" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "垂直分割（左/右）" } }
-      }
-    },
-    "menu.terminal" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Terminal" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "终端" } }
-      }
-    },
-    "quickActions.builtin.claude" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Claude Code" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "Claude Code" } }
-      }
-    },
-    "quickActions.builtin.codex" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Codex" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "Codex" } }
-      }
-    },
-    "quickActions.builtin.gitui" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Git" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "Git" } }
-      }
-    },
-    "quickActions.builtin.opencode" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "OpenCode" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "OpenCode" } }
-      }
-    },
-    "settings.appearance.backgroundBlur" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Background Blur" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "背景模糊" } }
-      }
-    },
-    "settings.appearance.backgroundOpacity" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Background Opacity" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "背景不透明度" } }
-      }
-    },
-    "settings.appearance.contentOpacity" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Content Opacity" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "内容不透明度" } }
-      }
-    },
-    "settings.appearance.contentShadow" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Content Shadow" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "内容阴影" } }
-      }
-    },
-    "settings.appearance.cursorBlink" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Cursor Blink" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "光标闪烁" } }
-      }
-    },
-    "settings.appearance.cursorStyle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Cursor Style" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "光标样式" } }
-      }
-    },
-    "settings.appearance.language" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Language" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "语言" } }
-      }
-    },
-    "settings.appearance.theme" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Theme" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "主题" } }
-      }
-    },
-    "settings.appearance.unfocusedPaneOpacity" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Unfocused Pane Opacity" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "非聚焦窗格不透明度" } }
-      }
-    },
-    "settings.appearance.windowPaddingX" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Window Padding X" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "窗口内边距 X" } }
-      }
-    },
-    "settings.appearance.windowPaddingY" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Window Padding Y" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "窗口内边距 Y" } }
-      }
-    },
-    "settings.close" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Close settings" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "关闭设置" } }
-      }
-    },
-    "settings.font.custom" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Custom…" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "自定义…" } }
-      }
-    },
-    "settings.font.customPlaceholder" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Font name" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "字体名称" } }
-      }
-    },
-    "settings.font.default" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "(default)" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "（默认）" } }
-      }
-    },
-    "settings.font.family" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Font Family" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "字体" } }
-      }
-    },
-    "settings.font.listButton" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "List" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "列表" } }
-      }
-    },
-    "settings.font.size" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Font Size" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "字号" } }
-      }
-    },
-    "settings.font.thicken" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Font Thicken" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "加粗字体" } }
-      }
-    },
-    "settings.footer.edit" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Edit Config File…" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "编辑配置文件…" } }
-      }
-    },
-    "settings.footer.live" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Changes apply live." } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "修改即时生效。" } }
-      }
-    },
-    "settings.language.system" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "System" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "跟随系统" } }
-      }
-    },
-    "settings.quickActions.addCustomButton" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Add Custom Action" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "新建自定义快捷操作" } }
-      }
-    },
-    "settings.quickActions.customCommandPlaceholder" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Command" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "命令" } }
-      }
-    },
-    "settings.quickActions.customNamePlaceholder" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Name" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "名称" } }
-      }
-    },
-    "settings.quickActions.deleteCustom.tooltip" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Delete custom action" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "删除自定义快捷操作" } }
-      }
-    },
-    "settings.quickActions.heading" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Enabled & Order" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "启用与排序" } }
-      }
-    },
-    "settings.quickActions.headingFooter" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Enabled buttons appear in the top-right corner of the window. Drag to reorder." } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "启用的按钮会按下方顺序出现在窗口右上角，可拖拽排序。" } }
-      }
-    },
-    "settings.reset.alertTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Reset these settings?" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "重置这些设置？" } }
-      }
-    },
-    "settings.reset.button" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Reset" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "重置" } }
-      }
-    },
-    "settings.reset.cancel" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Cancel" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "取消" } }
-      }
-    },
-    "settings.reset.message" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "All settings in this section will revert to their defaults. You can still change them afterwards." } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "本分类下的所有设置将恢复为默认值，之后你仍可以修改。" } }
-      }
-    },
-    "settings.reset.rowLabel" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Restore Defaults" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "恢复默认" } }
-      }
-    },
-    "settings.agents.betaBadge" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "BETA" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "BETA" } }
-      }
-    },
-    "settings.agents.codexAlertTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Enable Codex Experimental Hooks" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "需要开启 Codex 实验性 Hook" } }
-      }
-    },
-    "settings.agents.codexAlertMessage" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Codex hooks are gated behind an experimental flag. Add the following to ~/.codex/config.toml, then restart Codex:\n\n[features]\ncodex_hooks = true\n\nWithout this flag, Codex turn status will stay idle during running." } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "Codex 的 hooks 是实验特性，默认关闭。请在 ~/.codex/config.toml 中加入下面内容，然后重启 Codex：\n\n[features]\ncodex_hooks = true\n\n未开启时 Codex 运行中状态会一直停留在 idle。" } }
-      }
-    },
-    "settings.agents.codexAlertOK" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Got it" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "我知道了" } }
-      }
-    },
-    "settings.agents.claude" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Claude Code" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "Claude Code" } }
-      }
-    },
-    "settings.agents.codex" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Codex" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "Codex" } }
-      }
-    },
-    "settings.agents.opencode" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "OpenCode" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "OpenCode" } }
-      }
-    },
-    "settings.agents.notificationsTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Notifications" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "通知" } }
-      }
-    },
-    "settings.agents.notificationsFooter" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Show running / idle / finished status icons next to tabs that run the selected agents." } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "在跑这些 agent 的 tab 旁显示运行 / 闲置 / 完成的状态图标。" } }
-      }
-    },
-    "settings.agents.resumeTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Resume on Launch" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "启动时恢复会话" } }
-      }
-    },
-    "settings.agents.resumeFooter" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "On next launch, auto-run `claude --resume <id>` / `codex resume <id>` to land back in the most recent session. Off by default. Turning a row off also drops any saved session id." } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "下次启动时自动执行 `claude --resume <id>` / `codex resume <id>`，回到最近一次的会话。默认关闭。关闭某一行同时会清除已保存的会话 id。" } }
-      }
-    },
-    "settings.section.agents" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Agents" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "Agents" } }
-      }
-    },
-    "settings.section.appearance" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Appearance" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "外观" } }
-      }
-    },
-    "settings.section.font" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Font" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "字体" } }
-      }
-    },
-    "settings.section.quickActions" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Quick Actions" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "快捷操作" } }
-      }
-    },
-    "settings.section.shell" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Shell" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "Shell" } }
-      }
-    },
-    "settings.section.terminal" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Terminal" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "终端" } }
-      }
-    },
-    "settings.shell.customCommand" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Custom Command" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "自定义命令" } }
-      }
-    },
-    "settings.shell.defaultPlaceholder" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "(default shell)" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "（默认 shell）" } }
-      }
-    },
-    "settings.shell.features" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Integration Features" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "集成特性" } }
-      }
-    },
-    "settings.shell.integration" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Shell Integration" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "Shell 集成" } }
-      }
-    },
-    "settings.terminal.confirmClose" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Confirm Close" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "关闭确认" } }
-      }
-    },
-    "settings.terminal.copyOnSelect" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Copy On Select" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "选中即复制" } }
-      }
-    },
-    "settings.terminal.hideMouseWhileTyping" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Hide Mouse While Typing" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "键入时隐藏鼠标" } }
-      }
-    },
-    "settings.terminal.scrollbackLimit" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Scrollback Limit" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "回滚缓冲大小" } }
-      }
-    },
-    "settings.theme.dark" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Dark" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "深色" } }
-      }
-    },
-    "settings.theme.followSystem" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Follow system" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "跟随系统" } }
-      }
-    },
-    "settings.theme.light" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Light" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "浅色" } }
-      }
-    },
-    "settings.theme.name" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Theme Name" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "主题名称" } }
-      }
-    },
-    "settings.theme.searchPlaceholder" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Search themes" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "搜索主题" } }
-      }
-    },
-    "settings.theme.inherit" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Inherit from Ghostty" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "继承 Ghostty（默认）" } }
-      }
-    },
-    "settings.theme.single" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Single" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "单主题" } }
-      }
-    },
-    "sidebar.deleteAlert.cancel" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Cancel" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "取消" } }
-      }
-    },
-    "sidebar.deleteAlert.confirm" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Delete" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "删除" } }
-      }
-    },
-    "sidebar.deleteAlert.message %@" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "\"%@\" will be deleted with all its tabs. This action cannot be undone." } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "「%@」及其所有 tab 将被删除，此操作不可撤销。" } }
-      }
-    },
-    "sidebar.deleteAlert.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Delete workspace?" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "删除 workspace？" } }
-      }
-    },
-    "sidebar.hide" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Hide sidebar" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "收起侧栏" } }
-      }
-    },
-    "sidebar.newWorkspace" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "New workspace" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "新建 workspace" } }
-      }
-    },
-    "sidebar.row.delete" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Delete" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "删除" } }
-      }
-    },
-    "sidebar.row.commandPanel.editTitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Edit Default Command" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "编辑默认命令" } }
-      }
-    },
-    "sidebar.row.commandPanel.cancel" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Cancel" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "取消" } }
-      }
-    },
-    "sidebar.row.commandPanel.placeholder" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "e.g. ssh user@server" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "例如 ssh user@server" } }
-      }
-    },
-    "sidebar.row.commandPanel.save" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Save" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "保存" } }
-      }
-    },
-    "sidebar.row.rename" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Rename" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "重命名" } }
-      }
-    },
-    "sidebar.settings" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Settings" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "设置" } }
-      }
-    },
-    "sidebar.show" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Show sidebar" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "展开侧栏" } }
-      }
-    },
-    "sidebar.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Mux0" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "Mux0" } }
-      }
-    },
-    "tab.close.alert.cancel" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Cancel" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "取消" } }
-      }
-    },
-    "tab.close.alert.confirm" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Close" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "关闭" } }
-      }
-    },
-    "tab.close.alert.message %@" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "All terminal processes in \"%@\" will be terminated." } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "「%@」中的所有终端进程将被终止。" } }
-      }
-    },
-    "tab.close.alert.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Close tab?" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "关闭 tab？" } }
-      }
-    },
-    "tab.newTab" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "New tab" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "新建 tab" } }
-      }
-    },
-    "tab.row.close" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Close" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "关闭" } }
-      }
-    },
-    "tab.row.rename" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Rename" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "重命名" } }
-      }
-    },
-    "settings.section.update" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Update" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "更新" } }
-      }
-    },
-    "settings.update.action" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Action" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "操作" } }
-      }
-    },
-    "settings.update.availableUpdate" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Available Update" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "可用更新" } }
-      }
-    },
-    "settings.update.checkForUpdates" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Check for Updates" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "检查更新" } }
-      }
-    },
-    "settings.update.checking" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Checking…" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "检查中…" } }
-      }
-    },
-    "settings.update.currentVersion" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Current Version" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "当前版本" } }
-      }
-    },
-    "settings.update.debugBuild" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Debug Build" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "Debug 构建" } }
-      }
-    },
-    "settings.update.debugDisabled" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Auto-update disabled" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "已禁用自动更新" } }
-      }
-    },
-    "settings.update.dismiss" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Dismiss" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "稍后再说" } }
-      }
-    },
-    "settings.update.downloadInstall" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Download & Install" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "下载并安装" } }
-      }
-    },
-    "settings.update.downloading" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Downloading" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "下载中" } }
-      }
-    },
-    "settings.update.error" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Error" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "错误" } }
-      }
-    },
-    "settings.update.installing" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Installing & relaunching…" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "安装并重启中…" } }
-      }
-    },
-    "settings.update.releaseNotes" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Release Notes" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "更新说明" } }
-      }
-    },
-    "settings.update.retry" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Retry" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "重试" } }
-      }
-    },
-    "settings.update.skipThisVersion" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Skip This Version" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "跳过此版本" } }
-      }
-    },
-    "settings.update.status" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Status" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "状态" } }
-      }
-    },
-    "settings.update.upToDate" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "You're on the latest version." } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "已是最新版本。" } }
-      }
-    },
-    "settings.update.version %@" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Version %@" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "版本 %@" } }
-      }
-    },
-    "sidebar.checkForUpdates" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Check for updates" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "检查更新" } }
-      }
-    },
-    "sidebar.updateAvailable" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Update available" } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "有可用更新" } }
+  "sourceLanguage": "en",
+  "strings": {
+    "app.ghostty.notFound.detail": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mux0 requires Ghostty to be installed.\nRun scripts/build-vendor.sh first, then relaunch."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mux0 需要安装 Ghostty。请先运行 scripts/build-vendor.sh，然后重新启动。"
+          }
+        }
+      }
+    },
+    "app.ghostty.notFound.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ghostty not found"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到 Ghostty"
+          }
+        }
+      }
+    },
+    "menu.closePane": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close Pane"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭窗格"
+          }
+        }
+      }
+    },
+    "menu.copy": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "拷贝"
+          }
+        }
+      }
+    },
+    "menu.editConfig": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit Config File…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "编辑配置文件…"
+          }
+        }
+      }
+    },
+    "menu.focusNextPane": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Focus Next Pane"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "聚焦下一窗格"
+          }
+        }
+      }
+    },
+    "menu.focusPrevPane": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Focus Previous Pane"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "聚焦上一窗格"
+          }
+        }
+      }
+    },
+    "menu.help": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mux0 Help"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mux0 帮助"
+          }
+        }
+      }
+    },
+    "menu.newTab": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Tab"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新建 Tab"
+          }
+        }
+      }
+    },
+    "menu.newWorkspace": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Workspace"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新建 Workspace"
+          }
+        }
+      }
+    },
+    "menu.paste": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paste"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "粘贴"
+          }
+        }
+      }
+    },
+    "menu.selectAll": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select All"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全选"
+          }
+        }
+      }
+    },
+    "menu.selectNextTab": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select Next Tab"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下一个 Tab"
+          }
+        }
+      }
+    },
+    "menu.selectPrevTab": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select Previous Tab"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "上一个 Tab"
+          }
+        }
+      }
+    },
+    "menu.selectTab %lld": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select Tab %lld"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切换到第 %lld 个 Tab"
+          }
+        }
+      }
+    },
+    "menu.selectWorkspace %lld": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select Workspace %lld"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切换到第 %lld 个工作区"
+          }
+        }
+      }
+    },
+    "menu.settings": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置…"
+          }
+        }
+      }
+    },
+    "menu.splitHorizontal": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Split Horizontally (Top/Bottom)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "水平分割（上/下）"
+          }
+        }
+      }
+    },
+    "menu.splitVertical": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Split Vertically (Left/Right)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "垂直分割（左/右）"
+          }
+        }
+      }
+    },
+    "menu.terminal": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "终端"
+          }
+        }
+      }
+    },
+    "quickActions.builtin.claude": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Claude Code"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Claude Code"
+          }
+        }
+      }
+    },
+    "quickActions.builtin.codex": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codex"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codex"
+          }
+        }
+      }
+    },
+    "quickActions.builtin.gitui": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Git"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Git"
+          }
+        }
+      }
+    },
+    "quickActions.builtin.opencode": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OpenCode"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OpenCode"
+          }
+        }
+      }
+    },
+    "settings.appearance.backgroundBlur": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Background Blur"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "背景模糊"
+          }
+        }
+      }
+    },
+    "settings.appearance.backgroundOpacity": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Background Opacity"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "背景不透明度"
+          }
+        }
+      }
+    },
+    "settings.appearance.contentOpacity": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Content Opacity"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "内容不透明度"
+          }
+        }
+      }
+    },
+    "settings.appearance.contentShadow": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Content Shadow"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "内容阴影"
+          }
+        }
+      }
+    },
+    "settings.appearance.cursorBlink": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cursor Blink"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "光标闪烁"
+          }
+        }
+      }
+    },
+    "settings.appearance.cursorStyle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cursor Style"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "光标样式"
+          }
+        }
+      }
+    },
+    "settings.appearance.language": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Language"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "语言"
+          }
+        }
+      }
+    },
+    "settings.appearance.theme": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Theme"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "主题"
+          }
+        }
+      }
+    },
+    "settings.appearance.unfocusedPaneOpacity": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unfocused Pane Opacity"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "非聚焦窗格不透明度"
+          }
+        }
+      }
+    },
+    "settings.appearance.windowPaddingX": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Window Padding X"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "窗口内边距 X"
+          }
+        }
+      }
+    },
+    "settings.appearance.windowPaddingY": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Window Padding Y"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "窗口内边距 Y"
+          }
+        }
+      }
+    },
+    "settings.close": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close settings"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭设置"
+          }
+        }
+      }
+    },
+    "settings.font.custom": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Custom…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自定义…"
+          }
+        }
+      }
+    },
+    "settings.font.customPlaceholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Font name"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "字体名称"
+          }
+        }
+      }
+    },
+    "settings.font.default": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(default)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "（默认）"
+          }
+        }
+      }
+    },
+    "settings.font.family": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Font Family"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "字体"
+          }
+        }
+      }
+    },
+    "settings.font.listButton": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "List"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "列表"
+          }
+        }
+      }
+    },
+    "settings.font.size": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Font Size"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "字号"
+          }
+        }
+      }
+    },
+    "settings.font.thicken": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Font Thicken"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "加粗字体"
+          }
+        }
+      }
+    },
+    "settings.footer.edit": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit Config File…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "编辑配置文件…"
+          }
+        }
+      }
+    },
+    "settings.footer.live": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Changes apply live."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "修改即时生效。"
+          }
+        }
+      }
+    },
+    "settings.language.system": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "跟随系统"
+          }
+        }
+      }
+    },
+    "settings.quickActions.addCustomButton": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add Custom Action"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新建自定义快捷操作"
+          }
+        }
+      }
+    },
+    "settings.quickActions.customCommandPlaceholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Command"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "命令"
+          }
+        }
+      }
+    },
+    "settings.quickActions.customNamePlaceholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Name"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "名称"
+          }
+        }
+      }
+    },
+    "settings.quickActions.deleteCustom.tooltip": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete custom action"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除自定义快捷操作"
+          }
+        }
+      }
+    },
+    "settings.quickActions.heading": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enabled & Order"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启用与排序"
+          }
+        }
+      }
+    },
+    "settings.quickActions.headingFooter": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enabled buttons appear in the top-right corner of the window. Drag to reorder."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启用的按钮会按下方顺序出现在窗口右上角，可拖拽排序。"
+          }
+        }
+      }
+    },
+    "settings.reset.alertTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset these settings?"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置这些设置？"
+          }
+        }
+      }
+    },
+    "settings.reset.button": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置"
+          }
+        }
+      }
+    },
+    "settings.reset.cancel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
+          }
+        }
+      }
+    },
+    "settings.reset.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All settings in this section will revert to their defaults. You can still change them afterwards."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本分类下的所有设置将恢复为默认值，之后你仍可以修改。"
+          }
+        }
+      }
+    },
+    "settings.reset.rowLabel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore Defaults"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢复默认"
+          }
+        }
+      }
+    },
+    "settings.agents.betaBadge": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BETA"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BETA"
+          }
+        }
+      }
+    },
+    "settings.agents.codexAlertTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable Codex Experimental Hooks"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "需要开启 Codex 实验性 Hook"
+          }
+        }
+      }
+    },
+    "settings.agents.codexAlertMessage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codex hooks are gated behind an experimental flag. Add the following to ~/.codex/config.toml, then restart Codex:\n\n[features]\ncodex_hooks = true\n\nWithout this flag, Codex turn status will stay idle during running."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codex 的 hooks 是实验特性，默认关闭。请在 ~/.codex/config.toml 中加入下面内容，然后重启 Codex：\n\n[features]\ncodex_hooks = true\n\n未开启时 Codex 运行中状态会一直停留在 idle。"
+          }
+        }
+      }
+    },
+    "settings.agents.codexAlertOK": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Got it"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "我知道了"
+          }
+        }
+      }
+    },
+    "settings.agents.claude": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Claude Code"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Claude Code"
+          }
+        }
+      }
+    },
+    "settings.agents.codex": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codex"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codex"
+          }
+        }
+      }
+    },
+    "settings.agents.opencode": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OpenCode"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OpenCode"
+          }
+        }
+      }
+    },
+    "settings.agents.notificationsTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifications"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通知"
+          }
+        }
+      }
+    },
+    "settings.agents.notificationsFooter": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show running / idle / finished status icons next to tabs that run the selected agents."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在跑这些 agent 的 tab 旁显示运行 / 闲置 / 完成的状态图标。"
+          }
+        }
+      }
+    },
+    "settings.agents.resumeTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resume on Launch"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启动时恢复会话"
+          }
+        }
+      }
+    },
+    "settings.agents.resumeFooter": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "On next launch, auto-run `claude --resume <id>` / `codex resume <id>` to land back in the most recent session. Off by default. Turning a row off also drops any saved session id."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下次启动时自动执行 `claude --resume <id>` / `codex resume <id>`，回到最近一次的会话。默认关闭。关闭某一行同时会清除已保存的会话 id。"
+          }
+        }
+      }
+    },
+    "settings.section.agents": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agents"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agents"
+          }
+        }
+      }
+    },
+    "settings.section.appearance": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Appearance"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "外观"
+          }
+        }
+      }
+    },
+    "settings.section.font": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Font"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "字体"
+          }
+        }
+      }
+    },
+    "settings.section.quickActions": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quick Actions"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "快捷操作"
+          }
+        }
+      }
+    },
+    "settings.section.shell": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shell"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shell"
+          }
+        }
+      }
+    },
+    "settings.section.terminal": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "终端"
+          }
+        }
+      }
+    },
+    "settings.shell.customCommand": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Custom Command"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自定义命令"
+          }
+        }
+      }
+    },
+    "settings.shell.defaultPlaceholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(default shell)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "（默认 shell）"
+          }
+        }
+      }
+    },
+    "settings.shell.features": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Integration Features"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "集成特性"
+          }
+        }
+      }
+    },
+    "settings.shell.integration": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shell Integration"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shell 集成"
+          }
+        }
+      }
+    },
+    "settings.terminal.confirmClose": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirm Close"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭确认"
+          }
+        }
+      }
+    },
+    "settings.terminal.copyOnSelect": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy On Select"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选中即复制"
+          }
+        }
+      }
+    },
+    "settings.terminal.hideMouseWhileTyping": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide Mouse While Typing"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "键入时隐藏鼠标"
+          }
+        }
+      }
+    },
+    "settings.terminal.scrollbackLimit": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scrollback Limit"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "回滚缓冲大小"
+          }
+        }
+      }
+    },
+    "settings.theme.dark": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dark"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "深色"
+          }
+        }
+      }
+    },
+    "settings.theme.followSystem": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Follow system"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "跟随系统"
+          }
+        }
+      }
+    },
+    "settings.theme.light": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Light"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "浅色"
+          }
+        }
+      }
+    },
+    "settings.theme.name": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Theme Name"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "主题名称"
+          }
+        }
+      }
+    },
+    "settings.theme.searchPlaceholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search themes"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索主题"
+          }
+        }
+      }
+    },
+    "settings.theme.inherit": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inherit from Ghostty"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "继承 Ghostty（默认）"
+          }
+        }
+      }
+    },
+    "settings.theme.single": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Single"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "单主题"
+          }
+        }
+      }
+    },
+    "sidebar.deleteAlert.cancel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
+          }
+        }
+      }
+    },
+    "sidebar.deleteAlert.confirm": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除"
+          }
+        }
+      }
+    },
+    "sidebar.deleteAlert.message %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\"%@\" will be deleted with all its tabs. This action cannot be undone."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "「%@」及其所有 tab 将被删除，此操作不可撤销。"
+          }
+        }
+      }
+    },
+    "sidebar.deleteAlert.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete workspace?"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除 workspace？"
+          }
+        }
+      }
+    },
+    "sidebar.hide": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide sidebar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "收起侧栏"
+          }
+        }
+      }
+    },
+    "sidebar.newWorkspace": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New workspace"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新建 workspace"
+          }
+        }
+      }
+    },
+    "sidebar.row.delete": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除"
+          }
+        }
+      }
+    },
+    "sidebar.row.commandPanel.editTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit Default Command"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "编辑默认命令"
+          }
+        }
+      }
+    },
+    "sidebar.row.commandPanel.cancel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
+          }
+        }
+      }
+    },
+    "sidebar.row.commandPanel.placeholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "e.g. ssh user@server"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "例如 ssh user@server"
+          }
+        }
+      }
+    },
+    "sidebar.row.commandPanel.save": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存"
+          }
+        }
+      }
+    },
+    "sidebar.row.rename": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rename"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重命名"
+          }
+        }
+      }
+    },
+    "sidebar.settings": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置"
+          }
+        }
+      }
+    },
+    "sidebar.show": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show sidebar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "展开侧栏"
+          }
+        }
+      }
+    },
+    "sidebar.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mux0"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mux0"
+          }
+        }
+      }
+    },
+    "tab.close.alert.cancel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
+          }
+        }
+      }
+    },
+    "tab.close.alert.confirm": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭"
+          }
+        }
+      }
+    },
+    "tab.close.alert.message %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All terminal processes in \"%@\" will be terminated."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "「%@」中的所有终端进程将被终止。"
+          }
+        }
+      }
+    },
+    "tab.close.alert.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close tab?"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭 tab？"
+          }
+        }
+      }
+    },
+    "tab.newTab": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New tab"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新建 tab"
+          }
+        }
+      }
+    },
+    "tab.row.close": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭"
+          }
+        }
+      }
+    },
+    "tab.row.rename": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rename"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重命名"
+          }
+        }
+      }
+    },
+    "settings.section.update": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新"
+          }
+        }
+      }
+    },
+    "settings.update.action": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Action"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "操作"
+          }
+        }
+      }
+    },
+    "settings.update.availableUpdate": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Available Update"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可用更新"
+          }
+        }
+      }
+    },
+    "settings.update.checkForUpdates": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check for Updates"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查更新"
+          }
+        }
+      }
+    },
+    "settings.update.checking": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Checking…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查中…"
+          }
+        }
+      }
+    },
+    "settings.update.currentVersion": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Current Version"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当前版本"
+          }
+        }
+      }
+    },
+    "settings.update.debugBuild": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Debug Build"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Debug 构建"
+          }
+        }
+      }
+    },
+    "settings.update.debugDisabled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto-update disabled"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已禁用自动更新"
+          }
+        }
+      }
+    },
+    "settings.update.dismiss": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dismiss"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "稍后再说"
+          }
+        }
+      }
+    },
+    "settings.update.downloadInstall": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download & Install"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下载并安装"
+          }
+        }
+      }
+    },
+    "settings.update.downloading": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Downloading"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下载中"
+          }
+        }
+      }
+    },
+    "settings.update.error": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "错误"
+          }
+        }
+      }
+    },
+    "settings.update.installing": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installing & relaunching…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安装并重启中…"
+          }
+        }
+      }
+    },
+    "settings.update.releaseNotes": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Release Notes"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新说明"
+          }
+        }
+      }
+    },
+    "settings.update.retry": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retry"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重试"
+          }
+        }
+      }
+    },
+    "settings.update.skipThisVersion": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skip This Version"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "跳过此版本"
+          }
+        }
+      }
+    },
+    "settings.update.status": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Status"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "状态"
+          }
+        }
+      }
+    },
+    "settings.update.upToDate": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You're on the latest version."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已是最新版本。"
+          }
+        }
+      }
+    },
+    "settings.update.version %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "版本 %@"
+          }
+        }
+      }
+    },
+    "sidebar.checkForUpdates": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check for updates"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查更新"
+          }
+        }
+      }
+    },
+    "sidebar.updateAvailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update available"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有可用更新"
+          }
+        }
+      }
+    },
+    "tab.row.resetAutoTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset to auto title"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置为自动标题"
+          }
+        }
       }
     }
   },
-  "version" : "1.0"
+  "version": "1.0"
 }

--- a/mux0/Models/HookDispatcher.swift
+++ b/mux0/Models/HookDispatcher.swift
@@ -23,7 +23,7 @@ enum HookDispatcher {
         // disabled notifications but still wants auto-naming) are a real use
         // case; we don't second-guess.
         if let title = msg.sessionTitle, let titleStore = sessionTitleStore {
-            titleStore.update(terminalId: msg.terminalId, title: title)
+            titleStore.update(terminalId: msg.terminalId, title: title, at: msg.at)
         }
 
         // Resume is gated independently from the status (notifications)

--- a/mux0/Models/HookDispatcher.swift
+++ b/mux0/Models/HookDispatcher.swift
@@ -16,7 +16,16 @@ enum HookDispatcher {
     static func dispatch(_ msg: HookMessage,
                          settings: SettingsConfigStore,
                          store: TerminalStatusStore,
-                         workspaceStore: WorkspaceStore? = nil) {
+                         workspaceStore: WorkspaceStore? = nil,
+                         sessionTitleStore: TerminalSessionTitleStore? = nil) {
+        // Session title is independent of status / resume gating — once any
+        // agent hook emits it, the tab name follows. Title-only tabs (user
+        // disabled notifications but still wants auto-naming) are a real use
+        // case; we don't second-guess.
+        if let title = msg.sessionTitle, let titleStore = sessionTitleStore {
+            titleStore.update(terminalId: msg.terminalId, title: title)
+        }
+
         // Resume is gated independently from the status (notifications)
         // toggle: a user who only wants auto-resume but doesn't want the
         // running/idle icons should still get their session id persisted.

--- a/mux0/Models/HookMessage.swift
+++ b/mux0/Models/HookMessage.swift
@@ -59,6 +59,13 @@ struct HookMessage: Decodable, Equatable {
     /// triggered by `UserPromptSubmit`; mux0 records the most-recent value
     /// per terminal and replays it as the next-launch shell input.
     let resumeCommand: String?
+    /// Optional human-readable session title — e.g. Claude's `ai-title`
+    /// transcript entry, Codex's `threads.title` SQLite column, or
+    /// OpenCode's `session.title`. Emitted alongside `running` / `stop`
+    /// events. mux0 routes it into `TerminalSessionTitleStore`; empty
+    /// strings are dropped to avoid clobbering an already-known title with
+    /// a transient "title not yet generated" state.
+    let sessionTitle: String?
 
     var timestamp: Date { Date(timeIntervalSince1970: at) }
 }

--- a/mux0/Models/HookMessage.swift
+++ b/mux0/Models/HookMessage.swift
@@ -61,7 +61,7 @@ struct HookMessage: Decodable, Equatable {
     let resumeCommand: String?
     /// Optional human-readable session title — e.g. Claude's `ai-title`
     /// transcript entry, Codex's `threads.title` SQLite column, or
-    /// OpenCode's `session.title`. Emitted alongside `running` / `stop`
+    /// OpenCode's `session.title`. Emitted alongside `running` / `finished`
     /// events. mux0 routes it into `TerminalSessionTitleStore`; empty
     /// strings are dropped to avoid clobbering an already-known title with
     /// a transient "title not yet generated" state.

--- a/mux0/Models/TerminalSessionTitleStore.swift
+++ b/mux0/Models/TerminalSessionTitleStore.swift
@@ -50,6 +50,17 @@ final class TerminalSessionTitleStore {
         if changed { scheduleSave() }
     }
 
+    /// Snapshot of all titles keyed by `UUID`. The AppKit tab bar reads this
+    /// once per `update(...)` so the render path doesn't depend on Observable
+    /// tracking of the SwiftUI side.
+    func titlesSnapshot() -> [UUID: String] {
+        var out: [UUID: String] = [:]
+        for (k, v) in storage {
+            if let id = UUID(uuidString: k) { out[id] = v }
+        }
+        return out
+    }
+
     // MARK: - Persistence
 
     #if DEBUG

--- a/mux0/Models/TerminalSessionTitleStore.swift
+++ b/mux0/Models/TerminalSessionTitleStore.swift
@@ -13,6 +13,13 @@ import Observation
 @Observable
 final class TerminalSessionTitleStore {
     private var storage: [String: String] = [:]
+    /// Last accepted update timestamp per terminal (epoch seconds). NOT
+    /// persisted — on relaunch it starts empty so the first live hook always
+    /// wins over whatever title was restored from disk. Used to reject
+    /// out-of-order hook deliveries (e.g. a rotated session's trailing `stop`
+    /// landing after the next session's `prompt`), mirroring
+    /// `TerminalStatusStore`'s staleness guard.
+    private var lastAt: [String: TimeInterval] = [:]
     private let persistenceKey: String
     private var saveWorkItem: DispatchWorkItem?
 
@@ -28,16 +35,22 @@ final class TerminalSessionTitleStore {
     /// Write `title` for `terminalId`. Empty or whitespace-only inputs are
     /// dropped — agents emit empty strings before the LLM-generated title is
     /// materialized, and we don't want a transient empty state to wipe out
-    /// the previously known title.
-    func update(terminalId: UUID, title: String) {
+    /// the previously known title. `at` (the hook event timestamp) gates
+    /// out-of-order deliveries: an update older than the last accepted one
+    /// for the same terminal is ignored.
+    func update(terminalId: UUID, title: String, at: TimeInterval) {
         let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
-        guard storage[terminalId.uuidString] != trimmed else { return }
-        storage[terminalId.uuidString] = trimmed
+        let key = terminalId.uuidString
+        if let prev = lastAt[key], at < prev { return }
+        lastAt[key] = at
+        guard storage[key] != trimmed else { return }
+        storage[key] = trimmed
         scheduleSave()
     }
 
     func clear(terminalId: UUID) {
+        lastAt.removeValue(forKey: terminalId.uuidString)
         guard storage.removeValue(forKey: terminalId.uuidString) != nil else { return }
         scheduleSave()
     }
@@ -45,6 +58,7 @@ final class TerminalSessionTitleStore {
     func clear(terminalIds: [UUID]) {
         var changed = false
         for id in terminalIds {
+            lastAt.removeValue(forKey: id.uuidString)
             if storage.removeValue(forKey: id.uuidString) != nil { changed = true }
         }
         if changed { scheduleSave() }

--- a/mux0/Models/TerminalSessionTitleStore.swift
+++ b/mux0/Models/TerminalSessionTitleStore.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Observation
+
+/// Per-terminal human-readable agent session title, keyed by terminal UUID.
+/// Populated by `HookDispatcher` when an agent hook emits a `sessionTitle`
+/// field; consumed by `TabItemView` via `TerminalTab.displayTitle(store:)`.
+///
+/// Persisted to UserDefaults under `mux0.sessionTitles.v1` so that on app
+/// restart each tab can keep showing its previous title until the next hook
+/// emit refreshes it. Writes are debounced (300 ms) to match `TerminalPwdStore`'s
+/// pattern — title arrival typically happens once per turn, not per keystroke,
+/// but keeping the same debouncer keeps both stores' UserDefaults patterns aligned.
+@Observable
+final class TerminalSessionTitleStore {
+    private var storage: [String: String] = [:]
+    private let persistenceKey: String
+    private var saveWorkItem: DispatchWorkItem?
+
+    init(persistenceKey: String = "mux0.sessionTitles.v1") {
+        self.persistenceKey = persistenceKey
+        load()
+    }
+
+    func title(for terminalId: UUID) -> String? {
+        storage[terminalId.uuidString]
+    }
+
+    /// Write `title` for `terminalId`. Empty or whitespace-only inputs are
+    /// dropped — agents emit empty strings before the LLM-generated title is
+    /// materialized, and we don't want a transient empty state to wipe out
+    /// the previously known title.
+    func update(terminalId: UUID, title: String) {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        guard storage[terminalId.uuidString] != trimmed else { return }
+        storage[terminalId.uuidString] = trimmed
+        scheduleSave()
+    }
+
+    func clear(terminalId: UUID) {
+        guard storage.removeValue(forKey: terminalId.uuidString) != nil else { return }
+        scheduleSave()
+    }
+
+    func clear(terminalIds: [UUID]) {
+        var changed = false
+        for id in terminalIds {
+            if storage.removeValue(forKey: id.uuidString) != nil { changed = true }
+        }
+        if changed { scheduleSave() }
+    }
+
+    // MARK: - Persistence
+
+    #if DEBUG
+    func flushSaveForTesting() {
+        saveWorkItem?.cancel()
+        saveWorkItem = nil
+        save()
+    }
+    #endif
+
+    private func scheduleSave() {
+        saveWorkItem?.cancel()
+        let item = DispatchWorkItem { [weak self] in self?.save() }
+        saveWorkItem = item
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: item)
+    }
+
+    private func save() {
+        guard let data = try? JSONEncoder().encode(storage) else { return }
+        UserDefaults.standard.set(data, forKey: persistenceKey)
+    }
+
+    private func load() {
+        guard let data = UserDefaults.standard.data(forKey: persistenceKey),
+              let decoded = try? JSONDecoder().decode([String: String].self, from: data)
+        else { return }
+        storage = decoded
+    }
+}

--- a/mux0/Models/TerminalSessionTitleStore.swift
+++ b/mux0/Models/TerminalSessionTitleStore.swift
@@ -53,6 +53,7 @@ final class TerminalSessionTitleStore {
     // MARK: - Persistence
 
     #if DEBUG
+    /// Immediately flush any pending debounced save. Used only in tests.
     func flushSaveForTesting() {
         saveWorkItem?.cancel()
         saveWorkItem = nil

--- a/mux0/Models/Workspace.swift
+++ b/mux0/Models/Workspace.swift
@@ -137,14 +137,63 @@ struct TerminalTab: Codable, Identifiable, Equatable {
     /// this id via `QuickActionsStore.command(for:)` and injects the result
     /// as the surface's initial_input.
     var quickActionId: String? = nil
+    /// True once the user has manually renamed this tab (inline rename UI).
+    /// When true, `displayTitle` returns `title` unconditionally — auto
+    /// session titles from `TerminalSessionTitleStore` are ignored. Reset
+    /// via `WorkspaceStore.resetTabToAutoTitle` (right-click → "Reset to
+    /// auto title"). Defaults to false; old persisted data without this
+    /// field decodes as false (legacy tabs re-enter auto mode).
+    var userRenamed: Bool = false
 
     init(id: UUID = UUID(), title: String, terminalId: UUID = UUID(),
-         quickActionId: String? = nil) {
+         quickActionId: String? = nil, userRenamed: Bool = false) {
         self.id = id
         self.title = title
         self.layout = .terminal(terminalId)
         self.focusedTerminalId = terminalId
         self.quickActionId = quickActionId
+        self.userRenamed = userRenamed
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, title, layout, focusedTerminalId, quickActionId, userRenamed
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try c.decode(UUID.self, forKey: .id)
+        self.title = try c.decode(String.self, forKey: .title)
+        self.layout = try c.decode(SplitNode.self, forKey: .layout)
+        self.focusedTerminalId = try c.decode(UUID.self, forKey: .focusedTerminalId)
+        self.quickActionId = try c.decodeIfPresent(String.self, forKey: .quickActionId)
+        self.userRenamed = try c.decodeIfPresent(Bool.self, forKey: .userRenamed) ?? false
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(id, forKey: .id)
+        try c.encode(title, forKey: .title)
+        try c.encode(layout, forKey: .layout)
+        try c.encode(focusedTerminalId, forKey: .focusedTerminalId)
+        try c.encodeIfPresent(quickActionId, forKey: .quickActionId)
+        try c.encode(userRenamed, forKey: .userRenamed)
+    }
+
+    /// Resolve the title shown in the tab bar. Priority:
+    /// 1. User manually renamed → `title` (hard lock, ignores store)
+    /// 2. `sessionTitleStore[focusedTerminalId]` is non-nil → that
+    /// 3. Fallback → `title` (creation-time default like "Terminal 1" /
+    ///    quick action displayName)
+    ///
+    /// Tracks the focused pane, so split tabs switch label as the user
+    /// moves focus between panes. Shell pane (no agent session) falls
+    /// through to step 3 rather than retaining the previous agent pane's title.
+    func displayTitle(sessionTitleStore: TerminalSessionTitleStore) -> String {
+        if userRenamed { return title }
+        if let auto = sessionTitleStore.title(for: focusedTerminalId), !auto.isEmpty {
+            return auto
+        }
+        return title
     }
 }
 

--- a/mux0/Models/WorkspaceStore.swift
+++ b/mux0/Models/WorkspaceStore.swift
@@ -8,6 +8,13 @@ final class WorkspaceStore {
     private let persistenceKey: String
     private var saveWorkItem: DispatchWorkItem?  // debounce rapid ratio updates
 
+    /// Optional link to the session title store so close/remove paths can
+    /// purge stale `terminalId → title` mappings. Wired by `ContentView` at
+    /// app startup. Tests can construct a `WorkspaceStore` without it; in
+    /// production the store has app-lifetime ownership in ContentView so
+    /// `weak` is safe and prevents retain cycles.
+    weak var sessionTitleStore: TerminalSessionTitleStore?
+
     init(persistenceKey: String = "mux0.workspaces.v2") {
         self.persistenceKey = persistenceKey
         load()
@@ -38,6 +45,10 @@ final class WorkspaceStore {
     }
 
     func deleteWorkspace(id: UUID) {
+        if let wsIdx = wsIndex(id) {
+            let allLeaves = workspaces[wsIdx].tabs.flatMap { $0.layout.allTerminalIds() }
+            sessionTitleStore?.clear(terminalIds: allLeaves)
+        }
         workspaces.removeAll { $0.id == id }
         if selectedId == id { selectedId = workspaces.first?.id }
         save()
@@ -119,9 +130,11 @@ final class WorkspaceStore {
         // Find the index before removal so we can select the adjacent tab
         let closedIdx = workspaces[wsIdx].tabs.firstIndex(where: { $0.id == id })
         if let tIdx = closedIdx {
-            for tid in workspaces[wsIdx].tabs[tIdx].layout.allTerminalIds() {
+            let leafIds = workspaces[wsIdx].tabs[tIdx].layout.allTerminalIds()
+            for tid in leafIds {
                 workspaces[wsIdx].pendingPrefills.removeValue(forKey: tid.uuidString)
             }
+            sessionTitleStore?.clear(terminalIds: leafIds)
         }
         workspaces[wsIdx].tabs.removeAll { $0.id == id }
         if workspaces[wsIdx].tabs.isEmpty {
@@ -147,9 +160,30 @@ final class WorkspaceStore {
         let trimmed = newTitle.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty,
               let wsIdx = wsIndex(workspaceId),
-              let tIdx = tabIndex(id, in: wsIdx),
-              workspaces[wsIdx].tabs[tIdx].title != trimmed else { return }
-        workspaces[wsIdx].tabs[tIdx].title = trimmed
+              let tIdx = tabIndex(id, in: wsIdx) else { return }
+        // Always set userRenamed=true (even if title unchanged) — the user
+        // explicitly hit enter on the rename UI, signaling intent to lock.
+        var changed = false
+        if workspaces[wsIdx].tabs[tIdx].title != trimmed {
+            workspaces[wsIdx].tabs[tIdx].title = trimmed
+            changed = true
+        }
+        if !workspaces[wsIdx].tabs[tIdx].userRenamed {
+            workspaces[wsIdx].tabs[tIdx].userRenamed = true
+            changed = true
+        }
+        if changed { save() }
+    }
+
+    /// Clear the manual-rename lock on a tab. After this, the tab falls
+    /// back to the auto title chain (`TerminalSessionTitleStore[focused]`
+    /// → tab.title). `title` itself is left as-is; next agent hook emit
+    /// will overwrite the displayed value via the store.
+    func resetTabToAutoTitle(tabId: UUID, in workspaceId: UUID) {
+        guard let wsIdx = wsIndex(workspaceId),
+              let tIdx = tabIndex(tabId, in: wsIdx),
+              workspaces[wsIdx].tabs[tIdx].userRenamed else { return }
+        workspaces[wsIdx].tabs[tIdx].userRenamed = false
         save()
     }
 
@@ -207,6 +241,7 @@ final class WorkspaceStore {
         if let newLayout = tab.layout.removing(terminalId: terminalId) {
             workspaces[wsIdx].tabs[tIdx].layout = newLayout
             workspaces[wsIdx].pendingPrefills.removeValue(forKey: terminalId.uuidString)
+            sessionTitleStore?.clear(terminalId: terminalId)
             if tab.focusedTerminalId == terminalId {
                 // Safe: newLayout is non-nil so it contains at least one terminal
                 workspaces[wsIdx].tabs[tIdx].focusedTerminalId =

--- a/mux0/TabContent/TabBarView.swift
+++ b/mux0/TabContent/TabBarView.swift
@@ -12,6 +12,7 @@ final class TabBarView: NSView {
     /// (fromIndex, toIndex) 采用 insertion-index 语义（0…count），
     /// 与 `WorkspaceStore.moveTab(fromIndex:toIndex:in:)` 对齐
     var onReorderTab: ((Int, Int) -> Void)?
+    var onResetAutoTitle: ((UUID) -> Void)?
     /// 若 tab 总数 ≤ 1，TabItemView 禁用 × 按钮与菜单 Close 项
     private var canClose: Bool { tabs.count > 1 }
 
@@ -34,6 +35,7 @@ final class TabBarView: NSView {
     private var tabs: [TerminalTab] = []
     private var selectedTabId: UUID?
     private var statuses: [UUID: TerminalStatus] = [:]
+    private var sessionTitles: [UUID: String] = [:]
     private var showStatusIndicators: Bool = false
     /// Source for tab pill icon rendering (Quick Action ids → SF Symbol /
     /// asset / letter). TabContentView wires this in via setter; TabItemView
@@ -108,16 +110,29 @@ final class TabBarView: NSView {
                 selectedTabId: UUID?,
                 theme: AppTheme,
                 statuses: [UUID: TerminalStatus] = [:],
+                sessionTitles: [UUID: String] = [:],
                 backgroundOpacity: CGFloat = 1.0,
                 showStatusIndicators: Bool = false) {
         self.tabs = tabs
         self.selectedTabId = selectedTabId
         self.theme = theme
         self.statuses = statuses
+        self.sessionTitles = sessionTitles
         self.backgroundOpacity = backgroundOpacity
         self.showStatusIndicators = showStatusIndicators
         rebuildTabItems()   // tab items are already initialised with correct theme
         applyTheme(theme, backgroundOpacity: backgroundOpacity)   // re-apply theme to non-tab elements (layer bg, addButton tint)
+    }
+
+    /// Display title with same 3-step priority as `TerminalTab.displayTitle(store:)`,
+    /// but reads from the snapshot dictionary we receive in `update`. Kept inline
+    /// so the AppKit view doesn't need to hold a store reference.
+    private func displayTitle(for tab: TerminalTab) -> String {
+        if tab.userRenamed { return tab.title }
+        if let auto = sessionTitles[tab.focusedTerminalId], !auto.isEmpty {
+            return auto
+        }
+        return tab.title
     }
 
     /// 复用现有 TabItemView——仅在 tabs 的 id 序列变化时才完整重建。
@@ -140,7 +155,10 @@ final class TabBarView: NSView {
                     let tabStatus = TerminalStatus.aggregate(
                         tab.layout.allTerminalIds().map { statuses[$0] ?? .neverRan }
                     )
-                    item.refresh(tab: tab, isSelected: isSel, theme: theme, canClose: canCloseNow, status: tabStatus, backgroundOpacity: backgroundOpacity, showStatusIndicators: showStatusIndicators)
+                    item.refresh(tab: tab, isSelected: isSel, theme: theme, canClose: canCloseNow,
+                                 status: tabStatus, backgroundOpacity: backgroundOpacity,
+                                 showStatusIndicators: showStatusIndicators,
+                                 displayTitle: displayTitle(for: tab))
                 }
             }
             return
@@ -152,11 +170,16 @@ final class TabBarView: NSView {
             let tabStatus = TerminalStatus.aggregate(
                 tab.layout.allTerminalIds().map { statuses[$0] ?? .neverRan }
             )
-            let item = TabItemView(tab: tab, isSelected: tab.id == selectedTabId, theme: theme, status: tabStatus, backgroundOpacity: backgroundOpacity, showStatusIndicators: showStatusIndicators, quickActionsStore: quickActionsStore)
+            let item = TabItemView(tab: tab, isSelected: tab.id == selectedTabId, theme: theme,
+                                   status: tabStatus, backgroundOpacity: backgroundOpacity,
+                                   showStatusIndicators: showStatusIndicators,
+                                   quickActionsStore: quickActionsStore,
+                                   displayTitle: displayTitle(for: tab))
             item.canClose = canCloseNow
             item.onSelect = { [weak self] in self?.onSelectTab?(tab.id) }
             item.onClose  = { [weak self] in self?.onCloseTab?(tab.id) }
             item.onRename = { [weak self] newTitle in self?.onRenameTab?(tab.id, newTitle) }
+            item.onResetAutoTitle = { [weak self] in self?.onResetAutoTitle?(tab.id) }
             // drop 失败（拖到 TabBarView 外）时，source 端 sessionEnded 会触发——清理 preview state
             item.onDragEnded = { [weak self] in self?.cleanupAfterDrag() }
             tabsContainer.addSubview(item)
@@ -341,9 +364,11 @@ private final class TabItemView: NSView, NSTextFieldDelegate, NSDraggingSource {
     var onSelect: (() -> Void)?
     var onClose:  (() -> Void)?
     var onRename: ((String) -> Void)?
+    var onResetAutoTitle: (() -> Void)?
     /// 在 drag session 结束时（无论是否成功 drop）调用——用来让 TabBarView 清除 preview 状态。
     var onDragEnded: (() -> Void)?
     var canClose: Bool = true
+    private var userRenamed: Bool = false
 
     /// 拖拽 preview 中被拖 item 的 "占位" 显示——淡化 alpha 暗示它会被移走。
     var isDragGhost: Bool = false {
@@ -378,7 +403,9 @@ private final class TabItemView: NSView, NSTextFieldDelegate, NSDraggingSource {
         didSet { applyQuickActionImage(displayedQuickActionId) }
     }
 
-    init(tab: TerminalTab, isSelected: Bool, theme: AppTheme, status: TerminalStatus = .neverRan, backgroundOpacity: CGFloat = 1.0, showStatusIndicators: Bool = false, quickActionsStore: QuickActionsStore? = nil) {
+    init(tab: TerminalTab, isSelected: Bool, theme: AppTheme, status: TerminalStatus = .neverRan,
+         backgroundOpacity: CGFloat = 1.0, showStatusIndicators: Bool = false,
+         quickActionsStore: QuickActionsStore? = nil, displayTitle: String) {
         self.tabId = tab.id
         self.isSelected = isSelected
         self.theme = theme
@@ -388,7 +415,8 @@ private final class TabItemView: NSView, NSTextFieldDelegate, NSDraggingSource {
         self.quickActionsStore = quickActionsStore
         super.init(frame: .zero)
         self.showStatusIndicators = showStatusIndicators
-        titleLabel.stringValue = tab.title
+        self.userRenamed = tab.userRenamed
+        titleLabel.stringValue = displayTitle
         setup()
         applyQuickActionImage(tab.quickActionId)
         updateStyle()
@@ -542,14 +570,16 @@ private final class TabItemView: NSView, NSTextFieldDelegate, NSDraggingSource {
     func refresh(tab: TerminalTab, isSelected: Bool, theme: AppTheme,
                  canClose: Bool, status: TerminalStatus = .neverRan,
                  backgroundOpacity: CGFloat = 1.0,
-                 showStatusIndicators: Bool = false) {
+                 showStatusIndicators: Bool = false,
+                 displayTitle: String) {
         self.theme = theme
         self.backgroundOpacity = backgroundOpacity
         self.isSelected = isSelected
         self.canClose = canClose
         self.status = status
-        if titleLabel.stringValue != tab.title && !isRenaming {
-            titleLabel.stringValue = tab.title
+        self.userRenamed = tab.userRenamed
+        if titleLabel.stringValue != displayTitle && !isRenaming {
+            titleLabel.stringValue = displayTitle
         }
         if displayedQuickActionId != tab.quickActionId {
             displayedQuickActionId = tab.quickActionId
@@ -753,8 +783,18 @@ private final class TabItemView: NSView, NSTextFieldDelegate, NSDraggingSource {
         closeItem.isEnabled = canClose
         menu.addItem(closeItem)
 
+        if userRenamed {
+            menu.addItem(.separator())
+            let resetItem = NSMenuItem(title: L10n.string("tab.row.resetAutoTitle"),
+                                       action: #selector(resetAutoTitleTapped),
+                                       keyEquivalent: "")
+            resetItem.target = self
+            menu.addItem(resetItem)
+        }
+
         NSMenu.popUpContextMenu(menu, with: event, for: self)
     }
 
     @objc private func closeTapped() { onClose?() }
+    @objc private func resetAutoTitleTapped() { onResetAutoTitle?() }
 }

--- a/mux0/TabContent/TabBarView.swift
+++ b/mux0/TabContent/TabBarView.swift
@@ -774,6 +774,15 @@ private final class TabItemView: NSView, NSTextFieldDelegate, NSDraggingSource {
         renameItem.target = self
         menu.addItem(renameItem)
 
+        // Reset belongs visually next to Rename — it's the undo for it.
+        if userRenamed {
+            let resetItem = NSMenuItem(title: L10n.string("tab.row.resetAutoTitle"),
+                                       action: #selector(resetAutoTitleTapped),
+                                       keyEquivalent: "")
+            resetItem.target = self
+            menu.addItem(resetItem)
+        }
+
         menu.addItem(.separator())
 
         let closeItem = NSMenuItem(title: L10n.string("tab.row.close"),
@@ -782,15 +791,6 @@ private final class TabItemView: NSView, NSTextFieldDelegate, NSDraggingSource {
         closeItem.target = self
         closeItem.isEnabled = canClose
         menu.addItem(closeItem)
-
-        if userRenamed {
-            menu.addItem(.separator())
-            let resetItem = NSMenuItem(title: L10n.string("tab.row.resetAutoTitle"),
-                                       action: #selector(resetAutoTitleTapped),
-                                       keyEquivalent: "")
-            resetItem.target = self
-            menu.addItem(resetItem)
-        }
 
         NSMenu.popUpContextMenu(menu, with: event, for: self)
     }

--- a/mux0/TabContent/TabContentView.swift
+++ b/mux0/TabContent/TabContentView.swift
@@ -37,6 +37,10 @@ final class TabContentView: NSView {
     var quickActionsStore: QuickActionsStore? {
         didSet { tabBar.quickActionsStore = quickActionsStore }
     }
+    /// Agent session titles keyed by terminal UUID. Snapshot is forwarded to
+    /// `TabBarView.update` on every `loadWorkspace` call so the tab strip shows
+    /// agent-generated titles without requiring Observable tracking on the AppKit side.
+    var sessionTitleStore: TerminalSessionTitleStore?
 
     private var theme: AppTheme = .systemFallback(isDark: true)
     /// Mirror of ghostty `background-opacity`. Applied to paneContainer's layer so
@@ -107,6 +111,11 @@ final class TabContentView: NSView {
             self.store?.moveTab(fromIndex: fromIndex, toIndex: toIndex, in: wsId)
             self.reloadFromStore()
         }
+        tabBar.onResetAutoTitle = { [weak self] tabId in
+            guard let self, let ws = self.store?.selectedWorkspace else { return }
+            self.store?.resetTabToAutoTitle(tabId: tabId, in: ws.id)
+            self.reloadFromStore()
+        }
 
         subscribeNotifications()
         installKeyMonitor()
@@ -159,6 +168,7 @@ final class TabContentView: NSView {
                       selectedTabId: workspace.selectedTabId,
                       theme: theme,
                       statuses: self.lastStatuses,
+                      sessionTitles: sessionTitleStore?.titlesSnapshot() ?? [:],
                       backgroundOpacity: backgroundOpacity,
                       showStatusIndicators: self.lastShowStatusIndicators)
 

--- a/mux0Tests/HookDispatcherSessionTitleTests.swift
+++ b/mux0Tests/HookDispatcherSessionTitleTests.swift
@@ -52,7 +52,7 @@ final class HookDispatcherSessionTitleTests: XCTestCase {
     func testSkipsWhenSessionTitleNil() {
         settings.set(HookMessage.Agent.claude.settingsKey, "true")
         settings.save()
-        titleStore.update(terminalId: tid, title: "Previous")
+        titleStore.update(terminalId: tid, title: "Previous", at: 1)
         HookDispatcher.dispatch(makeMsg(sessionTitle: nil),
                                 settings: settings, store: statusStore,
                                 sessionTitleStore: titleStore)

--- a/mux0Tests/HookDispatcherSessionTitleTests.swift
+++ b/mux0Tests/HookDispatcherSessionTitleTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import mux0
+
+final class HookDispatcherSessionTitleTests: XCTestCase {
+
+    private var tmpConfigPath: String!
+    private var settings: SettingsConfigStore!
+    private var statusStore: TerminalStatusStore!
+    private var titleStore: TerminalSessionTitleStore!
+    private let tid = UUID()
+
+    override func setUpWithError() throws {
+        tmpConfigPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mux0-dispatch-\(UUID().uuidString).conf").path
+        settings = SettingsConfigStore(filePath: tmpConfigPath)
+        statusStore = TerminalStatusStore()
+        titleStore = TerminalSessionTitleStore(persistenceKey: "test-\(UUID())")
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(atPath: tmpConfigPath)
+    }
+
+    private func makeMsg(sessionTitle: String?) -> HookMessage {
+        var fields = #"{"terminalId":"\#(tid.uuidString)","event":"running","agent":"claude","at":1.0"#
+        if let t = sessionTitle {
+            fields += #","sessionTitle":"\#(t)""#
+        }
+        fields += "}"
+        return try! JSONDecoder().decode(HookMessage.self, from: Data(fields.utf8))
+    }
+
+    func testRoutesSessionTitleWhenAgentEnabled() {
+        settings.set(HookMessage.Agent.claude.settingsKey, "true")
+        settings.save()
+        HookDispatcher.dispatch(makeMsg(sessionTitle: "Doing the thing"),
+                                settings: settings, store: statusStore,
+                                sessionTitleStore: titleStore)
+        XCTAssertEqual(titleStore.title(for: tid), "Doing the thing")
+    }
+
+    func testRoutesSessionTitleEvenWhenStatusAgentDisabled() {
+        // Title is independent of the per-agent "status notifications" toggle —
+        // tab naming is unconditional once the field arrives.
+        // (No settings.set — agent NOT enabled.)
+        HookDispatcher.dispatch(makeMsg(sessionTitle: "Still applies"),
+                                settings: settings, store: statusStore,
+                                sessionTitleStore: titleStore)
+        XCTAssertEqual(titleStore.title(for: tid), "Still applies")
+    }
+
+    func testSkipsWhenSessionTitleNil() {
+        settings.set(HookMessage.Agent.claude.settingsKey, "true")
+        settings.save()
+        titleStore.update(terminalId: tid, title: "Previous")
+        HookDispatcher.dispatch(makeMsg(sessionTitle: nil),
+                                settings: settings, store: statusStore,
+                                sessionTitleStore: titleStore)
+        XCTAssertEqual(titleStore.title(for: tid), "Previous",
+                       "nil sessionTitle should not clobber existing value")
+    }
+}

--- a/mux0Tests/HookDispatcherTests.swift
+++ b/mux0Tests/HookDispatcherTests.swift
@@ -256,7 +256,8 @@ final class HookDispatcherTests: XCTestCase {
         let term = wsStore.workspaces[0].tabs[0].layout.allTerminalIds()[0]
         let msg = HookMessage(terminalId: term, event: .running, agent: .claude,
                               at: 1, exitCode: nil, toolDetail: nil,
-                              summary: nil, resumeCommand: "claude --resume abc")
+                              summary: nil, resumeCommand: "claude --resume abc",
+                              sessionTitle: nil)
 
         HookDispatcher.dispatch(msg, settings: settings, store: store,
                                 workspaceStore: wsStore)
@@ -276,7 +277,8 @@ final class HookDispatcherTests: XCTestCase {
         let term = wsStore.workspaces[0].tabs[0].layout.allTerminalIds()[0]
         let msg = HookMessage(terminalId: term, event: .running, agent: .claude,
                               at: 1, exitCode: nil, toolDetail: nil,
-                              summary: nil, resumeCommand: "claude --resume abc")
+                              summary: nil, resumeCommand: "claude --resume abc",
+                              sessionTitle: nil)
 
         HookDispatcher.dispatch(msg, settings: settings, store: store,
                                 workspaceStore: wsStore)
@@ -296,7 +298,8 @@ final class HookDispatcherTests: XCTestCase {
         let term = wsStore.workspaces[0].tabs[0].layout.allTerminalIds()[0]
         let msg = HookMessage(terminalId: term, event: .running, agent: .claude,
                               at: 1, exitCode: nil, toolDetail: nil,
-                              summary: nil, resumeCommand: "claude --resume abc")
+                              summary: nil, resumeCommand: "claude --resume abc",
+                              sessionTitle: nil)
 
         HookDispatcher.dispatch(msg, settings: settings, store: store,
                                 workspaceStore: wsStore)

--- a/mux0Tests/HookMessageTests.swift
+++ b/mux0Tests/HookMessageTests.swift
@@ -86,4 +86,20 @@ final class HookMessageTests: XCTestCase {
         XCTAssertEqual(HookMessage.Agent.codex.settingsKey,    "mux0-agent-status-codex")
         XCTAssertEqual(HookMessage.Agent.opencode.settingsKey, "mux0-agent-status-opencode")
     }
+
+    func testDecodesSessionTitle() throws {
+        let json = #"""
+        {"terminalId":"\#(UUID().uuidString)","event":"running","agent":"claude","at":1.0,"sessionTitle":"Implement auto-naming"}
+        """#
+        let msg = try JSONDecoder().decode(HookMessage.self, from: Data(json.utf8))
+        XCTAssertEqual(msg.sessionTitle, "Implement auto-naming")
+    }
+
+    func testSessionTitleMissingIsNil() throws {
+        let json = #"""
+        {"terminalId":"\#(UUID().uuidString)","event":"running","agent":"claude","at":1.0}
+        """#
+        let msg = try JSONDecoder().decode(HookMessage.self, from: Data(json.utf8))
+        XCTAssertNil(msg.sessionTitle)
+    }
 }

--- a/mux0Tests/L10nSmokeTests.swift
+++ b/mux0Tests/L10nSmokeTests.swift
@@ -153,6 +153,7 @@ final class L10nSmokeTests: XCTestCase {
         "tab.newTab",
         "tab.row.close",
         "tab.row.rename",
+        "tab.row.resetAutoTitle",
     ]
 
     override func tearDown() {

--- a/mux0Tests/TerminalSessionTitleStoreTests.swift
+++ b/mux0Tests/TerminalSessionTitleStoreTests.swift
@@ -11,30 +11,30 @@ final class TerminalSessionTitleStoreTests: XCTestCase {
     func testUpdateStoresValue() {
         let store = TerminalSessionTitleStore(persistenceKey: "test-\(UUID())")
         let id = UUID()
-        store.update(terminalId: id, title: "Hello")
+        store.update(terminalId: id, title: "Hello", at: 1)
         XCTAssertEqual(store.title(for: id), "Hello")
     }
 
     func testUpdateEmptyStringIsIgnored() {
         let store = TerminalSessionTitleStore(persistenceKey: "test-\(UUID())")
         let id = UUID()
-        store.update(terminalId: id, title: "Real title")
-        store.update(terminalId: id, title: "")
+        store.update(terminalId: id, title: "Real title", at: 1)
+        store.update(terminalId: id, title: "", at: 2)
         XCTAssertEqual(store.title(for: id), "Real title")
     }
 
     func testUpdateWhitespaceOnlyIsIgnored() {
         let store = TerminalSessionTitleStore(persistenceKey: "test-\(UUID())")
         let id = UUID()
-        store.update(terminalId: id, title: "Real")
-        store.update(terminalId: id, title: "   \n")
+        store.update(terminalId: id, title: "Real", at: 1)
+        store.update(terminalId: id, title: "   \n", at: 2)
         XCTAssertEqual(store.title(for: id), "Real")
     }
 
     func testClearRemovesValue() {
         let store = TerminalSessionTitleStore(persistenceKey: "test-\(UUID())")
         let id = UUID()
-        store.update(terminalId: id, title: "X")
+        store.update(terminalId: id, title: "X", at: 1)
         store.clear(terminalId: id)
         XCTAssertNil(store.title(for: id))
     }
@@ -42,9 +42,9 @@ final class TerminalSessionTitleStoreTests: XCTestCase {
     func testClearMultipleRemovesAll() {
         let store = TerminalSessionTitleStore(persistenceKey: "test-\(UUID())")
         let a = UUID(); let b = UUID(); let c = UUID()
-        store.update(terminalId: a, title: "A")
-        store.update(terminalId: b, title: "B")
-        store.update(terminalId: c, title: "C")
+        store.update(terminalId: a, title: "A", at: 1)
+        store.update(terminalId: b, title: "B", at: 1)
+        store.update(terminalId: c, title: "C", at: 1)
         store.clear(terminalIds: [a, c])
         XCTAssertNil(store.title(for: a))
         XCTAssertEqual(store.title(for: b), "B")
@@ -55,7 +55,7 @@ final class TerminalSessionTitleStoreTests: XCTestCase {
         let key = "test-\(UUID())"
         let id = UUID()
         let store = TerminalSessionTitleStore(persistenceKey: key)
-        store.update(terminalId: id, title: "Persisted")
+        store.update(terminalId: id, title: "Persisted", at: 1)
         store.flushSaveForTesting()
 
         let store2 = TerminalSessionTitleStore(persistenceKey: key)
@@ -69,8 +69,38 @@ final class TerminalSessionTitleStoreTests: XCTestCase {
         let key = "test-\(UUID())"
         let id = UUID()
         let store = TerminalSessionTitleStore(persistenceKey: key)
-        store.update(terminalId: id, title: "Stable")
-        store.update(terminalId: id, title: "Stable")
+        store.update(terminalId: id, title: "Stable", at: 1)
+        store.update(terminalId: id, title: "Stable", at: 2)
         XCTAssertEqual(store.title(for: id), "Stable")
+    }
+
+    func testOlderTimestampIsRejected() {
+        // An out-of-order hook delivery (e.g. a rotated session's trailing
+        // `stop` landing after the next session's `prompt`) must not revert
+        // the tab to a stale title.
+        let store = TerminalSessionTitleStore(persistenceKey: "test-\(UUID())")
+        let id = UUID()
+        store.update(terminalId: id, title: "newer", at: 20)
+        store.update(terminalId: id, title: "older", at: 10)
+        XCTAssertEqual(store.title(for: id), "newer")
+    }
+
+    func testEqualTimestampIsAccepted() {
+        // Same-turn prompt + stop share the wrapper clock granularity; an
+        // equal timestamp must still be allowed to update (not treated stale).
+        let store = TerminalSessionTitleStore(persistenceKey: "test-\(UUID())")
+        let id = UUID()
+        store.update(terminalId: id, title: "first", at: 5)
+        store.update(terminalId: id, title: "second", at: 5)
+        XCTAssertEqual(store.title(for: id), "second")
+    }
+
+    func testTimestampIsPerTerminal() {
+        // A high timestamp on terminal A must not block a low timestamp on B.
+        let store = TerminalSessionTitleStore(persistenceKey: "test-\(UUID())")
+        let a = UUID(); let b = UUID()
+        store.update(terminalId: a, title: "A", at: 100)
+        store.update(terminalId: b, title: "B", at: 1)
+        XCTAssertEqual(store.title(for: b), "B")
     }
 }

--- a/mux0Tests/TerminalSessionTitleStoreTests.swift
+++ b/mux0Tests/TerminalSessionTitleStoreTests.swift
@@ -62,4 +62,15 @@ final class TerminalSessionTitleStoreTests: XCTestCase {
         XCTAssertEqual(store2.title(for: id), "Persisted")
         UserDefaults.standard.removeObject(forKey: key)
     }
+
+    func testUpdateSameValueIsIdempotent() {
+        // Equality guard exists to avoid spurious debounced writes when an
+        // agent hook fires the same title repeatedly (e.g. one per turn).
+        let key = "test-\(UUID())"
+        let id = UUID()
+        let store = TerminalSessionTitleStore(persistenceKey: key)
+        store.update(terminalId: id, title: "Stable")
+        store.update(terminalId: id, title: "Stable")
+        XCTAssertEqual(store.title(for: id), "Stable")
+    }
 }

--- a/mux0Tests/TerminalSessionTitleStoreTests.swift
+++ b/mux0Tests/TerminalSessionTitleStoreTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import mux0
+
+final class TerminalSessionTitleStoreTests: XCTestCase {
+
+    func testDefaultIsEmpty() {
+        let store = TerminalSessionTitleStore(persistenceKey: "test-\(UUID())")
+        XCTAssertNil(store.title(for: UUID()))
+    }
+
+    func testUpdateStoresValue() {
+        let store = TerminalSessionTitleStore(persistenceKey: "test-\(UUID())")
+        let id = UUID()
+        store.update(terminalId: id, title: "Hello")
+        XCTAssertEqual(store.title(for: id), "Hello")
+    }
+
+    func testUpdateEmptyStringIsIgnored() {
+        let store = TerminalSessionTitleStore(persistenceKey: "test-\(UUID())")
+        let id = UUID()
+        store.update(terminalId: id, title: "Real title")
+        store.update(terminalId: id, title: "")
+        XCTAssertEqual(store.title(for: id), "Real title")
+    }
+
+    func testUpdateWhitespaceOnlyIsIgnored() {
+        let store = TerminalSessionTitleStore(persistenceKey: "test-\(UUID())")
+        let id = UUID()
+        store.update(terminalId: id, title: "Real")
+        store.update(terminalId: id, title: "   \n")
+        XCTAssertEqual(store.title(for: id), "Real")
+    }
+
+    func testClearRemovesValue() {
+        let store = TerminalSessionTitleStore(persistenceKey: "test-\(UUID())")
+        let id = UUID()
+        store.update(terminalId: id, title: "X")
+        store.clear(terminalId: id)
+        XCTAssertNil(store.title(for: id))
+    }
+
+    func testClearMultipleRemovesAll() {
+        let store = TerminalSessionTitleStore(persistenceKey: "test-\(UUID())")
+        let a = UUID(); let b = UUID(); let c = UUID()
+        store.update(terminalId: a, title: "A")
+        store.update(terminalId: b, title: "B")
+        store.update(terminalId: c, title: "C")
+        store.clear(terminalIds: [a, c])
+        XCTAssertNil(store.title(for: a))
+        XCTAssertEqual(store.title(for: b), "B")
+        XCTAssertNil(store.title(for: c))
+    }
+
+    func testPersistenceRoundtrip() {
+        let key = "test-\(UUID())"
+        let id = UUID()
+        let store = TerminalSessionTitleStore(persistenceKey: key)
+        store.update(terminalId: id, title: "Persisted")
+        store.flushSaveForTesting()
+
+        let store2 = TerminalSessionTitleStore(persistenceKey: key)
+        XCTAssertEqual(store2.title(for: id), "Persisted")
+        UserDefaults.standard.removeObject(forKey: key)
+    }
+}

--- a/mux0Tests/TerminalTabDisplayTitleTests.swift
+++ b/mux0Tests/TerminalTabDisplayTitleTests.swift
@@ -20,7 +20,7 @@ final class TerminalTabDisplayTitleTests: XCTestCase {
         var tab = TerminalTab(title: "claude", terminalId: termId)
         tab.focusedTerminalId = termId
         let store = makeStore()
-        store.update(terminalId: termId, title: "Implement feature X")
+        store.update(terminalId: termId, title: "Implement feature X", at: 1)
         XCTAssertEqual(tab.displayTitle(sessionTitleStore: store), "Implement feature X")
     }
 
@@ -30,7 +30,7 @@ final class TerminalTabDisplayTitleTests: XCTestCase {
         tab.focusedTerminalId = termId
         tab.userRenamed = true
         let store = makeStore()
-        store.update(terminalId: termId, title: "Should not show")
+        store.update(terminalId: termId, title: "Should not show", at: 1)
         XCTAssertEqual(tab.displayTitle(sessionTitleStore: store), "My Tab")
     }
 
@@ -43,8 +43,8 @@ final class TerminalTabDisplayTitleTests: XCTestCase {
                             .terminal(leftId), .terminal(rightId))
         tab.focusedTerminalId = rightId
         let store = makeStore()
-        store.update(terminalId: leftId, title: "Left pane session")
-        store.update(terminalId: rightId, title: "Right pane session")
+        store.update(terminalId: leftId, title: "Left pane session", at: 1)
+        store.update(terminalId: rightId, title: "Right pane session", at: 1)
         XCTAssertEqual(tab.displayTitle(sessionTitleStore: store), "Right pane session")
     }
 

--- a/mux0Tests/TerminalTabDisplayTitleTests.swift
+++ b/mux0Tests/TerminalTabDisplayTitleTests.swift
@@ -50,8 +50,12 @@ final class TerminalTabDisplayTitleTests: XCTestCase {
 
     func testCodableDefaultsUserRenamedToFalse() throws {
         // Legacy tab data without `userRenamed` key must decode with default false.
+        // focusedTerminalId must reference the layout's terminalId — they're
+        // not independent in valid data; use the same UUID for both.
+        let tabId = UUID()
+        let termId = UUID()
         let json = #"""
-        {"id":"\#(UUID().uuidString)","title":"old","layout":{"type":"terminal","terminalId":"\#(UUID().uuidString)"},"focusedTerminalId":"\#(UUID().uuidString)"}
+        {"id":"\#(tabId.uuidString)","title":"old","layout":{"type":"terminal","terminalId":"\#(termId.uuidString)"},"focusedTerminalId":"\#(termId.uuidString)"}
         """#
         let tab = try JSONDecoder().decode(TerminalTab.self, from: Data(json.utf8))
         XCTAssertFalse(tab.userRenamed)

--- a/mux0Tests/TerminalTabDisplayTitleTests.swift
+++ b/mux0Tests/TerminalTabDisplayTitleTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+@testable import mux0
+
+final class TerminalTabDisplayTitleTests: XCTestCase {
+
+    private func makeStore() -> TerminalSessionTitleStore {
+        TerminalSessionTitleStore(persistenceKey: "test-\(UUID())")
+    }
+
+    func testFallsBackToTabTitleWhenStoreEmpty() {
+        let termId = UUID()
+        var tab = TerminalTab(title: "Terminal 1", terminalId: termId)
+        tab.focusedTerminalId = termId
+        let store = makeStore()
+        XCTAssertEqual(tab.displayTitle(sessionTitleStore: store), "Terminal 1")
+    }
+
+    func testUsesStoreTitleForFocusedTerminal() {
+        let termId = UUID()
+        var tab = TerminalTab(title: "claude", terminalId: termId)
+        tab.focusedTerminalId = termId
+        let store = makeStore()
+        store.update(terminalId: termId, title: "Implement feature X")
+        XCTAssertEqual(tab.displayTitle(sessionTitleStore: store), "Implement feature X")
+    }
+
+    func testUserRenamedOverridesStore() {
+        let termId = UUID()
+        var tab = TerminalTab(title: "My Tab", terminalId: termId)
+        tab.focusedTerminalId = termId
+        tab.userRenamed = true
+        let store = makeStore()
+        store.update(terminalId: termId, title: "Should not show")
+        XCTAssertEqual(tab.displayTitle(sessionTitleStore: store), "My Tab")
+    }
+
+    func testTracksFocusedTerminalAcrossPanes() {
+        // Two-pane tab: focus the second; only second's title should be used.
+        let leftId = UUID()
+        let rightId = UUID()
+        var tab = TerminalTab(title: "split tab", terminalId: leftId)
+        tab.layout = .split(UUID(), .vertical, 0.5,
+                            .terminal(leftId), .terminal(rightId))
+        tab.focusedTerminalId = rightId
+        let store = makeStore()
+        store.update(terminalId: leftId, title: "Left pane session")
+        store.update(terminalId: rightId, title: "Right pane session")
+        XCTAssertEqual(tab.displayTitle(sessionTitleStore: store), "Right pane session")
+    }
+
+    func testCodableDefaultsUserRenamedToFalse() throws {
+        // Legacy tab data without `userRenamed` key must decode with default false.
+        let json = #"""
+        {"id":"\#(UUID().uuidString)","title":"old","layout":{"type":"terminal","terminalId":"\#(UUID().uuidString)"},"focusedTerminalId":"\#(UUID().uuidString)"}
+        """#
+        let tab = try JSONDecoder().decode(TerminalTab.self, from: Data(json.utf8))
+        XCTAssertFalse(tab.userRenamed)
+    }
+
+    func testCodableRoundtripPreservesUserRenamed() throws {
+        let termId = UUID()
+        var tab = TerminalTab(title: "X", terminalId: termId)
+        tab.userRenamed = true
+        let data = try JSONEncoder().encode(tab)
+        let decoded = try JSONDecoder().decode(TerminalTab.self, from: data)
+        XCTAssertTrue(decoded.userRenamed)
+    }
+}

--- a/mux0Tests/WorkspaceStoreTests.swift
+++ b/mux0Tests/WorkspaceStoreTests.swift
@@ -849,8 +849,8 @@ final class WorkspaceStoreRenameLockTests: XCTestCase {
         // Split so close doesn't auto-remove the tab.
         let newTermId = ws.splitTerminal(id: termId, in: wsId, tabId: tabId,
                                          direction: .vertical)!
-        titleStore.update(terminalId: termId, title: "Left")
-        titleStore.update(terminalId: newTermId, title: "Right")
+        titleStore.update(terminalId: termId, title: "Left", at: 1)
+        titleStore.update(terminalId: newTermId, title: "Right", at: 1)
         ws.closeTerminal(id: termId, in: wsId, tabId: tabId)
         XCTAssertNil(titleStore.title(for: termId))
         XCTAssertEqual(titleStore.title(for: newTermId), "Right")
@@ -864,8 +864,8 @@ final class WorkspaceStoreRenameLockTests: XCTestCase {
         let (tabId, termId) = ws.addTab(to: wsId)!
         let split2 = ws.splitTerminal(id: termId, in: wsId, tabId: tabId,
                                        direction: .horizontal)!
-        titleStore.update(terminalId: termId, title: "A")
-        titleStore.update(terminalId: split2, title: "B")
+        titleStore.update(terminalId: termId, title: "A", at: 1)
+        titleStore.update(terminalId: split2, title: "B", at: 1)
         ws.removeTab(id: tabId, from: wsId)
         XCTAssertNil(titleStore.title(for: termId))
         XCTAssertNil(titleStore.title(for: split2))

--- a/mux0Tests/WorkspaceStoreTests.swift
+++ b/mux0Tests/WorkspaceStoreTests.swift
@@ -212,14 +212,19 @@ final class WorkspaceStoreTests: XCTestCase {
         XCTAssertEqual(store.workspaces[0].tabs[0].title, original)
     }
 
-    func testRenameTab_sameNameIsNoop() {
+    func testRenameTab_sameNameStillLocksUserRenamed() {
+        // Renaming a tab to its current title still counts as an explicit
+        // user commit on the rename UI — title field stays the same, but
+        // userRenamed flips to true so the auto-naming pipeline backs off.
         let store = WorkspaceStore(persistenceKey: "test-\(UUID())")
         store.createWorkspace(name: "ws")
         let wsId = store.workspaces[0].id
         let tabId = store.workspaces[0].tabs[0].id
         let original = store.workspaces[0].tabs[0].title
+        XCTAssertFalse(store.workspaces[0].tabs[0].userRenamed)
         store.renameTab(id: tabId, in: wsId, to: original)
         XCTAssertEqual(store.workspaces[0].tabs[0].title, original)
+        XCTAssertTrue(store.workspaces[0].tabs[0].userRenamed)
     }
 
     // MARK: - Move tab

--- a/mux0Tests/WorkspaceStoreTests.swift
+++ b/mux0Tests/WorkspaceStoreTests.swift
@@ -801,3 +801,68 @@ final class WorkspaceStoreTests: XCTestCase {
         XCTAssertEqual(tab.quickActionId, "claude")
     }
 }
+
+// MARK: - Rename lock + session title store cleanup
+
+final class WorkspaceStoreRenameLockTests: XCTestCase {
+
+    private func makeStore() -> WorkspaceStore {
+        let store = WorkspaceStore(persistenceKey: "test-\(UUID())")
+        store.createWorkspace(name: "ws")
+        return store
+    }
+
+    func testRenameTabSetsUserRenamedTrue() {
+        let ws = makeStore()
+        let wsId = ws.workspaces[0].id
+        let (tabId, _) = ws.addTab(to: wsId)!
+        ws.renameTab(id: tabId, in: wsId, to: "My Custom Name")
+        let tab = ws.workspaces[0].tabs.first { $0.id == tabId }!
+        XCTAssertEqual(tab.title, "My Custom Name")
+        XCTAssertTrue(tab.userRenamed)
+    }
+
+    func testResetTabToAutoTitleClearsLock() {
+        let ws = makeStore()
+        let wsId = ws.workspaces[0].id
+        let (tabId, _) = ws.addTab(to: wsId)!
+        ws.renameTab(id: tabId, in: wsId, to: "Locked")
+        ws.resetTabToAutoTitle(tabId: tabId, in: wsId)
+        let tab = ws.workspaces[0].tabs.first { $0.id == tabId }!
+        XCTAssertFalse(tab.userRenamed)
+        // title field unchanged — fallback path will continue to show it
+        // until next hook emit overrides via the store.
+        XCTAssertEqual(tab.title, "Locked")
+    }
+
+    func testCloseTerminalClearsSessionTitleStore() {
+        let ws = makeStore()
+        let titleStore = TerminalSessionTitleStore(persistenceKey: "test-\(UUID())")
+        ws.sessionTitleStore = titleStore
+        let wsId = ws.workspaces[0].id
+        let (tabId, termId) = ws.addTab(to: wsId)!
+        // Split so close doesn't auto-remove the tab.
+        let newTermId = ws.splitTerminal(id: termId, in: wsId, tabId: tabId,
+                                         direction: .vertical)!
+        titleStore.update(terminalId: termId, title: "Left")
+        titleStore.update(terminalId: newTermId, title: "Right")
+        ws.closeTerminal(id: termId, in: wsId, tabId: tabId)
+        XCTAssertNil(titleStore.title(for: termId))
+        XCTAssertEqual(titleStore.title(for: newTermId), "Right")
+    }
+
+    func testRemoveTabClearsAllItsTerminalsInStore() {
+        let ws = makeStore()
+        let titleStore = TerminalSessionTitleStore(persistenceKey: "test-\(UUID())")
+        ws.sessionTitleStore = titleStore
+        let wsId = ws.workspaces[0].id
+        let (tabId, termId) = ws.addTab(to: wsId)!
+        let split2 = ws.splitTerminal(id: termId, in: wsId, tabId: tabId,
+                                       direction: .horizontal)!
+        titleStore.update(terminalId: termId, title: "A")
+        titleStore.update(terminalId: split2, title: "B")
+        ws.removeTab(id: tabId, from: wsId)
+        XCTAssertNil(titleStore.title(for: termId))
+        XCTAssertNil(titleStore.title(for: split2))
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -118,7 +118,7 @@ targets:
         CODE_SIGN_STYLE: Automatic
         CODE_SIGN_ENTITLEMENTS: mux0/mux0.entitlements
         ENABLE_HARDENED_RUNTIME: YES
-        MARKETING_VERSION: "0.5.3"
+        MARKETING_VERSION: "0.6.0"
         CURRENT_PROJECT_VERSION: "3"
       configs:
         # Debug 构建用独立 bundle id + display name，让 TCC / LaunchServices /


### PR DESCRIPTION
## Summary

Tab 在用户未手动命名时，自动跟随当前焦点 pane 的 agent 会话标题（Claude / Codex / OpenCode），用户一次 rename 即永久锁定。统一以「第一条 user message」为 fallback、LLM 生成标题优先（与 cmux + 各 agent `--resume` picker 对齐）。

主要改动：
- **Wire format**：`HookMessage.sessionTitle`
- **Hook 端**：`agent-hook.py` 读 Claude transcript（custom-title → ai-title → 第一条 user prompt）+ Codex rollout（thread_name_updated → 第一条 user_message，按 `CODEX_HOME` 解析）；`mux0-status.js` 读 OpenCode `session.title` → 缓存的首条 chat.message
- **Swift 模型**：新增 `TerminalSessionTitleStore`（@Observable + UserDefaults 持久化 + 时间戳防乱序覆盖）、`TerminalTab.userRenamed` 锁 + `displayTitle` 三段回退、`HookDispatcher` 路由（独立于状态通知开关）、`WorkspaceStore` 生命周期清理
- **UI**：TabBarView 渲染 displayTitle，右键菜单「Reset to auto title」解锁
- **i18n**：`tab.row.resetAutoTitle`（en + zh-Hans）
- **附带修复** `fix(ghostty)`：分屏后非前台 pane resize 卡旧帧 → 用 0.4s 重绘突发期修复（根因：mux0 只画 frontmost，ghostty resize 需多帧 reflow）
- **版本**：bump 到 0.6.0

Spec / plan 见 `docs/superpowers/specs/2026-05-24-auto-tab-naming-design.md`、`docs/superpowers/plans/2026-05-24-auto-tab-naming.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)