### PR TITLE
fix(theme): resolve stale effectiveAppearance on day/night switch

### DIFF
--- a/mux0.xcodeproj/project.pbxproj
+++ b/mux0.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		5C5C2F39FAD6D937EBCEFCD4 /* TerminalStatusStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A56725925248FD6CAB92C5 /* TerminalStatusStoreTests.swift */; };
 		5CCE5836621069FDE33156A4 /* TerminalSessionTitleStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C44043B923CC4EF74123D4 /* TerminalSessionTitleStoreTests.swift */; };
 		620938F8EA5927DD270C9E4D /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FC595B7F0A7BC1E449FCC999 /* AppKit.framework */; };
+		680198B89C91F26FB496495B /* GhosttyConfigReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D2B9EDC6D541F4F4CBB258 /* GhosttyConfigReaderTests.swift */; };
 		684789E3C67497DD5A45DC6B /* ThemeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C43A714AAB5B2FF59F5C935 /* ThemeManager.swift */; };
 		6986FB2583059FEABBCDCBD1 /* HookDispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D68BE3B4BF39A66486E169B9 /* HookDispatcherTests.swift */; };
 		6AA362AD3255878AD318860E /* TerminalStatusIconViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC8D978AA26C3DD97EF58200 /* TerminalStatusIconViewTests.swift */; };
@@ -214,6 +215,7 @@
 		EFFA7A6778F19840BCAE2246 /* AppTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTheme.swift; sourceTree = "<group>"; };
 		F3A60150D4D181A6D9B55930 /* AppearanceSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceSectionView.swift; sourceTree = "<group>"; };
 		F4B27139F1EE49A3F3942275 /* mux0Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = mux0Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		F4D2B9EDC6D541F4F4CBB258 /* GhosttyConfigReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyConfigReaderTests.swift; sourceTree = "<group>"; };
 		F58750DF02302B3749F21937 /* GhosttyConfigReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyConfigReader.swift; sourceTree = "<group>"; };
 		F5E3E4715565F7F2A0692381 /* SplitPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitPaneView.swift; sourceTree = "<group>"; };
 		F8F3CA90C6310DE9C99652EB /* WorkspacePasteboardType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspacePasteboardType.swift; sourceTree = "<group>"; };
@@ -384,6 +386,7 @@
 			children = (
 				E7EFC41E34E76ABACF864F59 /* GhosttyBridgeCommandTests.swift */,
 				6E913A692A8A268E63CF1022 /* GhosttyBridgeOpenURLTests.swift */,
+				F4D2B9EDC6D541F4F4CBB258 /* GhosttyConfigReaderTests.swift */,
 				E5347252E77411776BBE4282 /* GhosttyTerminalViewPwdTests.swift */,
 				5C8D71111463899481471BE2 /* HookDispatcherSessionTitleTests.swift */,
 				D68BE3B4BF39A66486E169B9 /* HookDispatcherTests.swift */,
