### PR TITLE
feat(tabcontent): hover 显示完整 Tab 标题 + bump 0.6.1

### DIFF
--- a/landing-page/index.html
+++ b/landing-page/index.html
@@ -1220,7 +1220,7 @@ kbd{
         <span data-i18n="hero.cta.source">View source</span>
         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17L17 7M9 7h8v8"/></svg>
       </a>
-      <span class="chip-meta"><span class="mono" data-i18n="hero.meta.ver">v0.6.0</span></span>
+      <span class="chip-meta"><span class="mono" data-i18n="hero.meta.ver">v0.6.1</span></span>
     </div>
 
     <!-- hero window (interactive) -->
@@ -1247,7 +1247,7 @@ kbd{
               </div>
               <div class="ws-list" id="ws-list"></div>
               <div class="sidebar-footer">
-                <span class="mono">v0.6.0</span>
+                <span class="mono">v0.6.1</span>
                 <button class="side-icon disabled" data-disabled-msg title="Settings" aria-label="Settings (disabled in preview)">
                   <svg width="13" height="13"><use href="#icon-gear"/></svg>
                 </button>
@@ -1622,7 +1622,7 @@ const i18n = {
     "hero.sub": "A native macOS terminal built on libghostty. Workspaces, tabs, and split panes for your repos — with live status for every Claude Code, OpenCode, and Codex session you run.",
     "hero.cta.download": "Download for macOS",
     "hero.cta.source": "View source",
-    "hero.meta.ver": "v0.6.0",
+    "hero.meta.ver": "v0.6.1",
     "sidebar.workspaces": "WORKSPACES",
     "preview.caption": "Live preview — + add workspace/tab · double-click to rename · drag to reorder · type a command and hit Enter",
     "why.kicker": "THREE IDEAS",
@@ -1726,7 +1726,7 @@ const i18n = {
     "term.agent.needs": "waiting for your approval on tool call",
     "term.agent.failedMsg": "tool error: typecheck failed",
     "term.neofetch.os": "macOS 14.4 · Apple Silicon",
-    "term.neofetch.term": "Mux0 v0.6.0 · libghostty · Metal",
+    "term.neofetch.term": "Mux0 v0.6.1 · libghostty · Metal",
     "term.neofetch.shell": "zsh 5.9",
     "term.neofetch.uptime": "uptime 1d 4h",
     "term.neofetch.theme": "nocturne · 200 ms hot-reload",
@@ -1747,7 +1747,7 @@ const i18n = {
     "hero.sub": "基于 libghostty 的原生 macOS 终端。为多仓库工作流而设计 —— 侧边栏实时显示每一个 Claude Code、OpenCode、Codex 会话的运行状态。",
     "hero.cta.download": "下载 macOS 版",
     "hero.cta.source": "查看源码",
-    "hero.meta.ver": "v0.6.0",
+    "hero.meta.ver": "v0.6.1",
     "sidebar.workspaces": "工作区",
     "preview.caption": "实时预览 —— + 新建工作区/标签 · 双击重命名 · 拖拽排序 · 输入命令回车执行",
     "why.kicker": "三个理念",
@@ -1851,7 +1851,7 @@ const i18n = {
     "term.agent.needs": "等待工具调用授权",
     "term.agent.failedMsg": "工具报错：typecheck 失败",
     "term.neofetch.os": "macOS 14.4 · Apple Silicon",
-    "term.neofetch.term": "Mux0 v0.6.0 · libghostty · Metal",
+    "term.neofetch.term": "Mux0 v0.6.1 · libghostty · Metal",
     "term.neofetch.shell": "zsh 5.9",
     "term.neofetch.uptime": "运行 1d 4h",
     "term.neofetch.theme": "nocturne · 200 ms 热重载",

--- a/mux0/TabContent/TabBarView.swift
+++ b/mux0/TabContent/TabBarView.swift
@@ -418,6 +418,7 @@ private final class TabItemView: NSView, NSTextFieldDelegate, NSDraggingSource {
         self.userRenamed = tab.userRenamed
         titleLabel.stringValue = displayTitle
         setup()
+        applyToolTip(displayTitle)
         applyQuickActionImage(tab.quickActionId)
         updateStyle()
         statusIcon.isHidden = !showStatusIndicators
@@ -456,6 +457,17 @@ private final class TabItemView: NSView, NSTextFieldDelegate, NSDraggingSource {
         renameField.delegate = self
         renameField.isHidden = true
         addSubview(renameField)
+    }
+
+    /// AppKit tooltips don't bubble from child to parent — the tooltip shown is the
+    /// one owned by the topmost view under the cursor. Mirror the full title onto every
+    /// subview that covers the pill so hovering anywhere on the tab reveals the title.
+    private func applyToolTip(_ title: String) {
+        self.toolTip = title
+        pillView.toolTip = title
+        titleLabel.toolTip = title
+        kindIcon.toolTip = title
+        statusIcon.toolTip = title
     }
 
     override func updateTrackingAreas() {
@@ -581,6 +593,7 @@ private final class TabItemView: NSView, NSTextFieldDelegate, NSDraggingSource {
         if titleLabel.stringValue != displayTitle && !isRenaming {
             titleLabel.stringValue = displayTitle
         }
+        applyToolTip(displayTitle)
         if displayedQuickActionId != tab.quickActionId {
             displayedQuickActionId = tab.quickActionId
             applyQuickActionImage(tab.quickActionId)

--- a/project.yml
+++ b/project.yml
@@ -118,7 +118,7 @@ targets:
         CODE_SIGN_STYLE: Automatic
         CODE_SIGN_ENTITLEMENTS: mux0/mux0.entitlements
         ENABLE_HARDENED_RUNTIME: YES
-        MARKETING_VERSION: "0.6.0"
+        MARKETING_VERSION: "0.6.1"
         CURRENT_PROJECT_VERSION: "3"
       configs:
         # Debug 构建用独立 bundle id + display name，让 TCC / LaunchServices /


### PR DESCRIPTION
## Summary
- Tab pill 标题超长被省略时，hover 鼠标可通过原生 AppKit tooltip 显示完整标题
- tooltip 同步设到覆盖整个 pill 的所有子视图（pillView / titleLabel / kindIcon / statusIcon），因为 AppKit tooltip 不会从子视图冒泡到父视图
- bump MARKETING_VERSION 0.6.0 → 0.6.1，并同步 landing 版本号

🤖 Generated with [Claude Code](https://claude.com/claude-code)