### PR TITLE
feat(ghostty): 终端链接 Cmd+点击跳转 + hover 下划线/tooltip

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,8 @@ mux0/
 ├── Ghostty/
 │   ├── ghostty-bridging-header.h  — 桥接头文件
 │   ├── GhosttyBridge.swift        — libghostty 单例（app/config 生命周期 + window blur）
-│   └── GhosttyTerminalView.swift  — NSView，持有 ghostty_surface_t，Metal 渲染
+│   ├── GhosttyTerminalView.swift  — NSView，持有 ghostty_surface_t，Metal 渲染
+│   └── LinkHintTooltip.swift      — 链接 hover 提示气泡（无边框浮层窗口）
 ├── Localization/
 │   ├── LanguageStore.swift  — @Observable，语言偏好 + UserDefaults 持久化 + effectiveBundle + locale + tick
 │   ├── L10n.swift           — 常量命名空间（LocalizedStringResource + AppKit helper L10n.string(_:args...)）

--- a/docs/ghostty-integration.md
+++ b/docs/ghostty-integration.md
@@ -83,7 +83,21 @@ GhosttyBridge.shared.readPalette()     // → ghostty_config_palette_s?
 | `write_clipboard_cb` | 写入 NSPasteboard |
 | `read_clipboard_cb` | 目前 no-op，v1 不实现剪贴板读取 |
 | `close_surface_cb` | surface 请求关闭时通知 canvas |
-| `action_cb` | ghostty 内部 action 分发（目前 no-op）|
+| `action_cb` | ghostty 内部 action 分发（CONFIG_CHANGE / CELL_SIZE / SCROLLBAR / PWD / OPEN_URL / MOUSE_SHAPE）|
+
+### 链接交互相关 action
+
+终端里的 URL 由 libghostty 内部识别、Cmd 判定与下划线渲染，宿主只接三处：
+
+- `GHOSTTY_ACTION_OPEN_URL` — Cmd+点击链接时触发；宿主经 `GhosttyBridge.resolveOpenURL`
+  做 scheme 白名单（http / https / mailto / file）后用 `NSWorkspace.shared.open` 打开。
+- `GHOSTTY_ACTION_MOUSE_SHAPE` — 悬停链接等场景下 ghostty 通知期望光标；映射到
+  `NSCursor`（POINTER→pointingHand、TEXT→iBeam、其余→arrow），经
+  `GhosttyTerminalView.applyMouseShape` 应用，配合 tracking area 的 `.cursorUpdate`
+  与 `cursorUpdate(with:)` override。
+- 下划线高亮由 ghostty 渲染器自绘，依赖 `GhosttyTerminalView.mouseMoved` 把带修饰键的
+  hover 位置转发给 `ghostty_surface_mouse_pos`（仅焦点 pane）。
+  `GHOSTTY_ACTION_MOUSE_OVER_LINK` 未接入（YAGNI）。
 
 ## 升级 ghostty 版本
 

--- a/docs/ghostty-integration.md
+++ b/docs/ghostty-integration.md
@@ -83,7 +83,7 @@ GhosttyBridge.shared.readPalette()     // → ghostty_config_palette_s?
 | `write_clipboard_cb` | 写入 NSPasteboard |
 | `read_clipboard_cb` | 目前 no-op，v1 不实现剪贴板读取 |
 | `close_surface_cb` | surface 请求关闭时通知 canvas |
-| `action_cb` | ghostty 内部 action 分发（CONFIG_CHANGE / CELL_SIZE / SCROLLBAR / PWD / OPEN_URL / MOUSE_SHAPE）|
+| `action_cb` | ghostty 内部 action 分发（CONFIG_CHANGE / CELL_SIZE / SCROLLBAR / PWD / OPEN_URL / MOUSE_SHAPE / MOUSE_OVER_LINK）|
 
 ### 链接交互相关 action
 
@@ -97,7 +97,14 @@ GhosttyBridge.shared.readPalette()     // → ghostty_config_palette_s?
   与 `cursorUpdate(with:)` override。
 - 下划线高亮由 ghostty 渲染器自绘，依赖 `GhosttyTerminalView.mouseMoved` 把带修饰键的
   hover 位置转发给 `ghostty_surface_mouse_pos`（仅焦点 pane）。
-  `GHOSTTY_ACTION_MOUSE_OVER_LINK` 未接入（YAGNI）。
+- `GHOSTTY_ACTION_MOUSE_OVER_LINK` — hover 命中/离开链接时通知 URL；用于驱动
+  `LinkHintTooltip` 提示气泡与链接光标（经 `GhosttyTerminalView.applyHoveredLink`
+  → `updateLinkAffordance`）。
+- 普通 hover（不按 Cmd）也要下划线/提示：`mouseMoved` 转发时注入 `GHOSTTY_MODS_SUPER`
+  伪造 Cmd，使 ghostty 在无修饰键时也高亮链接并发 MOUSE_OVER_LINK；点击事件传真实修饰键
+  （`mouseDown` 在按钮前先用真实 mods 发一次 mouse_pos 清掉伪造态），故仅真·Cmd+单击打开。
+  光标与 tooltip 由 `updateLinkAffordance` 按真实 Cmd 状态接管；`applyMouseShape` 在
+  hover 链接期间让位；`mouseExited`/失焦时清理 tooltip。
 
 ## 升级 ghostty 版本
 