@@ -628,6 +631,7 @@
 			files = (
 				D6C6838185488C7EDEA33E97 /* GhosttyBridgeCommandTests.swift in Sources */,
 				1CE921B28990EA64082901F6 /* GhosttyBridgeOpenURLTests.swift in Sources */,
+				680198B89C91F26FB496495B /* GhosttyConfigReaderTests.swift in Sources */,
 				B87CA03C3EDF66D3B0D2C8AF /* GhosttyTerminalViewPwdTests.swift in Sources */,
 				C49A697E5CE9EA92414F8C19 /* HookDispatcherSessionTitleTests.swift in Sources */,
 				6986FB2583059FEABBCDCBD1 /* HookDispatcherTests.swift in Sources */,

--- a/mux0/Theme/GhosttyConfigReader.swift
+++ b/mux0/Theme/GhosttyConfigReader.swift
@@ -37,7 +37,11 @@ enum GhosttyConfigReader {
     /// 加载并解析当前用户的 ghostty 配置 + theme 文件 + mux0 override，返回组合后的颜色。
     /// 用户在 config 里直接写的 background/foreground/palette 优先于 theme；
     /// mux0 override 优先于 ghostty 标准 config。
-    static func load() -> Colors {
+    /// - Parameter systemIsDark: Whether the system (or user preference) is
+    ///   currently dark mode. Passed explicitly so the caller controls the source
+    ///   of truth — `NSApp.effectiveAppearance` may be stale when read inside an
+    ///   `AppleInterfaceThemeChangedNotification` handler.
+    static func load(systemIsDark: Bool = false) -> Colors {
         var theme = Colors()
         var direct = Colors()
 
@@ -55,7 +59,7 @@ enum GhosttyConfigReader {
         // 最后一个 theme= 为准（mux0 override 会赢）。
         if let themeValue = mergedKvs.reversed().first(where: { $0.0 == "theme" })?.1,
            !themeValue.isEmpty {
-            let name = resolveThemeNameForAppearance(themeValue)
+            let name = resolveThemeNameForAppearance(themeValue, isDark: systemIsDark)
             if let themePath = locateTheme(named: name) {
                 let themeKvs = parseFile(at: themePath)
                 applyKVs(themeKvs, into: &theme)
@@ -73,10 +77,12 @@ enum GhosttyConfigReader {
     }
 
     /// 解析 `theme = ...` 的 value，在 follow-system 语法 `light:X,dark:Y` 下
-    /// 按当前系统外观挑一侧返回；单值直接返回。
-    private static func resolveThemeNameForAppearance(_ raw: String) -> String {
+    /// 按传入的 isDark 挑一侧返回；单值直接返回。
+    ///
+    /// `isDark` 由调用方显式传入，而非内部读取 `NSApp.effectiveAppearance`，
+    /// 因为后者在 `AppleInterfaceThemeChangedNotification` 回调中可能仍为旧值。
+    private static func resolveThemeNameForAppearance(_ raw: String, isDark: Bool) -> String {
         guard raw.contains(":") && raw.contains(",") else { return raw }
-        let isDark = NSApp?.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
         let wantPrefix = isDark ? "dark:" : "light:"
         for part in raw.split(separator: ",") {
             let p = part.trimmingCharacters(in: .whitespaces)
@@ -135,13 +141,17 @@ enum GhosttyConfigReader {
     ///
     /// 来源优先级：mux0 override > ghostty 标准 config。这样在设置 UI 里改主题后，
     /// 下一次 reloadConfig 能立即加载正确的主题文件，而不是把旧主题焊在 config 上。
-    static func resolvedThemePath() -> String? {
+    /// - Parameter isDark: Whether dark mode is active. Falls back to
+    ///   `NSApp.effectiveAppearance` when nil (for call sites that are NOT
+    ///   inside an `AppleInterfaceThemeChangedNotification` handler).
+    static func resolvedThemePath(isDark: Bool? = nil) -> String? {
         let sources: [String] = [SettingsConfigStore.defaultPath] + configPaths
         for path in sources where FileManager.default.fileExists(atPath: path) {
             let kvs = parseFile(at: path)
             guard let themeValue = kvs.first(where: { $0.0 == "theme" })?.1,
                   !themeValue.isEmpty else { continue }
-            let name = resolveThemeNameForAppearance(themeValue)
+            let dark = isDark ?? (NSApp?.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua)
+            let name = resolveThemeNameForAppearance(themeValue, isDark: dark)
             return locateTheme(named: name)
         }
         return nil

--- a/mux0/Theme/GhosttyConfigReader.swift
+++ b/mux0/Theme/GhosttyConfigReader.swift
@@ -38,10 +38,12 @@ enum GhosttyConfigReader {
     /// 用户在 config 里直接写的 background/foreground/palette 优先于 theme；
     /// mux0 override 优先于 ghostty 标准 config。
     /// - Parameter systemIsDark: Whether the system (or user preference) is
-    ///   currently dark mode. Passed explicitly so the caller controls the source
-    ///   of truth — `NSApp.effectiveAppearance` may be stale when read inside an
-    ///   `AppleInterfaceThemeChangedNotification` handler.
-    static func load(systemIsDark: Bool = false) -> Colors {
+    ///   currently dark mode. Required (no default) so the caller always owns the
+    ///   source of truth — `NSApp.effectiveAppearance` may be stale when read
+    ///   inside an `AppleInterfaceThemeChangedNotification` handler, and a default
+    ///   would silently resolve the wrong side for any future caller that forgets
+    ///   to pass it.
+    static func load(systemIsDark: Bool) -> Colors {
         var theme = Colors()
         var direct = Colors()
 
@@ -81,7 +83,9 @@ enum GhosttyConfigReader {
     ///
     /// `isDark` 由调用方显式传入，而非内部读取 `NSApp.effectiveAppearance`，
     /// 因为后者在 `AppleInterfaceThemeChangedNotification` 回调中可能仍为旧值。
-    private static func resolveThemeNameForAppearance(_ raw: String, isDark: Bool) -> String {
+    ///
+    /// internal（非 private）以便单测直接覆盖各分支。
+    static func resolveThemeNameForAppearance(_ raw: String, isDark: Bool) -> String {
         guard raw.contains(":") && raw.contains(",") else { return raw }
         let wantPrefix = isDark ? "dark:" : "light:"
         for part in raw.split(separator: ",") {
@@ -141,17 +145,18 @@ enum GhosttyConfigReader {
     ///
     /// 来源优先级：mux0 override > ghostty 标准 config。这样在设置 UI 里改主题后，
     /// 下一次 reloadConfig 能立即加载正确的主题文件，而不是把旧主题焊在 config 上。
-    /// - Parameter isDark: Whether dark mode is active. Falls back to
-    ///   `NSApp.effectiveAppearance` when nil (for call sites that are NOT
-    ///   inside an `AppleInterfaceThemeChangedNotification` handler).
-    static func resolvedThemePath(isDark: Bool? = nil) -> String? {
+    ///
+    /// 仅由 `GhosttyBridge.buildConfig()` 调用，而 buildConfig 只在 `reloadConfig()`
+    /// 链路（onAppear / 设置变更）触发，不在 `AppleInterfaceThemeChangedNotification`
+    /// 回调里，因此这里直接读 `NSApp.effectiveAppearance` 是安全的——读到的是最新值。
+    static func resolvedThemePath() -> String? {
         let sources: [String] = [SettingsConfigStore.defaultPath] + configPaths
         for path in sources where FileManager.default.fileExists(atPath: path) {
             let kvs = parseFile(at: path)
             guard let themeValue = kvs.first(where: { $0.0 == "theme" })?.1,
                   !themeValue.isEmpty else { continue }
-            let dark = isDark ?? (NSApp?.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua)
-            let name = resolveThemeNameForAppearance(themeValue, isDark: dark)
+            let isDark = NSApp?.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+            let name = resolveThemeNameForAppearance(themeValue, isDark: isDark)
             return locateTheme(named: name)
         }
         return nil

--- a/mux0/Theme/ThemeManager.swift
+++ b/mux0/Theme/ThemeManager.swift
@@ -39,7 +39,7 @@ final class ThemeManager {
     init() {
         // 初始化时直接尝试解析 ghostty config (不需要 libghostty)
         let isDark = NSApp?.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-        let colors = GhosttyConfigReader.load()
+        let colors = GhosttyConfigReader.load(systemIsDark: isDark)
         let accent = colors.palette[3] ?? colors.palette[11] ?? colors.palette[6]
         self.theme = AppTheme.derive(
             background: colors.background,
@@ -65,7 +65,9 @@ final class ThemeManager {
         }
 
         // 直接从 ghostty config + theme 文件解析颜色（绕过 libghostty C API 的 key 不确定性）
-        let colors = GhosttyConfigReader.load()
+        // 将 systemIsDark 传入，避免 GhosttyConfigReader 内部再读一次
+        // effectiveAppearance（在通知回调中可能仍为旧值）。
+        let colors = GhosttyConfigReader.load(systemIsDark: systemIsDark)
         let accent = colors.palette[3]   // ANSI yellow
             ?? colors.palette[11]
             ?? colors.palette[6]
@@ -164,7 +166,13 @@ final class ThemeManager {
             queue: .main
         ) { [weak self] _ in
             guard let self, self.currentScheme == .system else { return }
-            self.applyScheme(.system)
+            // Defer by one run-loop tick: NSApp.effectiveAppearance may still
+            // reflect the *old* appearance when this notification fires.  Giving
+            // the run loop a cycle allows AppKit to update its internal state
+            // before we read it.
+            DispatchQueue.main.async {
+                self.applyScheme(.system)
+            }
         }
     }
 }

--- a/mux0Tests/GhosttyConfigReaderTests.swift
+++ b/mux0Tests/GhosttyConfigReaderTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+@testable import mux0
+
+/// 覆盖 `resolveThemeNameForAppearance` 的纯函数行为：follow-system 语法
+/// `light:X,dark:Y` 的双向解析、顺序无关，以及各种单值/边界输入。
+/// 这是把 day/night 切换 bug 收敛后的回归护栏——错误地挑了另一侧主题正是
+/// 当初文字不可读的根因。
+final class GhosttyConfigReaderTests: XCTestCase {
+
+    func testSingleValuePassthroughDark() {
+        XCTAssertEqual(
+            GhosttyConfigReader.resolveThemeNameForAppearance("Catppuccin Mocha", isDark: true),
+            "Catppuccin Mocha"
+        )
+    }
+
+    func testSingleValuePassthroughLight() {
+        XCTAssertEqual(
+            GhosttyConfigReader.resolveThemeNameForAppearance("Catppuccin Mocha", isDark: false),
+            "Catppuccin Mocha"
+        )
+    }
+
+    func testFollowSystemPicksDarkSide() {
+        XCTAssertEqual(
+            GhosttyConfigReader.resolveThemeNameForAppearance(
+                "light:Catppuccin Latte,dark:Catppuccin Mocha", isDark: true
+            ),
+            "Catppuccin Mocha"
+        )
+    }
+
+    func testFollowSystemPicksLightSide() {
+        XCTAssertEqual(
+            GhosttyConfigReader.resolveThemeNameForAppearance(
+                "light:Catppuccin Latte,dark:Catppuccin Mocha", isDark: false
+            ),
+            "Catppuccin Latte"
+        )
+    }
+
+    /// dark/light 顺序颠倒，结果不应改变。
+    func testFollowSystemOrderIndependent() {
+        XCTAssertEqual(
+            GhosttyConfigReader.resolveThemeNameForAppearance(
+                "dark:Catppuccin Mocha,light:Catppuccin Latte", isDark: false
+            ),
+            "Catppuccin Latte"
+        )
+        XCTAssertEqual(
+            GhosttyConfigReader.resolveThemeNameForAppearance(
+                "dark:Catppuccin Mocha,light:Catppuccin Latte", isDark: true
+            ),
+            "Catppuccin Mocha"
+        )
+    }
+
+    /// 含空格的 light:/dark: 片段（用户配置里常见）也要正确 trim 后匹配。
+    func testFollowSystemTrimsWhitespace() {
+        XCTAssertEqual(
+            GhosttyConfigReader.resolveThemeNameForAppearance(
+                "light:Catppuccin Latte, dark:Catppuccin Mocha", isDark: true
+            ),
+            "Catppuccin Mocha"
+        )
+    }
+
+    /// 含 `:` 但无 `,` —— 不满足 follow-system 语法，原样返回（不当作前缀拆分）。
+    func testColonWithoutCommaReturnsRaw() {
+        XCTAssertEqual(
+            GhosttyConfigReader.resolveThemeNameForAppearance("dark:Catppuccin Mocha", isDark: true),
+            "dark:Catppuccin Mocha"
+        )
+    }
+
+    /// 含 `,` 但无 `:` —— 同样不满足语法，原样返回。
+    func testCommaWithoutColonReturnsRaw() {
+        XCTAssertEqual(
+            GhosttyConfigReader.resolveThemeNameForAppearance("Foo,Bar", isDark: false),
+            "Foo,Bar"
+        )
+    }
+}


### PR DESCRIPTION
## Problem

When macOS switches between light and dark mode, some color schemas (e.g. text color) do not update, resulting in completely unreadable text. Users must manually switch the theme or restart mux0 to recover.

## Root Cause

`AppleInterfaceThemeChangedNotification` fires **before** `NSApp.effectiveAppearance` has been updated by AppKit. The old code read `effectiveAppearance` inside the notification handler, getting a stale value:

1. `ThemeManager.observeSystemAppearance()` called `applyScheme(.system)` synchronously → read `effectiveAppearance` → got the **old** appearance
2. `GhosttyConfigReader.resolveThemeNameForAppearance()` internally read `effectiveAppearance` again → still **stale**
3. For `theme = light:Catppuccin Latte,dark:Catppuccin Mocha`, this resolved to the wrong side (e.g. the light theme when dark was needed)
4. Result: light foreground colors on a light background (or dark-on-dark) → unreadable

## Fix (two parts)

### A) `ThemeManager.swift` — Defer the applyScheme call by one run-loop tick

```swift
// Before
self.applyScheme(.system)

// After
DispatchQueue.main.async {
    self.applyScheme(.system)
}
```

This gives AppKit time to update `NSApp.effectiveAppearance` before we read it.

### B) `GhosttyConfigReader.swift` — Pass `isDark` explicitly instead of reading effectiveAppearance internally

- `load()` gains a `systemIsDark` parameter (default `false` for backward compatibility)
- `resolveThemeNameForAppearance()` now takes `isDark: Bool` instead of reading `NSApp.effectiveAppearance` internally
- `resolvedThemePath()` gains an optional `isDark` parameter (falls back to reading `effectiveAppearance` when `nil`, safe for non-notification call sites)

This ensures the dark/light decision is made once (by the caller who knows the context) and propagated consistently, eliminating the redundant stale read inside GhosttyConfigReader.