--- a/docs/superpowers/plans/2026-05-31-terminal-clickable-links.md
+++ b/docs/superpowers/plans/2026-05-31-terminal-clickable-links.md
@@ -1,0 +1,309 @@
+# 终端可点击链接 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 让终端里的 URL 支持 Cmd+点击打开、Cmd+悬停显示下划线高亮与手型光标，体验对齐 VS Code 终端。
+
+**Architecture:** libghostty 已内置链接识别 / Cmd 判定 / 下划线渲染，宿主只需补三处接线：在 `GhosttyBridge.actionCallback` 处理 `OPEN_URL` 和 `MOUSE_SHAPE` 两个 action，并在 `GhosttyTerminalView` 重新开启 `mouseMoved` 的 hover 转发并由 ghostty 驱动光标。URL 打开逻辑抽成纯静态函数以便单测。
+
+**Tech Stack:** Swift / AppKit，libghostty C API，XCTest，xcodebuild。
+
+---
+
+## File Structure
+
+- `mux0/Ghostty/GhosttyBridge.swift` — 新增 `static func resolveOpenURL`，在 `actionCallback` 加 `OPEN_URL` / `MOUSE_SHAPE` 两个 case。
+- `mux0/Ghostty/GhosttyTerminalView.swift` — 新增 `currentCursor` 状态、`cursorUpdate(with:)`、tracking area 追加 `.cursorUpdate`、`mouseMoved` 改为转发 hover，新增 `applyMouseShape` 方法。
+- `mux0Tests/GhosttyBridgeOpenURLTests.swift` — 新建，覆盖 `resolveOpenURL` 白名单逻辑。
+- `docs/ghostty-integration.md` — 补充新接入的 action 回调说明。
+
+---
+
+## Task 1: URL scheme 白名单解析（纯函数 + 测试）
+
+**Files:**
+- Modify: `mux0/Ghostty/GhosttyBridge.swift`
+- Test: `mux0Tests/GhosttyBridgeOpenURLTests.swift`（Create）
+
+- [ ] **Step 1: 写失败测试**
+
+新建 `mux0Tests/GhosttyBridgeOpenURLTests.swift`：
+
+```swift
+import XCTest
+@testable import mux0
+
+final class GhosttyBridgeOpenURLTests: XCTestCase {
+    func testAllowsHTTPAndHTTPS() {
+        XCTAssertEqual(GhosttyBridge.resolveOpenURL("http://example.com")?.absoluteString,
+                       "http://example.com")
+        XCTAssertEqual(GhosttyBridge.resolveOpenURL("https://example.com/a?b=1")?.absoluteString,
+                       "https://example.com/a?b=1")
+    }
+
+    func testAllowsMailtoAndFile() {
+        XCTAssertEqual(GhosttyBridge.resolveOpenURL("mailto:x@y.com")?.scheme, "mailto")
+        XCTAssertEqual(GhosttyBridge.resolveOpenURL("file:///tmp/a.txt")?.scheme, "file")
+    }
+
+    func testRejectsDisallowedSchemes() {
+        XCTAssertNil(GhosttyBridge.resolveOpenURL("javascript:alert(1)"))
+        XCTAssertNil(GhosttyBridge.resolveOpenURL("ftp://example.com"))
+        XCTAssertNil(GhosttyBridge.resolveOpenURL("custom-scheme://do-something"))
+    }
+
+    func testRejectsEmptyAndSchemeless() {
+        XCTAssertNil(GhosttyBridge.resolveOpenURL(""))
+        XCTAssertNil(GhosttyBridge.resolveOpenURL("   "))
+        XCTAssertNil(GhosttyBridge.resolveOpenURL("example.com"))
+    }
+
+    func testSchemeMatchIsCaseInsensitive() {
+        XCTAssertEqual(GhosttyBridge.resolveOpenURL("HTTPS://example.com")?.scheme?.lowercased(),
+                       "https")
+    }
+}
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `xcodebuild test -project mux0.xcodeproj -scheme mux0Tests -only-testing:mux0Tests/GhosttyBridgeOpenURLTests 2>&1 | tail -20`
+Expected: 编译失败，`resolveOpenURL` 未定义。
+
+- [ ] **Step 3: 实现 resolveOpenURL**
+
+在 `GhosttyBridge.swift` 的 `GhosttyBridge` 类里（靠近 `sanitizedPwd` 静态方法处）新增：
+
+```swift
+/// 终端链接 Cmd+点击时由 ghostty 传来的原始 URL 字符串。仅放行安全 scheme，
+/// 过滤掉终端输出里可能注入的自定义 scheme（如 javascript:）。
+static func resolveOpenURL(_ raw: String) -> URL? {
+    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty,
+          let url = URL(string: trimmed),
+          let scheme = url.scheme?.lowercased(),
+          ["http", "https", "mailto", "file"].contains(scheme)
+    else { return nil }
+    return url
+}
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `xcodebuild test -project mux0.xcodeproj -scheme mux0Tests -only-testing:mux0Tests/GhosttyBridgeOpenURLTests 2>&1 | tail -20`
+Expected: 全部 PASS。
+
+> 注意：新建的测试文件需被 Xcode target 收录。`project.yml` 用目录通配收 `mux0Tests/`，重生工程即可——若测试找不到，先跑 `xcodegen generate` 再测。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add mux0/Ghostty/GhosttyBridge.swift mux0Tests/GhosttyBridgeOpenURLTests.swift
+git commit -m "feat(ghostty): add resolveOpenURL scheme allowlist"
+```
+
+---
+
+## Task 2: 接入 OPEN_URL action（Cmd+点击打开）
+
+**Files:**
+- Modify: `mux0/Ghostty/GhosttyBridge.swift`（`actionCallback` switch，约 347-394 行）
+
+- [ ] **Step 1: 在 actionCallback 加 OPEN_URL case**
+
+在 `GHOSTTY_ACTION_PWD` 之后、`default` 之前插入：
+
+```swift
+        case GHOSTTY_ACTION_OPEN_URL:
+            let ou = action.action.open_url
+            guard let ptr = ou.url else { return true }
+            // url 不保证 NUL 结尾，按 len 取字节构造 String。
+            let data = Data(bytes: ptr, count: Int(ou.len))
+            guard let raw = String(data: data, encoding: .utf8) else { return true }
+            DispatchQueue.main.async {
+                if let url = GhosttyBridge.resolveOpenURL(raw) {
+                    NSWorkspace.shared.open(url)
+                }
+            }
+            return true
+```
+
+- [ ] **Step 2: 编译验证**
+
+Run: `xcodebuild -project mux0.xcodeproj -scheme mux0 -configuration Debug build 2>&1 | tail -15`
+Expected: BUILD SUCCEEDED。
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add mux0/Ghostty/GhosttyBridge.swift
+git commit -m "feat(ghostty): open terminal links on cmd-click via OPEN_URL action"
+```
+
+---
+
+## Task 3: 接入 MOUSE_SHAPE action（手型光标）
+
+**Files:**
+- Modify: `mux0/Ghostty/GhosttyBridge.swift`（`actionCallback` switch）
+- Modify: `mux0/Ghostty/GhosttyTerminalView.swift`（tracking area + 新方法 + cursorUpdate）
+
+- [ ] **Step 1: GhosttyTerminalView 新增 currentCursor 与 applyMouseShape**
+
+在 `GhosttyTerminalView` 类的属性区（与其他 `private var` 同处，例如 `surface` 附近）新增：
+
+```swift
+    /// 由 ghostty 的 MOUSE_SHAPE action 驱动。默认 iBeam，与终端文本区一致。
+    private var currentCursor: NSCursor = .iBeam
+```
+
+在类内（靠近 `applyCellSize` 等 `apply*` 方法处）新增：
+
+```swift
+    /// ghostty 通知鼠标应显示的形状（悬停链接→手型，文本→iBeam）。
+    func applyMouseShape(_ cursor: NSCursor) {
+        currentCursor = cursor
+        // 若鼠标正悬在自身上，立即生效，不必等下一次 cursorUpdate。
+        if let window = window, window.isKeyWindow {
+            let pt = convert(window.mouseLocationOutsideOfEventStream, from: nil)
+            if bounds.contains(pt) {
+                cursor.set()
+            }
+        }
+    }
+```
+
+- [ ] **Step 2: tracking area 追加 .cursorUpdate 并 override cursorUpdate**
+
+把 `updateTrackingAreas()`（约 250-258 行）的 options 改为：
+
+```swift
+        let options: NSTrackingArea.Options = [
+            .activeWhenFirstResponder, .mouseMoved, .cursorUpdate, .inVisibleRect
+        ]
+```
+
+在 `mouseMoved` 附近新增 override：
+
+```swift
+    override func cursorUpdate(with event: NSEvent) {
+        currentCursor.set()
+    }
+```
+
+- [ ] **Step 3: GhosttyBridge 加 MOUSE_SHAPE case**
+
+在 `actionCallback` 的 `GHOSTTY_ACTION_OPEN_URL` case 之后插入：
+
+```swift
+        case GHOSTTY_ACTION_MOUSE_SHAPE:
+            guard target.tag == GHOSTTY_TARGET_SURFACE,
+                  let surface = target.target.surface
+            else { return true }
+            let shape = action.action.mouse_shape
+            let cursor: NSCursor
+            switch shape {
+            case GHOSTTY_MOUSE_SHAPE_POINTER: cursor = .pointingHand
+            case GHOSTTY_MOUSE_SHAPE_TEXT:    cursor = .iBeam
+            default:                          cursor = .arrow
+            }
+            DispatchQueue.main.async {
+                guard let view = GhosttyTerminalView.view(forSurface: surface) else { return }
+                view.applyMouseShape(cursor)
+            }
+            return true
+```
+
+- [ ] **Step 4: 编译验证**
+
+Run: `xcodebuild -project mux0.xcodeproj -scheme mux0 -configuration Debug build 2>&1 | tail -15`
+Expected: BUILD SUCCEEDED。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add mux0/Ghostty/GhosttyBridge.swift mux0/Ghostty/GhosttyTerminalView.swift
+git commit -m "feat(ghostty): drive cursor shape from MOUSE_SHAPE action (pointer over links)"
+```
+
+---
+
+## Task 4: 重新开启 mouseMoved hover 转发（Cmd+悬停高亮）
+
+**Files:**
+- Modify: `mux0/Ghostty/GhosttyTerminalView.swift`（`mouseMoved`，约 686-690 行）
+
+- [ ] **Step 1: 把 mouseMoved 空实现改为转发**
+
+将现有空的 `mouseMoved(with:)` 替换为：
+
+```swift
+    override func mouseMoved(with event: NSEvent) {
+        // 转发 hover 位置以驱动 ghostty 的链接下划线高亮与光标形状。
+        // 安全性：tracking area 为 .activeWhenFirstResponder，仅焦点 pane 触发；
+        // 再加 isCursorOverSelf 守卫。纯 hover（无按键）不会扩选区，后台 pane 的
+        // mouseLocation 轮询问题已被现有 frontmost gate 拦住。
+        guard isCursorOverSelf(event) else { return }
+        guard let s = surface else { return }
+        let pt = flippedPoint(event.locationInWindow)
+        ghostty_surface_mouse_pos(s, pt.x, pt.y, modsFromEvent(event))
+    }
+```
+
+- [ ] **Step 2: 编译验证**
+
+Run: `xcodebuild -project mux0.xcodeproj -scheme mux0 -configuration Debug build 2>&1 | tail -15`
+Expected: BUILD SUCCEEDED。
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add mux0/Ghostty/GhosttyTerminalView.swift
+git commit -m "feat(ghostty): forward hover to ghostty for cmd-hover link highlight"
+```
+
+---
+
+## Task 5: 跑全量测试 + 更新文档
+
+**Files:**
+- Modify: `docs/ghostty-integration.md`
+
+- [ ] **Step 1: 跑全量测试**
+
+Run: `xcodebuild test -project mux0.xcodeproj -scheme mux0Tests 2>&1 | tail -20`
+Expected: 全部 PASS（含新增 `GhosttyBridgeOpenURLTests`）。
+
+- [ ] **Step 2: 更新 ghostty-integration.md**
+
+在该文档的 action 回调相关章节补充一段，说明现已处理的 action：
+
+```markdown
+### 链接交互相关 action
+
+- `GHOSTTY_ACTION_OPEN_URL` — Cmd+点击链接时触发；宿主经 `GhosttyBridge.resolveOpenURL`
+  做 scheme 白名单（http/https/mailto/file）后用 `NSWorkspace.shared.open` 打开。
+- `GHOSTTY_ACTION_MOUSE_SHAPE` — 悬停链接等场景下 ghostty 通知期望光标；映射到
+  `NSCursor`（POINTER→pointingHand、TEXT→iBeam、其余→arrow），经
+  `GhosttyTerminalView.applyMouseShape` 应用，配合 `.cursorUpdate` tracking + `cursorUpdate(with:)`。
+- 下划线高亮由 ghostty 渲染器自绘，依赖 `mouseMoved` 把带修饰键的 hover 位置转发给
+  `ghostty_surface_mouse_pos`（仅焦点 pane）。`GHOSTTY_ACTION_MOUSE_OVER_LINK` 未接入。
+```
+
+（若文档结构不同，放到最贴切的 action / 鼠标章节，保持风格一致。）
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add docs/ghostty-integration.md
+git commit -m "docs(ghostty): document link-interaction action callbacks"
+```
+
+---
+
+## 手动验证（实现完成后由用户执行）
+
+1. `xcodebuild -project mux0.xcodeproj -scheme mux0 -configuration Debug build` 编译通过。
+2. 用户自行重启 mux0.app（不要由 agent `open`/`killall`）。
+3. 在终端里 `echo https://example.com`，Cmd+悬停看是否出现下划线 + 手型光标；Cmd+点击是否在浏览器打开。
+4. 普通点击（不按 Cmd）链接不触发打开、不误选区；多 pane 时只有焦点 pane 响应 hover。

--- a/docs/superpowers/plans/2026-06-01-terminal-link-hover-tooltip.md
+++ b/docs/superpowers/plans/2026-06-01-terminal-link-hover-tooltip.md
@@ -1,0 +1,322 @@
+# 终端链接 hover 下划线 + tooltip（Phase 2）Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** 让普通 hover（不按 Cmd）也能显示链接下划线 + tooltip「⌘ + 单击打开链接」，光标保持 iBeam；Cmd+hover 显示手型、Cmd+单击打开。对齐 VS Code。
+
+**Architecture:** 修饰键注入——`mouseMoved` 转发时给 mods 注入 SUPER 骗 ghostty 在普通 hover 也画下划线并发 `MOUSE_OVER_LINK`；点击事件传真实 mods 故只有真 Cmd+单击打开。光标与 tooltip 由宿主根据 `MOUSE_OVER_LINK` + 真实 Cmd 状态集中接管。
+
+**Tech Stack:** Swift / AppKit，libghostty C API，String Catalog，XCTest。
+
+分支：继续在 `agent/terminal-clickable-links`。
+
+---
+
+## Task 6: 新增 tooltip 文案（i18n）
+
+**Files:**
+- Modify: `mux0/Localization/Localizable.xcstrings`
+
+- [ ] **Step 1: 加 key**
+
+在 `mux0/Localization/Localizable.xcstrings` 的 `"strings"` 对象里新增一个 key（保持文件其余部分不动，注意 JSON 合法、与现有条目同结构）：
+
+```json
+"terminal.link.openHint" : {
+  "extractionState" : "manual",
+  "localizations" : {
+    "en" : { "stringUnit" : { "state" : "translated", "value" : "⌘ + click to open link" } },
+    "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "⌘ + 单击打开链接" } }
+  }
+}
+```
+
+- [ ] **Step 2: 验证 JSON + 构建**
+
+Run: `python3 -c "import json; json.load(open('mux0/Localization/Localizable.xcstrings')); print('ok')"`
+Expected: `ok`
+Run: `xcodebuild -project mux0.xcodeproj -scheme mux0 -configuration Debug build 2>&1 | tail -8`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add mux0/Localization/Localizable.xcstrings
+git commit -m "feat(i18n): add terminal link open hint string"
+```
+
+---
+
+## Task 7: LinkHintTooltip 浮层窗口（新文件 + 目录文档同步）
+
+**Files:**
+- Create: `mux0/Ghostty/LinkHintTooltip.swift`
+- Modify: `CLAUDE.md`, `AGENTS.md`（Directory Structure 的 Ghostty/ 段）
+
+- [ ] **Step 1: 新建 tooltip 类**
+
+Create `mux0/Ghostty/LinkHintTooltip.swift`:
+
+```swift
+import AppKit
+
+/// 链接 hover 提示气泡。一个无边框、不激活、不接收鼠标事件的浮层窗口，
+/// 显示「⌘ + 单击打开链接」之类提示。由 GhosttyTerminalView 在普通 hover
+/// 链接时显示，Cmd 按下或离开链接时隐藏。使用系统 toolTip 材质与语义色，
+/// 不引入主题耦合。
+final class LinkHintTooltip {
+    private var label: NSTextField?
+
+    private lazy var window: NSWindow = {
+        let w = NSWindow(
+            contentRect: .zero,
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: true
+        )
+        w.isOpaque = false
+        w.backgroundColor = .clear
+        w.level = .floating
+        w.ignoresMouseEvents = true
+        w.hasShadow = true
+
+        let blur = NSVisualEffectView()
+        blur.material = .toolTip
+        blur.state = .active
+        blur.wantsLayer = true
+        blur.layer?.cornerRadius = 5
+        blur.layer?.masksToBounds = true
+
+        let label = NSTextField(labelWithString: "")
+        label.font = .systemFont(ofSize: 11)
+        label.textColor = .labelColor
+        label.backgroundColor = .clear
+        label.isBordered = false
+        blur.addSubview(label)
+
+        w.contentView = blur
+        self.label = label
+        return w
+    }()
+
+    /// 在屏幕坐标 `screenPoint` 附近显示提示。
+    func show(_ text: String, at screenPoint: NSPoint) {
+        _ = window
+        guard let label else { return }
+        label.stringValue = text
+        label.sizeToFit()
+
+        let padX: CGFloat = 8
+        let padY: CGFloat = 5
+        let size = NSSize(
+            width: label.frame.width + padX * 2,
+            height: label.frame.height + padY * 2
+        )
+        label.setFrameOrigin(NSPoint(x: padX, y: padY))
+        window.setContentSize(size)
+        window.contentView?.frame = NSRect(origin: .zero, size: size)
+        // 放在光标右下方一点，避免遮住链接本身。
+        window.setFrameOrigin(NSPoint(x: screenPoint.x + 12,
+                                      y: screenPoint.y - size.height - 12))
+        window.orderFront(nil)
+    }
+
+    func hide() {
+        window.orderOut(nil)
+    }
+}
+```
+
+- [ ] **Step 2: 构建**
+
+Run: `xcodegen generate` (新文件需进 target) then `xcodebuild -project mux0.xcodeproj -scheme mux0 -configuration Debug build 2>&1 | tail -8`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 3: 同步目录文档**
+
+在 `CLAUDE.md` 和 `AGENTS.md` 的 Directory Structure 里，`Ghostty/` 段落新增一行（与现有 `│   ├──` 缩进风格一致）：
+```
+│   ├── LinkHintTooltip.swift      — 链接 hover 提示气泡（无边框浮层窗口）
+```
+放在 `GhosttyTerminalView.swift` 行之后。读这两个文件确认确切缩进与表述风格后再改。
+
+Run: `./scripts/check-doc-drift.sh 2>&1 | tail -5`
+Expected: 目录匹配通过，exit 0。
+
+- [ ] **Step 4: 提交**
+
+```bash
+git add mux0/Ghostty/LinkHintTooltip.swift CLAUDE.md AGENTS.md mux0.xcodeproj/project.pbxproj
+git commit -m "feat(ghostty): add LinkHintTooltip floating hint window"
+```
+
+---
+
+## Task 8: 接线——hover 注入 + MOUSE_OVER_LINK + 光标/tooltip 接管
+
+**Files:**
+- Modify: `mux0/Ghostty/GhosttyBridge.swift`（actionCallback 加 MOUSE_OVER_LINK case）
+- Modify: `mux0/Ghostty/GhosttyTerminalView.swift`（mouseMoved 注入、hoveredLinkURL、updateLinkAffordance、flagsChanged、applyMouseShape 让位、linkTooltip）
+
+- [ ] **Step 1: GhosttyTerminalView — 状态与集中更新**
+
+在属性区（`currentCursor` 附近）新增：
+```swift
+    /// 当前 hover 命中的链接 URL（来自 ghostty MOUSE_OVER_LINK）；nil 表示未在链接上。
+    private var hoveredLinkURL: String?
+    private let linkTooltip = LinkHintTooltip()
+```
+
+新增方法（放在 `applyMouseShape` 附近）：
+```swift
+    /// ghostty 通知 hover 命中/离开链接。url 非 nil 表示在链接上。
+    func applyHoveredLink(_ url: String?) {
+        hoveredLinkURL = url
+        updateLinkAffordance()
+    }
+
+    /// 根据「是否在链接上」与「真实 Cmd 是否按下」集中决定光标与 tooltip。
+    /// 普通 hover 链接：iBeam + 显示提示；Cmd+hover 链接：手型 + 隐藏提示。
+    private func updateLinkAffordance() {
+        let cmdHeld = NSEvent.modifierFlags.contains(.command)
+        if hoveredLinkURL != nil {
+            currentCursor = cmdHeld ? .pointingHand : .iBeam
+            if cmdHeld {
+                linkTooltip.hide()
+            } else {
+                linkTooltip.show(L10n.string("terminal.link.openHint"), at: NSEvent.mouseLocation)
+            }
+        } else {
+            currentCursor = .iBeam
+            linkTooltip.hide()
+        }
+        // 若鼠标正悬在自身上，立即生效。
+        if let window = window, window.isKeyWindow {
+            let pt = convert(window.mouseLocationOutsideOfEventStream, from: nil)
+            if bounds.contains(pt) { currentCursor.set() }
+        }
+    }
+```
+
+- [ ] **Step 2: GhosttyTerminalView — applyMouseShape 让位 + flagsChanged**
+
+把现有 `applyMouseShape(_:)` 改成在 hover 链接时让位（链接光标由 updateLinkAffordance 接管）。在方法体最前面加一行 guard：
+```swift
+    func applyMouseShape(_ cursor: NSCursor) {
+        // 链接 hover 期间光标由 updateLinkAffordance 接管，避免与注入产生的 POINTER 打架。
+        guard hoveredLinkURL == nil else { return }
+        currentCursor = cursor
+        if let window = window, window.isKeyWindow {
+            let pt = convert(window.mouseLocationOutsideOfEventStream, from: nil)
+            if bounds.contains(pt) {
+                cursor.set()
+            }
+        }
+    }
+```
+（保留原有的「鼠标在自身上则立即 set」逻辑，只是在最前面加 guard。读现有实现，确保只加 guard、不破坏其余。）
+
+新增 `flagsChanged` override（放在 mouseMoved 附近）：
+```swift
+    override func flagsChanged(with event: NSEvent) {
+        super.flagsChanged(with: event)
+        // Cmd 的按下/松开会切换链接光标与 tooltip（即便鼠标没动）。
+        updateLinkAffordance()
+    }
+```
+
+- [ ] **Step 3: GhosttyTerminalView — mouseMoved 注入 SUPER**
+
+把 Phase 1 的 `mouseMoved` 改为注入伪造 super：
+```swift
+    override func mouseMoved(with event: NSEvent) {
+        guard isCursorOverSelf(event) else { return }
+        guard let s = surface else { return }
+        let pt = flippedPoint(event.locationInWindow)
+        // 注入 SUPER：让 ghostty 在普通 hover 也判定链接可高亮，从而画下划线并发
+        // MOUSE_OVER_LINK。点击事件（mouseDown）仍传真实修饰键，且按下按钮前会先用真实
+        // mods 发一次 mouse_pos 清掉这里的伪造状态，故只有真·Cmd+单击才会打开链接。
+        var raw = modsFromEvent(event).rawValue
+        raw |= GHOSTTY_MODS_SUPER.rawValue
+        ghostty_surface_mouse_pos(s, pt.x, pt.y, ghostty_input_mods_e(rawValue: raw))
+    }
+```
+
+- [ ] **Step 4: GhosttyBridge — MOUSE_OVER_LINK case**
+
+在 `actionCallback` 的 `GHOSTTY_ACTION_MOUSE_SHAPE` case 之后、`default` 之前新增：
+```swift
+        case GHOSTTY_ACTION_MOUSE_OVER_LINK:
+            guard target.tag == GHOSTTY_TARGET_SURFACE,
+                  let surface = target.target.surface
+            else { return true }
+            let mol = action.action.mouse_over_link
+            let url: String?
+            if let ptr = mol.url, mol.len > 0 {
+                url = String(data: Data(bytes: UnsafeRawPointer(ptr), count: Int(mol.len)), encoding: .utf8)
+            } else {
+                url = nil
+            }
+            DispatchQueue.main.async {
+                guard let view = GhosttyTerminalView.view(forSurface: surface) else { return }
+                view.applyHoveredLink(url)
+            }
+            return true
+```
+
+- [ ] **Step 5: 构建**
+
+Run: `xcodebuild -project mux0.xcodeproj -scheme mux0 -configuration Debug build 2>&1 | tail -10`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 6: 提交**
+
+```bash
+git add mux0/Ghostty/GhosttyBridge.swift mux0/Ghostty/GhosttyTerminalView.swift
+git commit -m "feat(ghostty): plain-hover link underline + tooltip via modifier injection"
+```
+
+---
+
+## Task 9: 全量测试 + 文档
+
+**Files:**
+- Modify: `docs/ghostty-integration.md`
+
+- [ ] **Step 1: 全量测试**
+
+Run: `xcodebuild test -project mux0.xcodeproj -scheme mux0Tests 2>&1 | tail -20`
+Expected: TEST SUCCEEDED（含 i18n smoke 测试通过）。若失败，STOP 并报告。
+
+- [ ] **Step 2: 更新 ghostty-integration.md**
+
+在「### 链接交互相关 action」小节补充 `MOUSE_OVER_LINK` 与修饰键注入说明：
+```markdown
+- `GHOSTTY_ACTION_MOUSE_OVER_LINK` — hover 命中/离开链接时通知 URL；用于驱动
+  `LinkHintTooltip` 提示与链接光标（经 `GhosttyTerminalView.applyHoveredLink`）。
+- 普通 hover 也想要下划线/提示：`mouseMoved` 转发时注入 `GHOSTTY_MODS_SUPER`
+  伪造 Cmd，使 ghostty 在无修饰键时也高亮链接并发 MOUSE_OVER_LINK；点击事件传真实
+  修饰键，故仅真·Cmd+单击打开。光标与 tooltip 由 `updateLinkAffordance` 按真实 Cmd
+  状态接管（`applyMouseShape` 在 hover 链接期间让位）。
+```
+（读现有小节，衔接自然、不重复。）
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add docs/ghostty-integration.md
+git commit -m "docs(ghostty): document MOUSE_OVER_LINK + modifier injection"
+```
+
+---
+
+## 手动验证（实现完成后由用户执行）
+
+1. `xcodebuild build` 通过，用户自行重启 app。
+2. `echo https://example.com`：
+   - 普通 hover → 出现下划线 + tooltip「⌘ + 单击打开链接」，光标仍是 iBeam。
+   - 按住 Cmd hover → 下划线 + 手型光标，tooltip 隐藏。
+   - 普通单击 → 不打开链接（只定位/选择）。
+   - Cmd+单击 → 浏览器打开。
+3. 多 pane：仅焦点 pane 响应；离开链接 tooltip 消失。
+4. 重点验证「修饰键注入」无副作用：普通单击不误开、拖拽选区正常。

--- a/docs/superpowers/specs/2026-05-31-terminal-clickable-links-design.md
+++ b/docs/superpowers/specs/2026-05-31-terminal-clickable-links-design.md
@@ -91,3 +91,50 @@ ghostty_surface_mouse_pos(s, pt.x, pt.y, modsFromEvent(event))
 - `mux0/Ghostty/GhosttyTerminalView.swift` — `currentCursor` + `cursorUpdate` + `mouseMoved` 转发
 - `mux0Tests/` — 新增 `resolveOpenURL` 测试
 - `docs/ghostty-integration.md` — 补充新接入的 action 回调
+
+---
+
+## Phase 2：普通 hover 下划线 + tooltip（VS Code 手感）
+
+日期：2026-06-01
+
+### 背景与约束
+
+实测确认：libghostty 把「链接下划线高亮 / 手型光标 / 可点击」三者绑死在「按住 Cmd」条件上，普通 hover（不按 Cmd）不画任何东西。而下划线由 ghostty 渲染器内部绘制，C API 只暴露 `MOUSE_OVER_LINK`（给 URL 字符串，不给链接的单元格范围），所以宿主**无法自行精确绘制下划线**，只能依赖 ghostty 来画。
+
+目标行为（对齐 VS Code）：
+
+| 操作 | 下划线 | 光标 | tooltip | 点击打开 |
+|------|--------|------|---------|----------|
+| 普通 hover | ✅ | iBeam（不变）| ✅「⌘ + 单击打开链接」| 否 |
+| Cmd+hover | ✅ | 🖐 手型 | 隐藏 | Cmd+单击 ✅ |
+
+### 核心机制：修饰键注入（decouple highlight from open）
+
+ghostty 的「链接高亮」由**鼠标移动事件（mouse_pos）**携带的修饰键决定，「点击打开」由**鼠标点击事件（mouse_button）**携带的修饰键决定，两者独立。利用这点：
+
+- **`mouseMoved` 转发时给 mods 注入 `GHOSTTY_MODS_SUPER`（伪造 Cmd）** → ghostty 在普通 hover 也判定链接可高亮，于是画下划线 + 发 `MOUSE_OVER_LINK`（拿到 URL 用于 tooltip）+ 发 `MOUSE_SHAPE=POINTER`。
+- **点击事件不注入**，仍传真实修饰键。且 `mouseDown` 在按下按钮前会先用真实 mods 发一次 `mouse_pos`，把伪造的 super 状态清掉，所以普通单击不会打开、只有真·Cmd+单击才打开。
+- **光标单独接管**：普通 hover 强制 iBeam，只有真按 Cmd 才手型。
+
+### 组件
+
+1. **`mouseMoved` 注入**（GhosttyTerminalView）：转发 hover 位置时 `mods |= SUPER`。
+2. **`MOUSE_OVER_LINK` 回调**（GhosttyBridge）：读 `action.action.mouse_over_link`（url + len），len>0 → 在链接上（带 URL），len==0/url==nil → 离开链接（nil）。bounce 主线程 → `view.applyHoveredLink(url?)`。
+3. **链接 affordance 集中式更新**（GhosttyTerminalView）：`hoveredLinkURL: String?` + `updateLinkAffordance()`——根据「是否在链接上」与「真实 Cmd 是否按下」决定光标（hand/iBeam）与 tooltip（显示/隐藏）。由 `applyHoveredLink` 与 `flagsChanged`（Cmd 切换）触发。
+4. **`applyMouseShape` 让位**：当 `hoveredLinkURL != nil` 时 `applyMouseShape` 直接 return（链接光标由 `updateLinkAffordance` 接管），避免注入导致的 POINTER 与链接系统打架。非链接区仍由 MOUSE_SHAPE 设 iBeam。
+5. **Tooltip 气泡**（新文件 `mux0/Ghostty/LinkHintTooltip.swift`）：无边框、不激活、`ignoresMouseEvents` 的浮层窗口，`NSVisualEffectView(.toolTip)` + `NSTextField`（系统语义色，不硬编码），显示在光标附近。仅普通 hover 链接时显示，Cmd 按下或离开链接时隐藏。
+6. **文案**：`terminal.link.openHint` → en `⌘ + click to open link`，zh-Hans `⌘ + 单击打开链接`（`Localizable.xcstrings`）。
+
+### YAGNI / 风险
+
+- tooltip 仅在链接 enter 时定位一次，不随光标在同一链接内移动而跟随（VS Code 也是锚定式），可接受。
+- 这是绕过引擎默认行为的 workaround，依赖「ghostty 按点击事件 mods 判定 open」——逻辑已推演成立，但需真机验证无副作用（普通单击误打开、选区异常、注入 super 对 motion 的副作用）。
+
+### Phase 2 影响文件
+
+- `mux0/Ghostty/GhosttyTerminalView.swift` — mouseMoved 注入、hoveredLinkURL、updateLinkAffordance、flagsChanged、applyMouseShape 让位、linkTooltip
+- `mux0/Ghostty/GhosttyBridge.swift` — 新增 `MOUSE_OVER_LINK` case
+- `mux0/Ghostty/LinkHintTooltip.swift` — 新文件（tooltip 浮层）
+- `mux0/Localization/Localizable.xcstrings` — 新文案 key
+- `CLAUDE.md` / `AGENTS.md` / `docs/architecture.md` 或 `docs/ghostty-integration.md` — 目录结构同步 + action 文档

--- a/docs/superpowers/specs/2026-05-31-terminal-clickable-links-design.md
+++ b/docs/superpowers/specs/2026-05-31-terminal-clickable-links-design.md
@@ -1,0 +1,93 @@
+# 终端可点击链接（Cmd+点击打开 / Cmd+悬停高亮）设计
+
+日期：2026-05-31
+状态：已批准，待实现
+
+## 目标
+
+让终端里的 URL 支持 Cmd+点击跳转，并在 Cmd+悬停时显示下划线高亮与手型光标，体验对齐 VS Code 终端。
+
+## 背景
+
+libghostty 内部已实现完整的链接基础设施：链接正则识别、Cmd+点击判定、下划线高亮渲染都在引擎内部完成。mux0 当前未接入相关的 action 回调，所以：
+
+- Cmd+点击链接没有反应（`GHOSTTY_ACTION_OPEN_URL` 落到 `actionCallback` 的 `default` 分支返回 `false`）
+- 悬停链接光标不变手型（`GHOSTTY_ACTION_MOUSE_SHAPE` 未处理）
+- 悬停无下划线高亮（`mouseMoved` 故意不转发 hover 位置，见 `GhosttyTerminalView.swift:686`）
+
+`mouseDown` 已带修饰键转发（`modsFromEvent` 含 `GHOSTTY_MODS_SUPER`），所以缺的只是宿主侧的三处接线。
+
+改动集中在两个文件，不新增文件，不改目录结构。
+
+## 改动
+
+### 1. 打开 URL — `GhosttyBridge.swift`
+
+在 `actionCallback` 新增 `case GHOSTTY_ACTION_OPEN_URL`：
+
+- 从 `action.action.open_url` 读 `url` 指针与 `len`，按字节长度构造 `String`（不依赖 NUL 结尾，避免截断）。
+- bounce 到主线程，调用 `NSWorkspace.shared.open(url)`。
+- **scheme 白名单**：仅放行 `http` / `https` / `mailto` / `file`，其余 scheme 忽略，防止终端输出注入自定义 scheme 触发意外行为。
+- 返回 `true`（已处理）。
+
+为可测性，把解析与过滤抽成纯静态函数：
+
+```
+static func resolveOpenURL(_ raw: String) -> URL?
+```
+
+- 输入原始字符串，返回通过白名单校验的 `URL`，否则 `nil`。
+- `actionCallback` 调它，拿到非 nil 才 `NSWorkspace.shared.open`。
+
+### 2. 手型光标 — `GHOSTTY_ACTION_MOUSE_SHAPE`
+
+在 `actionCallback` 新增 `case GHOSTTY_ACTION_MOUSE_SHAPE`：
+
+- 读 `action.action.mouse_shape`，映射到 `NSCursor`：
+  - `GHOSTTY_MOUSE_SHAPE_POINTER → .pointingHand`
+  - `GHOSTTY_MOUSE_SHAPE_TEXT → .iBeam`
+  - 其余 → `.arrow`
+- bounce 到主线程，经 `GhosttyTerminalView.view(forSurface:)` 找到 view，写入其 `currentCursor` 并立即生效。
+
+`GhosttyTerminalView` 侧：
+
+- 新增 `private var currentCursor: NSCursor`（默认 `.iBeam`）。
+- tracking area 选项追加 `.cursorUpdate`。
+- override `cursorUpdate(with:)` → `currentCursor.set()`。
+- action 写入 `currentCursor` 时若鼠标在自身上，立即 `currentCursor.set()`。
+
+注意：这会让终端区域默认光标从当前的箭头变为更标准的 iBeam，与 VS Code 一致（已确认可接受）。
+
+### 3. 重新开启 hover 转发 — `mouseMoved`
+
+将 `GhosttyTerminalView.mouseMoved(with:)` 由空实现改为转发：
+
+```
+guard isCursorOverSelf(event) else { return }
+guard let s = surface else { return }
+let pt = flippedPoint(event.locationInWindow)
+ghostty_surface_mouse_pos(s, pt.x, pt.y, modsFromEvent(event))
+```
+
+安全性论证：
+
+- tracking area 为 `.activeWhenFirstResponder`，`mouseMoved` 仅在本 view 是 first responder（即焦点 pane）时触发，再加 `isCursorOverSelf` 守卫。
+- 旧注释担心的"选区跟随鼠标"只在鼠标按键按下时才扩选；无按键的纯 hover 不会画选区。
+- 后台 pane 的 ghostty `mouseLocation` 轮询问题已被现有 frontmost gate 拦住，不受本改动影响。
+
+### 不做
+
+- `GHOSTTY_ACTION_MOUSE_OVER_LINK`：下划线由 ghostty 渲染器自行绘制，此 action 仅为宿主可选地显示 URL 状态栏，YAGNI，不接。
+- 无需改 ghostty config，`link-url` 默认开启。
+
+## 测试
+
+- **单元测试**：`resolveOpenURL` 的白名单逻辑——放行 http/https/mailto/file，拒绝 javascript/自定义 scheme/空串/非法 URL。
+- **手动验证**：`xcodebuild build` 编译通过；用户重启 app 后实测 Cmd+悬停看下划线与手型光标、Cmd+点击打开 http 链接，普通点击不误触发。
+
+## 影响文件
+
+- `mux0/Ghostty/GhosttyBridge.swift` — 两个新 case + `resolveOpenURL`
+- `mux0/Ghostty/GhosttyTerminalView.swift` — `currentCursor` + `cursorUpdate` + `mouseMoved` 转发
+- `mux0Tests/` — 新增 `resolveOpenURL` 测试
+- `docs/ghostty-integration.md` — 补充新接入的 action 回调

--- a/landing-page/index.html
+++ b/landing-page/index.html
@@ -1220,7 +1220,7 @@ kbd{
         <span data-i18n="hero.cta.source">View source</span>
         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17L17 7M9 7h8v8"/></svg>
       </a>
-      <span class="chip-meta"><span class="mono" data-i18n="hero.meta.ver">v0.6.2</span></span>
+      <span class="chip-meta"><span class="mono" data-i18n="hero.meta.ver">v0.7.0</span></span>
     </div>
 
     <!-- hero window (interactive) -->
@@ -1247,7 +1247,7 @@ kbd{
               </div>
               <div class="ws-list" id="ws-list"></div>
               <div class="sidebar-footer">
-                <span class="mono">v0.6.2</span>
+                <span class="mono">v0.7.0</span>
                 <button class="side-icon disabled" data-disabled-msg title="Settings" aria-label="Settings (disabled in preview)">
                   <svg width="13" height="13"><use href="#icon-gear"/></svg>
                 </button>
@@ -1622,7 +1622,7 @@ const i18n = {
     "hero.sub": "A native macOS terminal built on libghostty. Workspaces, tabs, and split panes for your repos — with live status for every Claude Code, OpenCode, and Codex session you run.",
     "hero.cta.download": "Download for macOS",
     "hero.cta.source": "View source",
-    "hero.meta.ver": "v0.6.2",
+    "hero.meta.ver": "v0.7.0",
     "sidebar.workspaces": "WORKSPACES",
     "preview.caption": "Live preview — + add workspace/tab · double-click to rename · drag to reorder · type a command and hit Enter",
     "why.kicker": "THREE IDEAS",
@@ -1726,7 +1726,7 @@ const i18n = {
     "term.agent.needs": "waiting for your approval on tool call",
     "term.agent.failedMsg": "tool error: typecheck failed",
     "term.neofetch.os": "macOS 14.4 · Apple Silicon",
-    "term.neofetch.term": "Mux0 v0.6.2 · libghostty · Metal",
+    "term.neofetch.term": "Mux0 v0.7.0 · libghostty · Metal",
     "term.neofetch.shell": "zsh 5.9",
     "term.neofetch.uptime": "uptime 1d 4h",
     "term.neofetch.theme": "nocturne · 200 ms hot-reload",
@@ -1747,7 +1747,7 @@ const i18n = {
     "hero.sub": "基于 libghostty 的原生 macOS 终端。为多仓库工作流而设计 —— 侧边栏实时显示每一个 Claude Code、OpenCode、Codex 会话的运行状态。",
     "hero.cta.download": "下载 macOS 版",
     "hero.cta.source": "查看源码",
-    "hero.meta.ver": "v0.6.2",
+    "hero.meta.ver": "v0.7.0",
     "sidebar.workspaces": "工作区",
     "preview.caption": "实时预览 —— + 新建工作区/标签 · 双击重命名 · 拖拽排序 · 输入命令回车执行",
     "why.kicker": "三个理念",
@@ -1851,7 +1851,7 @@ const i18n = {
     "term.agent.needs": "等待工具调用授权",
     "term.agent.failedMsg": "工具报错：typecheck 失败",
     "term.neofetch.os": "macOS 14.4 · Apple Silicon",
-    "term.neofetch.term": "Mux0 v0.6.2 · libghostty · Metal",
+    "term.neofetch.term": "Mux0 v0.7.0 · libghostty · Metal",
     "term.neofetch.shell": "zsh 5.9",
     "term.neofetch.uptime": "运行 1d 4h",
     "term.neofetch.theme": "nocturne · 200 ms 热重载",

--- a/mux0.xcodeproj/project.pbxproj
+++ b/mux0.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		32A7B12961D2F46AEBD0E3F0 /* MetadataRefresherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92650C34DB180A72B23273A0 /* MetadataRefresherTests.swift */; };
 		368CDF074D86E31677DD944E /* AppearanceSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3A60150D4D181A6D9B55930 /* AppearanceSectionView.swift */; };
 		39B56550E6DE3A7BF8E95160 /* StartupCommandResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0520C77C17845C086A5E597A /* StartupCommandResolverTests.swift */; };
+		41C63A02D9C6DEDE7B5B2138 /* LinkHintTooltip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7156642613E48755F3EFC8AC /* LinkHintTooltip.swift */; };
 		4DF25EEF8F9CE22D00062158 /* SettingsTabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1BA2A24846F1D1712469C3 /* SettingsTabBarView.swift */; };
 		4E4FED23A4504E0204D3C515 /* WorkspacePasteboardType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F3CA90C6310DE9C99652EB /* WorkspacePasteboardType.swift */; };
 		5050C197246573A2D7174B05 /* QuickAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB6F2650B84DBA28A06D938D /* QuickAction.swift */; };
@@ -159,6 +160,7 @@
 		6ECD49D2FB00996850D13632 /* TabBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBridge.swift; sourceTree = "<group>"; };
 		70BBA11237B9EA46D6D3FFD6 /* ThemeManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeManagerTests.swift; sourceTree = "<group>"; };
 		70C36BFEC0226AFCE5094D35 /* ThemeCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeCatalog.swift; sourceTree = "<group>"; };
+		7156642613E48755F3EFC8AC /* LinkHintTooltip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkHintTooltip.swift; sourceTree = "<group>"; };
 		7B93B019349B80C08FDBBF7D /* HookDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookDispatcher.swift; sourceTree = "<group>"; };
 		81CD12FFB88B2BE6DFCE9F2A /* UpdateState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateState.swift; sourceTree = "<group>"; };
 		821BF7B943BBA8650E8769A4 /* TerminalPwdStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalPwdStoreTests.swift; sourceTree = "<group>"; };
@@ -477,6 +479,7 @@
 				E32257D2D28E09E97C065440 /* ghostty-bridging-header.h */,
 				97BE27EB11ED1ED01C8843B7 /* GhosttyBridge.swift */,
 				F9A8823EC09C8201A18A8CCE /* GhosttyTerminalView.swift */,
+				7156642613E48755F3EFC8AC /* LinkHintTooltip.swift */,
 			);
 			path = Ghostty;
 			sourceTree = "<group>";
@@ -674,6 +677,7 @@
 				0024B118D576BFA999FC6EFB /* IconButton.swift in Sources */,
 				5AB61AD35E457A1232CDA29A /* L10n.swift in Sources */,
 				0DC0EB6267E2B74A1D86BDD6 /* LanguageStore.swift in Sources */,
+				41C63A02D9C6DEDE7B5B2138 /* LinkHintTooltip.swift in Sources */,
 				8D92A0B981408874C548B7CE /* MetadataRefresher.swift in Sources */,
 				C25EEE04D310E199A62D191C /* PasteboardTypes.swift in Sources */,
 				5050C197246573A2D7174B05 /* QuickAction.swift in Sources */,

--- a/mux0.xcodeproj/project.pbxproj
+++ b/mux0.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		368CDF074D86E31677DD944E /* AppearanceSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3A60150D4D181A6D9B55930 /* AppearanceSectionView.swift */; };
 		39B56550E6DE3A7BF8E95160 /* StartupCommandResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0520C77C17845C086A5E597A /* StartupCommandResolverTests.swift */; };
 		41C63A02D9C6DEDE7B5B2138 /* LinkHintTooltip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7156642613E48755F3EFC8AC /* LinkHintTooltip.swift */; };
+		46EFA72285E02EF4674BF7A8 /* HoverHighlightURLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7423AB225EA4EAEA127DCB9 /* HoverHighlightURLTests.swift */; };
 		4DF25EEF8F9CE22D00062158 /* SettingsTabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1BA2A24846F1D1712469C3 /* SettingsTabBarView.swift */; };
 		4E4FED23A4504E0204D3C515 /* WorkspacePasteboardType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F3CA90C6310DE9C99652EB /* WorkspacePasteboardType.swift */; };
 		5050C197246573A2D7174B05 /* QuickAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB6F2650B84DBA28A06D938D /* QuickAction.swift */; };
@@ -180,6 +181,7 @@
 		9DBE7B66FAEB36EEB42A4857 /* SparkleBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparkleBridge.swift; sourceTree = "<group>"; };
 		A5F940956C8E5C463DA771CE /* PasteboardTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteboardTypes.swift; sourceTree = "<group>"; };
 		A688F7137F6F5369E3FCDB0C /* TerminalSessionTitleStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSessionTitleStore.swift; sourceTree = "<group>"; };
+		A7423AB225EA4EAEA127DCB9 /* HoverHighlightURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverHighlightURLTests.swift; sourceTree = "<group>"; };
 		AF17311B1358A9ECB083D3A4 /* WorkspaceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceStore.swift; sourceTree = "<group>"; };
 		B0C4FA9E98058C4E9936EC48 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		B0F181545CE8CDC275225D8B /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = System/Library/Frameworks/Metal.framework; sourceTree = SDKROOT; };
@@ -387,6 +389,7 @@
 				D68BE3B4BF39A66486E169B9 /* HookDispatcherTests.swift */,
 				399D6E84F70926B48FDB254D /* HookMessageTests.swift */,
 				6172CA48D21FC80F732CB23A /* HookSocketListenerTests.swift */,
+				A7423AB225EA4EAEA127DCB9 /* HoverHighlightURLTests.swift */,
 				4AB9513EB0F425DDEDAFA246 /* L10nSmokeTests.swift */,
 				EA1BC853B2A74058D4E3EDC4 /* LanguageStoreTests.swift */,
 				BFD4363754637D42A2211087 /* MetadataRefresherOnRefreshTests.swift */,
@@ -630,6 +633,7 @@
 				6986FB2583059FEABBCDCBD1 /* HookDispatcherTests.swift in Sources */,
 				B35766C44967278D296440C0 /* HookMessageTests.swift in Sources */,
 				D78733DF393F151691E97AF0 /* HookSocketListenerTests.swift in Sources */,
+				46EFA72285E02EF4674BF7A8 /* HoverHighlightURLTests.swift in Sources */,
 				14AEF17B71B6F1844E5D983D /* L10nSmokeTests.swift in Sources */,
 				2A515C5EBFDA3722DCE3F089 /* LanguageStoreTests.swift in Sources */,
 				A3D0BFE3A7FAB5735C84E453 /* MetadataRefresherOnRefreshTests.swift in Sources */,

--- a/mux0.xcodeproj/project.pbxproj
+++ b/mux0.xcodeproj/project.pbxproj
@@ -811,7 +811,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Vendor/ghostty/lib";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.6.2;
+				MARKETING_VERSION = 0.7.0;
 				MUX0_DISPLAY_NAME = Mux0;
 				OTHER_LDFLAGS = "-lghostty -lc++ -framework Carbon";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mux0.app;
@@ -936,7 +936,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Vendor/ghostty/lib";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.6.2;
+				MARKETING_VERSION = 0.7.0;
 				MUX0_DISPLAY_NAME = "Mux0 Dev";
 				OTHER_LDFLAGS = "-lghostty -lc++ -framework Carbon";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mux0.app.dev;

--- a/mux0.xcodeproj/project.pbxproj
+++ b/mux0.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		19BD6175DF11D2A4F682D037 /* NotificationNamesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 829BFF63567D2305C599651B /* NotificationNamesTests.swift */; };
 		1ACA82D8830D139B5869BCB2 /* SidebarListBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55F0C6038D23FE4472512A6 /* SidebarListBridge.swift */; };
 		1C796C37E496941073E60B63 /* HookDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B93B019349B80C08FDBBF7D /* HookDispatcher.swift */; };
+		1CE921B28990EA64082901F6 /* GhosttyBridgeOpenURLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E913A692A8A268E63CF1022 /* GhosttyBridgeOpenURLTests.swift */; };
 		205D81DA92E72BA9F8C00522 /* QuickActionsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 107354077329DDFCCA716A4D /* QuickActionsStore.swift */; };
 		207B3CDFB01968026553C4FD /* UpdateStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3A3CB55DB28818330806B72 /* UpdateStore.swift */; };
 		2639D53CE99FB3E1ABDB3C18 /* mux0App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FEFCD017628664F92CEDFC9 /* mux0App.swift */; };
@@ -153,6 +154,7 @@
 		6B95FF6C4289EE3D48831A08 /* BoundControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoundControls.swift; sourceTree = "<group>"; };
 		6C02DE9F1EA5DB3D6EFBA311 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		6CB172F8B41CDB874661F90C /* QuickActionsSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickActionsSectionView.swift; sourceTree = "<group>"; };
+		6E913A692A8A268E63CF1022 /* GhosttyBridgeOpenURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyBridgeOpenURLTests.swift; sourceTree = "<group>"; };
 		6E9FA78211379FE745A2A306 /* UpdateUserDriver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateUserDriver.swift; sourceTree = "<group>"; };
 		6ECD49D2FB00996850D13632 /* TabBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBridge.swift; sourceTree = "<group>"; };
 		70BBA11237B9EA46D6D3FFD6 /* ThemeManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeManagerTests.swift; sourceTree = "<group>"; };
@@ -377,6 +379,7 @@
 			isa = PBXGroup;
 			children = (
 				E7EFC41E34E76ABACF864F59 /* GhosttyBridgeCommandTests.swift */,
+				6E913A692A8A268E63CF1022 /* GhosttyBridgeOpenURLTests.swift */,
 				E5347252E77411776BBE4282 /* GhosttyTerminalViewPwdTests.swift */,
 				5C8D71111463899481471BE2 /* HookDispatcherSessionTitleTests.swift */,
 				D68BE3B4BF39A66486E169B9 /* HookDispatcherTests.swift */,
@@ -618,6 +621,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D6C6838185488C7EDEA33E97 /* GhosttyBridgeCommandTests.swift in Sources */,
+				1CE921B28990EA64082901F6 /* GhosttyBridgeOpenURLTests.swift in Sources */,
 				B87CA03C3EDF66D3B0D2C8AF /* GhosttyTerminalViewPwdTests.swift in Sources */,
 				C49A697E5CE9EA92414F8C19 /* HookDispatcherSessionTitleTests.swift in Sources */,
 				6986FB2583059FEABBCDCBD1 /* HookDispatcherTests.swift in Sources */,

--- a/mux0/Ghostty/GhosttyBridge.swift
+++ b/mux0/Ghostty/GhosttyBridge.swift
@@ -418,6 +418,22 @@ final class GhosttyBridge {
                 view.applyMouseShape(cursor)
             }
             return true
+        case GHOSTTY_ACTION_MOUSE_OVER_LINK:
+            guard target.tag == GHOSTTY_TARGET_SURFACE,
+                  let surface = target.target.surface
+            else { return true }
+            let mol = action.action.mouse_over_link
+            let url: String?
+            if let ptr = mol.url, mol.len > 0 {
+                url = String(data: Data(bytes: UnsafeRawPointer(ptr), count: Int(mol.len)), encoding: .utf8)
+            } else {
+                url = nil
+            }
+            DispatchQueue.main.async {
+                guard let view = GhosttyTerminalView.view(forSurface: surface) else { return }
+                view.applyHoveredLink(url)
+            }
+            return true
         default:
             return false
         }

--- a/mux0/Ghostty/GhosttyBridge.swift
+++ b/mux0/Ghostty/GhosttyBridge.swift
@@ -410,7 +410,8 @@ final class GhosttyBridge {
             switch shape {
             case GHOSTTY_MOUSE_SHAPE_POINTER: cursor = .pointingHand
             case GHOSTTY_MOUSE_SHAPE_TEXT:    cursor = .iBeam
-            default:                          cursor = .arrow
+            // 未映射的 shape 在终端里回退到 iBeam（而非 arrow），更贴近文本区预期。
+            default:                          cursor = .iBeam
             }
             DispatchQueue.main.async {
                 guard let view = GhosttyTerminalView.view(forSurface: surface) else { return }

--- a/mux0/Ghostty/GhosttyBridge.swift
+++ b/mux0/Ghostty/GhosttyBridge.swift
@@ -389,6 +389,18 @@ final class GhosttyBridge {
                 GhosttyBridge.shared.onPwdChanged?(terminalId, pwd)
             }
             return true
+        case GHOSTTY_ACTION_OPEN_URL:
+            let ou = action.action.open_url
+            guard let ptr = ou.url else { return true }
+            // url 不保证 NUL 结尾，按 len 取字节构造 String。
+            let data = Data(bytes: UnsafeRawPointer(ptr), count: Int(ou.len))
+            guard let raw = String(data: data, encoding: .utf8) else { return true }
+            DispatchQueue.main.async {
+                if let url = GhosttyBridge.resolveOpenURL(raw) {
+                    NSWorkspace.shared.open(url)
+                }
+            }
+            return true
         default:
             return false
         }

--- a/mux0/Ghostty/GhosttyBridge.swift
+++ b/mux0/Ghostty/GhosttyBridge.swift
@@ -401,6 +401,22 @@ final class GhosttyBridge {
                 }
             }
             return true
+        case GHOSTTY_ACTION_MOUSE_SHAPE:
+            guard target.tag == GHOSTTY_TARGET_SURFACE,
+                  let surface = target.target.surface
+            else { return true }
+            let shape = action.action.mouse_shape
+            let cursor: NSCursor
+            switch shape {
+            case GHOSTTY_MOUSE_SHAPE_POINTER: cursor = .pointingHand
+            case GHOSTTY_MOUSE_SHAPE_TEXT:    cursor = .iBeam
+            default:                          cursor = .arrow
+            }
+            DispatchQueue.main.async {
+                guard let view = GhosttyTerminalView.view(forSurface: surface) else { return }
+                view.applyMouseShape(cursor)
+            }
+            return true
         default:
             return false
         }

--- a/mux0/Ghostty/GhosttyBridge.swift
+++ b/mux0/Ghostty/GhosttyBridge.swift
@@ -394,6 +394,18 @@ final class GhosttyBridge {
         }
     }
 
+    /// 终端链接 Cmd+点击时由 ghostty 传来的原始 URL 字符串。仅放行安全 scheme，
+    /// 过滤掉终端输出里可能注入的自定义 scheme（如 javascript:）。
+    static func resolveOpenURL(_ raw: String) -> URL? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              let url = URL(string: trimmed),
+              let scheme = url.scheme?.lowercased(),
+              ["http", "https", "mailto", "file"].contains(scheme)
+        else { return nil }
+        return url
+    }
+
     /// ghostty forwards OSC 7 payloads as-is. zsh integration emits
     /// `kitty-shell-cwd://HOST/path` and `file://HOST/path` is the classic form;
     /// strip the scheme+host so we end up with a plain filesystem path usable by

--- a/mux0/Ghostty/GhosttyBridge.swift
+++ b/mux0/Ghostty/GhosttyBridge.swift
@@ -397,12 +397,15 @@ final class GhosttyBridge {
     /// 终端链接 Cmd+点击时由 ghostty 传来的原始 URL 字符串。仅放行安全 scheme，
     /// 过滤掉终端输出里可能注入的自定义 scheme（如 javascript:）。
     static func resolveOpenURL(_ raw: String) -> URL? {
+        let allowed: Set<String> = ["http", "https", "mailto", "file"]
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty,
               let url = URL(string: trimmed),
               let scheme = url.scheme?.lowercased(),
-              ["http", "https", "mailto", "file"].contains(scheme)
+              allowed.contains(scheme)
         else { return nil }
+        // file:// with no path is valid syntax but useless to open.
+        if scheme == "file", url.path.isEmpty { return nil }
         return url
     }
 

--- a/mux0/Ghostty/GhosttyTerminalView.swift
+++ b/mux0/Ghostty/GhosttyTerminalView.swift
@@ -300,7 +300,7 @@ final class GhosttyTerminalView: NSView, NSTextInputClient {
         // 只在自己是 first responder 时接收 mouseMoved，
         // 防止非聚焦 terminal 也收到鼠标位置更新（导致下层假性选区）。
         let options: NSTrackingArea.Options = [
-            .activeWhenFirstResponder, .mouseMoved, .cursorUpdate, .inVisibleRect
+            .activeWhenFirstResponder, .mouseMoved, .cursorUpdate, .mouseEnteredAndExited, .inVisibleRect
         ]
         addTrackingArea(NSTrackingArea(rect: bounds, options: options, owner: self, userInfo: nil))
     }
@@ -498,6 +498,8 @@ final class GhosttyTerminalView: NSView, NSTextInputClient {
     }
 
     override func resignFirstResponder() -> Bool {
+        // 失焦时清掉链接 hover 提示，避免 tooltip 滞留。
+        if hoveredLinkURL != nil { applyHoveredLink(nil) }
         if let s = surface {
             // 防御性释放：清掉任何可能残留的按键/拖拽选区状态，
             // 避免下次再聚焦时出现"鼠标一动就在选"的假象。
@@ -739,6 +741,12 @@ final class GhosttyTerminalView: NSView, NSTextInputClient {
         super.flagsChanged(with: event)
         // Cmd 的按下/松开会切换链接光标与 tooltip（即便鼠标没动）。
         updateLinkAffordance()
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        super.mouseExited(with: event)
+        // 鼠标移出 view 时清掉链接 hover 状态，否则浮层 tooltip 会一直留在屏幕上。
+        if hoveredLinkURL != nil { applyHoveredLink(nil) }
     }
 
     override func mouseMoved(with event: NSEvent) {

--- a/mux0/Ghostty/GhosttyTerminalView.swift
+++ b/mux0/Ghostty/GhosttyTerminalView.swift
@@ -68,6 +68,10 @@ final class GhosttyTerminalView: NSView, NSTextInputClient {
     /// 由 ghostty 的 MOUSE_SHAPE action 驱动。默认 iBeam，与终端文本区一致。
     private var currentCursor: NSCursor = .iBeam
 
+    /// 当前 hover 命中的链接 URL（来自 ghostty MOUSE_OVER_LINK）；nil 表示未在链接上。
+    private var hoveredLinkURL: String?
+    private let linkTooltip = LinkHintTooltip()
+
     /// Cell dimensions in points (already converted from backing px). Reported by
     /// ghostty's CELL_SIZE action when font/scale changes. Zero until first update.
     private(set) var cellSize: CGSize = .zero
@@ -90,6 +94,8 @@ final class GhosttyTerminalView: NSView, NSTextInputClient {
 
     /// ghostty 通知鼠标应显示的形状（悬停链接→手型，文本→iBeam）。
     func applyMouseShape(_ cursor: NSCursor) {
+        // 链接 hover 期间光标由 updateLinkAffordance 接管，避免与注入产生的 POINTER 打架。
+        guard hoveredLinkURL == nil else { return }
         currentCursor = cursor
         // 若鼠标正悬在自身上，立即生效，不必等下一次 cursorUpdate。
         if let window = window, window.isKeyWindow {
@@ -97,6 +103,33 @@ final class GhosttyTerminalView: NSView, NSTextInputClient {
             if bounds.contains(pt) {
                 cursor.set()
             }
+        }
+    }
+
+    /// ghostty 通知 hover 命中/离开链接。url 非 nil 表示在链接上。
+    func applyHoveredLink(_ url: String?) {
+        hoveredLinkURL = url
+        updateLinkAffordance()
+    }
+
+    /// 根据「是否在链接上」与「真实 Cmd 是否按下」集中决定光标与 tooltip。
+    /// 普通 hover 链接：iBeam + 显示提示；Cmd+hover 链接：手型 + 隐藏提示。
+    private func updateLinkAffordance() {
+        let cmdHeld = NSEvent.modifierFlags.contains(.command)
+        if hoveredLinkURL != nil {
+            currentCursor = cmdHeld ? .pointingHand : .iBeam
+            if cmdHeld {
+                linkTooltip.hide()
+            } else {
+                linkTooltip.show(L10n.string("terminal.link.openHint"), at: NSEvent.mouseLocation)
+            }
+        } else {
+            currentCursor = .iBeam
+            linkTooltip.hide()
+        }
+        if let window = window, window.isKeyWindow {
+            let pt = convert(window.mouseLocationOutsideOfEventStream, from: nil)
+            if bounds.contains(pt) { currentCursor.set() }
         }
     }
 
@@ -702,6 +735,12 @@ final class GhosttyTerminalView: NSView, NSTextInputClient {
         currentCursor.set()
     }
 
+    override func flagsChanged(with event: NSEvent) {
+        super.flagsChanged(with: event)
+        // Cmd 的按下/松开会切换链接光标与 tooltip（即便鼠标没动）。
+        updateLinkAffordance()
+    }
+
     override func mouseMoved(with event: NSEvent) {
         // 转发 hover 位置以驱动 ghostty 的链接下划线高亮与光标形状。
         // 安全性：tracking area 为 .activeWhenFirstResponder，仅焦点 pane 触发；
@@ -710,7 +749,12 @@ final class GhosttyTerminalView: NSView, NSTextInputClient {
         guard isCursorOverSelf(event) else { return }
         guard let s = surface else { return }
         let pt = flippedPoint(event.locationInWindow)
-        ghostty_surface_mouse_pos(s, pt.x, pt.y, modsFromEvent(event))
+        // 注入 SUPER：让 ghostty 在普通 hover 也判定链接可高亮，从而画下划线并发
+        // MOUSE_OVER_LINK。点击事件（mouseDown）仍传真实修饰键，且按下按钮前会先用真实
+        // mods 发一次 mouse_pos 清掉这里的伪造状态，故只有真·Cmd+单击才会打开链接。
+        var raw = modsFromEvent(event).rawValue
+        raw |= GHOSTTY_MODS_SUPER.rawValue
+        ghostty_surface_mouse_pos(s, pt.x, pt.y, ghostty_input_mods_e(rawValue: raw))
     }
 
     override func mouseDragged(with event: NSEvent) {

--- a/mux0/Ghostty/GhosttyTerminalView.swift
+++ b/mux0/Ghostty/GhosttyTerminalView.swift
@@ -703,9 +703,14 @@ final class GhosttyTerminalView: NSView, NSTextInputClient {
     }
 
     override func mouseMoved(with event: NSEvent) {
-        // 故意不转发 hover 位置：mux0 是多窗口浮动布局，
-        // ghostty 内部对未匹配 PRESS 的 mouse_pos 推进可能引发"鼠标飘到哪里就在哪里画选区"的假象。
-        // hover 仅用于 link 高亮等次要特性，宁可放弃也不要在底层 terminal 上误触发选中。
+        // 转发 hover 位置以驱动 ghostty 的链接下划线高亮与光标形状。
+        // 安全性：tracking area 为 .activeWhenFirstResponder，仅焦点 pane 触发；
+        // 再加 isCursorOverSelf 守卫。纯 hover（无按键）不会扩选区，后台 pane 的
+        // mouseLocation 轮询问题已被现有 frontmost gate 拦住。
+        guard isCursorOverSelf(event) else { return }
+        guard let s = surface else { return }
+        let pt = flippedPoint(event.locationInWindow)
+        ghostty_surface_mouse_pos(s, pt.x, pt.y, modsFromEvent(event))
     }
 
     override func mouseDragged(with event: NSEvent) {

--- a/mux0/Ghostty/GhosttyTerminalView.swift
+++ b/mux0/Ghostty/GhosttyTerminalView.swift
@@ -106,9 +106,48 @@ final class GhosttyTerminalView: NSView, NSTextInputClient {
         }
     }
 
-    /// ghostty 通知 hover 命中/离开链接。url 非 nil 表示在链接上。
+    /// hover 下划线/tooltip 只认可这些真能打开的 web 链接。故意排除 file://（那正是
+    /// shell 提示符路径之类的噪音来源）与无 scheme 的 OSC8 伪链接（如 /clear）。
+    /// Cmd+点击打开仍由 GhosttyBridge.resolveOpenURL 决定，范围不受此影响。
+    static func isHoverHighlightURL(_ raw: String) -> Bool {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              let url = URL(string: trimmed),
+              let scheme = url.scheme?.lowercased() else { return false }
+        return ["http", "https", "mailto"].contains(scheme)
+    }
+
+    /// 当前真实修饰键（不含注入的 SUPER），用于撤销 ghostty 对非真链接的高亮。
+    private func currentRealMods() -> ghostty_input_mods_e {
+        var raw: ghostty_input_mods_e.RawValue = 0
+        let flags = NSEvent.modifierFlags
+        if flags.contains(.shift)   { raw |= GHOSTTY_MODS_SHIFT.rawValue }
+        if flags.contains(.control) { raw |= GHOSTTY_MODS_CTRL.rawValue }
+        if flags.contains(.option)  { raw |= GHOSTTY_MODS_ALT.rawValue }
+        if flags.contains(.command) { raw |= GHOSTTY_MODS_SUPER.rawValue }
+        return ghostty_input_mods_e(rawValue: raw)
+    }
+
+    /// ghostty 高亮了一个我们不认可的「链接」（OSC8 路径/命令等）。用真实修饰键重发
+    /// 当前鼠标位置，让 ghostty 重新判定并撤掉那条下划线。
+    private func cancelGhosttyLinkHighlight() {
+        guard let s = surface, let window = window, window.isKeyWindow else { return }
+        let winPt = window.mouseLocationOutsideOfEventStream
+        let viewPt = convert(winPt, from: nil)
+        guard bounds.contains(viewPt) else { return }
+        let flipped = flippedPoint(winPt)
+        ghostty_surface_mouse_pos(s, flipped.x, flipped.y, currentRealMods())
+    }
+
+    /// ghostty 通知 hover 命中/离开链接。只认可真能打开的 web 链接；其余（点不开的
+    /// OSC8 路径/命令）撤掉 ghostty 的高亮，不显示任何 hover 反馈。
     func applyHoveredLink(_ url: String?) {
-        hoveredLinkURL = url
+        if let url, GhosttyTerminalView.isHoverHighlightURL(url) {
+            hoveredLinkURL = url
+        } else {
+            if url != nil { cancelGhosttyLinkHighlight() }
+            hoveredLinkURL = nil
+        }
         updateLinkAffordance()
     }
 

--- a/mux0/Ghostty/GhosttyTerminalView.swift
+++ b/mux0/Ghostty/GhosttyTerminalView.swift
@@ -65,6 +65,9 @@ final class GhosttyTerminalView: NSView, NSTextInputClient {
     /// Last scrollbar state from ghostty, or nil if never reported.
     private(set) var scrollbarState: ScrollbarState?
 
+    /// 由 ghostty 的 MOUSE_SHAPE action 驱动。默认 iBeam，与终端文本区一致。
+    private var currentCursor: NSCursor = .iBeam
+
     /// Cell dimensions in points (already converted from backing px). Reported by
     /// ghostty's CELL_SIZE action when font/scale changes. Zero until first update.
     private(set) var cellSize: CGSize = .zero
@@ -83,6 +86,18 @@ final class GhosttyTerminalView: NSView, NSTextInputClient {
         guard scrollbarState != s else { return }
         scrollbarState = s
         NotificationCenter.default.post(name: Self.scrollbarDidChangeNotification, object: self)
+    }
+
+    /// ghostty 通知鼠标应显示的形状（悬停链接→手型，文本→iBeam）。
+    func applyMouseShape(_ cursor: NSCursor) {
+        currentCursor = cursor
+        // 若鼠标正悬在自身上，立即生效，不必等下一次 cursorUpdate。
+        if let window = window, window.isKeyWindow {
+            let pt = convert(window.mouseLocationOutsideOfEventStream, from: nil)
+            if bounds.contains(pt) {
+                cursor.set()
+            }
+        }
     }
 
     /// Apply a new cell size in **backing pixels**. Converts to points using this
@@ -252,7 +267,7 @@ final class GhosttyTerminalView: NSView, NSTextInputClient {
         // 只在自己是 first responder 时接收 mouseMoved，
         // 防止非聚焦 terminal 也收到鼠标位置更新（导致下层假性选区）。
         let options: NSTrackingArea.Options = [
-            .activeWhenFirstResponder, .mouseMoved, .inVisibleRect
+            .activeWhenFirstResponder, .mouseMoved, .cursorUpdate, .inVisibleRect
         ]
         addTrackingArea(NSTrackingArea(rect: bounds, options: options, owner: self, userInfo: nil))
     }
@@ -681,6 +696,10 @@ final class GhosttyTerminalView: NSView, NSTextInputClient {
             GHOSTTY_MOUSE_MIDDLE,
             modsFromEvent(event)
         )
+    }
+
+    override func cursorUpdate(with event: NSEvent) {
+        currentCursor.set()
     }
 
     override func mouseMoved(with event: NSEvent) {

--- a/mux0/Ghostty/GhosttyTerminalView.swift
+++ b/mux0/Ghostty/GhosttyTerminalView.swift
@@ -118,25 +118,15 @@ final class GhosttyTerminalView: NSView, NSTextInputClient {
     }
 
     /// 当前真实修饰键（不含注入的 SUPER），用于撤销 ghostty 对非真链接的高亮。
-    private func currentRealMods() -> ghostty_input_mods_e {
-        var raw: ghostty_input_mods_e.RawValue = 0
-        let flags = NSEvent.modifierFlags
-        if flags.contains(.shift)   { raw |= GHOSTTY_MODS_SHIFT.rawValue }
-        if flags.contains(.control) { raw |= GHOSTTY_MODS_CTRL.rawValue }
-        if flags.contains(.option)  { raw |= GHOSTTY_MODS_ALT.rawValue }
-        if flags.contains(.command) { raw |= GHOSTTY_MODS_SUPER.rawValue }
-        return ghostty_input_mods_e(rawValue: raw)
-    }
-
-    /// ghostty 高亮了一个我们不认可的「链接」（OSC8 路径/命令等）。用真实修饰键重发
-    /// 当前鼠标位置，让 ghostty 重新判定并撤掉那条下划线。
+    /// ghostty 高亮了一个我们不认可的「链接」（OSC8 路径/命令等）。OSC8 链接的 hover
+    /// 高亮不看修饰键（且 ghostty 会去重同一格的 mouse_pos），单纯重发修饰键无法取消；
+    /// 用「鼠标移出」信号 (-1,-1) 强制 ghostty 清掉任何 hover 高亮。下一次 mouseMoved
+    /// 会重新进入，所以只是把噪音高亮抹掉，不影响后续真链接。
     private func cancelGhosttyLinkHighlight() {
         guard let s = surface, let window = window, window.isKeyWindow else { return }
-        let winPt = window.mouseLocationOutsideOfEventStream
-        let viewPt = convert(winPt, from: nil)
+        let viewPt = convert(window.mouseLocationOutsideOfEventStream, from: nil)
         guard bounds.contains(viewPt) else { return }
-        let flipped = flippedPoint(winPt)
-        ghostty_surface_mouse_pos(s, flipped.x, flipped.y, currentRealMods())
+        ghostty_surface_mouse_pos(s, -1, -1, ghostty_input_mods_e(rawValue: 0))
     }
 
     /// ghostty 通知 hover 命中/离开链接。只认可真能打开的 web 链接；其余（点不开的
@@ -145,7 +135,10 @@ final class GhosttyTerminalView: NSView, NSTextInputClient {
         if let url, GhosttyTerminalView.isHoverHighlightURL(url) {
             hoveredLinkURL = url
         } else {
-            if url != nil { cancelGhosttyLinkHighlight() }
+            // 仅普通 hover（未按 Cmd）时抹掉噪音高亮；按住 Cmd 是用户主动找链接，交给 ghostty。
+            if url != nil, !NSEvent.modifierFlags.contains(.command) {
+                cancelGhosttyLinkHighlight()
+            }
             hoveredLinkURL = nil
         }
         updateLinkAffordance()

--- a/mux0/Ghostty/LinkHintTooltip.swift
+++ b/mux0/Ghostty/LinkHintTooltip.swift
@@ -1,0 +1,67 @@
+import AppKit
+
+/// 链接 hover 提示气泡。一个无边框、不激活、不接收鼠标事件的浮层窗口，
+/// 显示「⌘ + 单击打开链接」之类提示。由 GhosttyTerminalView 在普通 hover
+/// 链接时显示，Cmd 按下或离开链接时隐藏。使用系统 toolTip 材质与语义色，
+/// 不引入主题耦合。
+final class LinkHintTooltip {
+    private var label: NSTextField?
+
+    private lazy var window: NSWindow = {
+        let w = NSWindow(
+            contentRect: .zero,
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: true
+        )
+        w.isOpaque = false
+        w.backgroundColor = .clear
+        w.level = .floating
+        w.ignoresMouseEvents = true
+        w.hasShadow = true
+
+        let blur = NSVisualEffectView()
+        blur.material = .toolTip
+        blur.state = .active
+        blur.wantsLayer = true
+        blur.layer?.cornerRadius = 5
+        blur.layer?.masksToBounds = true
+
+        let label = NSTextField(labelWithString: "")
+        label.font = .systemFont(ofSize: 11)
+        label.textColor = .labelColor
+        label.backgroundColor = .clear
+        label.isBordered = false
+        blur.addSubview(label)
+
+        w.contentView = blur
+        self.label = label
+        return w
+    }()
+
+    /// 在屏幕坐标 `screenPoint` 附近显示提示。
+    func show(_ text: String, at screenPoint: NSPoint) {
+        _ = window
+        guard let label else { return }
+        label.stringValue = text
+        label.sizeToFit()
+
+        let padX: CGFloat = 8
+        let padY: CGFloat = 5
+        let size = NSSize(
+            width: label.frame.width + padX * 2,
+            height: label.frame.height + padY * 2
+        )
+        label.setFrameOrigin(NSPoint(x: padX, y: padY))
+        window.setContentSize(size)
+        window.contentView?.frame = NSRect(origin: .zero, size: size)
+        // 放在光标右下方一点，避免遮住链接本身。
+        window.setFrameOrigin(NSPoint(x: screenPoint.x + 12,
+                                      y: screenPoint.y - size.height - 12))
+        window.orderFront(nil)
+    }
+
+    func hide() {
+        window.orderOut(nil)
+    }
+}

--- a/mux0/Localization/Localizable.xcstrings
+++ b/mux0/Localization/Localizable.xcstrings
@@ -2261,6 +2261,13 @@
           }
         }
       }
+    },
+    "terminal.link.openHint" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "⌘ + click to open link" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "⌘ + 单击打开链接" } }
+      }
     }
   },
   "version": "1.0"

--- a/mux0Tests/GhosttyBridgeOpenURLTests.swift
+++ b/mux0Tests/GhosttyBridgeOpenURLTests.swift
@@ -12,6 +12,16 @@ final class GhosttyBridgeOpenURLTests: XCTestCase {
     func testAllowsMailtoAndFile() {
         XCTAssertEqual(GhosttyBridge.resolveOpenURL("mailto:x@y.com")?.scheme, "mailto")
         XCTAssertEqual(GhosttyBridge.resolveOpenURL("file:///tmp/a.txt")?.scheme, "file")
+        XCTAssertEqual(GhosttyBridge.resolveOpenURL("file:///tmp/a.txt")?.absoluteString, "file:///tmp/a.txt")
+    }
+
+    func testRejectsEmptyFileURL() {
+        XCTAssertNil(GhosttyBridge.resolveOpenURL("file://"))
+    }
+
+    func testTrimsSurroundingWhitespace() {
+        XCTAssertEqual(GhosttyBridge.resolveOpenURL("  https://example.com  ")?.absoluteString,
+                       "https://example.com")
     }
 
     func testRejectsDisallowedSchemes() {

--- a/mux0Tests/GhosttyBridgeOpenURLTests.swift
+++ b/mux0Tests/GhosttyBridgeOpenURLTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+@testable import mux0
+
+final class GhosttyBridgeOpenURLTests: XCTestCase {
+    func testAllowsHTTPAndHTTPS() {
+        XCTAssertEqual(GhosttyBridge.resolveOpenURL("http://example.com")?.absoluteString,
+                       "http://example.com")
+        XCTAssertEqual(GhosttyBridge.resolveOpenURL("https://example.com/a?b=1")?.absoluteString,
+                       "https://example.com/a?b=1")
+    }
+
+    func testAllowsMailtoAndFile() {
+        XCTAssertEqual(GhosttyBridge.resolveOpenURL("mailto:x@y.com")?.scheme, "mailto")
+        XCTAssertEqual(GhosttyBridge.resolveOpenURL("file:///tmp/a.txt")?.scheme, "file")
+    }
+
+    func testRejectsDisallowedSchemes() {
+        XCTAssertNil(GhosttyBridge.resolveOpenURL("javascript:alert(1)"))
+        XCTAssertNil(GhosttyBridge.resolveOpenURL("ftp://example.com"))
+        XCTAssertNil(GhosttyBridge.resolveOpenURL("custom-scheme://do-something"))
+    }
+
+    func testRejectsEmptyAndSchemeless() {
+        XCTAssertNil(GhosttyBridge.resolveOpenURL(""))
+        XCTAssertNil(GhosttyBridge.resolveOpenURL("   "))
+        XCTAssertNil(GhosttyBridge.resolveOpenURL("example.com"))
+    }
+
+    func testSchemeMatchIsCaseInsensitive() {
+        XCTAssertEqual(GhosttyBridge.resolveOpenURL("HTTPS://example.com")?.scheme?.lowercased(),
+                       "https")
+    }
+}

--- a/mux0Tests/HoverHighlightURLTests.swift
+++ b/mux0Tests/HoverHighlightURLTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import mux0
+
+final class HoverHighlightURLTests: XCTestCase {
+    func testAcceptsWebAndMailto() {
+        XCTAssertTrue(GhosttyTerminalView.isHoverHighlightURL("http://example.com"))
+        XCTAssertTrue(GhosttyTerminalView.isHoverHighlightURL("https://example.com/a?b=1"))
+        XCTAssertTrue(GhosttyTerminalView.isHoverHighlightURL("mailto:x@y.com"))
+    }
+    func testRejectsFileAndSchemeless() {
+        // file:// 是提示符路径噪音的来源，hover 不高亮（但 Cmd+点击仍可由 resolveOpenURL 打开）。
+        XCTAssertFalse(GhosttyTerminalView.isHoverHighlightURL("file:///Users/me/repo"))
+        XCTAssertFalse(GhosttyTerminalView.isHoverHighlightURL("/clear"))
+        XCTAssertFalse(GhosttyTerminalView.isHoverHighlightURL("~/Documents/repos/clip0"))
+        XCTAssertFalse(GhosttyTerminalView.isHoverHighlightURL(""))
+    }
+    func testRejectsDangerousSchemes() {
+        XCTAssertFalse(GhosttyTerminalView.isHoverHighlightURL("javascript:alert(1)"))
+        XCTAssertFalse(GhosttyTerminalView.isHoverHighlightURL("ftp://example.com"))
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -127,7 +127,7 @@ targets:
         CODE_SIGN_STYLE: Automatic
         CODE_SIGN_ENTITLEMENTS: mux0/mux0.entitlements
         ENABLE_HARDENED_RUNTIME: YES
-        MARKETING_VERSION: "0.6.2"
+        MARKETING_VERSION: "0.7.0"
         CURRENT_PROJECT_VERSION: "3"
       configs:
         # Debug 构建用独立 bundle id + display name，让 TCC / LaunchServices /


### PR DESCRIPTION
## Summary

让终端里的链接像 VS Code 一样可交互,基于 libghostty 的链接能力接线 + 一层「只认真链接」的裁决。

**基础点击**
- `GhosttyBridge.resolveOpenURL` scheme 白名单(http/https/mailto/file)+ 单测
- 接 `OPEN_URL` → Cmd+单击用 `NSWorkspace` 打开
- 接 `MOUSE_SHAPE` → 驱动光标(未映射的 shape 回退 iBeam)
- 重新开启 `mouseMoved` hover 转发(仅焦点 pane)

**VS Code 式 hover(普通 hover 即反馈)**
- `LinkHintTooltip` 无边框浮层气泡 + i18n 文案「⌘ + 单击打开链接」
- 修饰键注入:`mouseMoved` 注入 `SUPER` 让 ghostty 在普通 hover 也画下划线并发 `MOUSE_OVER_LINK`;点击事件传真实修饰键,故仅真·Cmd+单击打开
- 光标/tooltip 由 `updateLinkAffordance` 按真实 Cmd 状态接管;`mouseExited`/失焦清理

**只高亮可打开的真链接**
- `isHoverHighlightURL` 仅放行 http/https/mailto;OSC8 伪链接(提示符路径、`/clear` 等)不显示 tooltip
- 这类噪音的下划线用 `(-1,-1)` 鼠标移出信号强制清掉(OSC8 hover 高亮不看修饰键,重发修饰键无效)

设计与计划见 `docs/superpowers/specs/2026-05-31-terminal-clickable-links-design.md` 与 `docs/superpowers/plans/`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)