### PR TITLE
fix(tabcontent): unified tab close confirmation + middle-click close

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Tip: you can add as many workspaces as you like. Each one keeps its own tabs and
 ### 3. Open Tabs and Split Panes
 
 - **New tab** — `⌘T`, or the **＋** button in the tab bar.
-- **Close tab** — `⌘W`, or the ✕ button on the tab.
+- **Close tab** — `⌘W`, middle-click the tab, or use the ✕ button.
 - **Split horizontally** — `⌘D`.
 - **Split vertically** — `⌘⇧D`.
 - **Move focus between panes** — `⌘⌥` + arrow keys.

--- a/docs/ghostty-integration.md
+++ b/docs/ghostty-integration.md
@@ -62,6 +62,13 @@ GhosttyTerminalView 需要：
 | `mouseMoved(_:)` / `mouseDragged(_:)` | `ghostty_surface_mouse_pos(surface, ...)` |
 | `scrollWheel(_:)` | `ghostty_surface_mouse_scroll(surface, ...)` |
 
+## 关闭确认
+
+mux0 自己管理 tab / split 生命周期，不使用 ghostty 内建的 surface tree 关闭路径。
+因此 tab 关闭前由 `GhosttyTerminalView.needsConfirmQuit` 调用
+`ghostty_surface_needs_confirm_quit(surface)`，把 ghostty 对
+`confirm-close-surface` 和前台进程状态的判断纳入 mux0 的统一关闭确认。
+
 ## 颜色读取
 
 从 ghostty config 读颜色用于主题：

--- a/docs/settings-reference.md
+++ b/docs/settings-reference.md
@@ -44,7 +44,7 @@ mux0 的设置面板分成七个 tab：**Appearance（外观）**、**Font（字
 | Scrollback Limit | `scrollback-limit` | `10_000_000`（一千万字节） | 回滚缓冲区上限（字节数）。决定你往回滚能看到多少历史输出。设太大吃内存，设为 `0` 等于禁用回滚。 |
 | Copy On Select | `copy-on-select` | — | 选中文本是否自动复制。`false`：不复制（要 ⌘C）；`true`：复制到普通剪贴板；`clipboard`：复制到系统剪贴板（跨 app 可粘贴）。 |
 | Hide Mouse While Typing | `mouse-hide-while-typing` | `false` | 打字时自动隐藏鼠标指针，防止指针挡住正在输入的位置。 |
-| Confirm Close | `confirm-close-surface` | — | 关闭终端 surface 时是否弹确认框。`true`：有运行中的进程才问；`false`：从不问；`always`：总是问。防止误关正在跑的命令。 |
+| Confirm Close | `confirm-close-surface` | — | 关闭终端 surface / tab / 最后一个 pane 时是否弹确认框。`true`：有运行中的进程才问；`false`：从不问；`always`：总是问。防止误关正在跑的命令。 |
 
 ---
 

--- a/mux0.xcodeproj/project.pbxproj
+++ b/mux0.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		724E2546197F4E6FD8F95B65 /* DraggedSnapshotShadow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531109F006EA4DC2299C7FC2 /* DraggedSnapshotShadow.swift */; };
 		749811FA06D8580CF545268A /* TextLinkButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2794897A7761B77AEFEC405F /* TextLinkButton.swift */; };
 		764C52B851F870CEAD204A76 /* SettingsResetRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6828870E05C9747F55C30BEE /* SettingsResetRow.swift */; };
+		76AC0B70AFCC7F438CC69211 /* TabCloseConfirmationPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A67C3840F9E9CD13F7F49C4 /* TabCloseConfirmationPolicyTests.swift */; };
 		7BB3ED2855848925E919A2EE /* AgentsSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98AEAE23A5BABC68B717A3C5 /* AgentsSectionView.swift */; };
 		7CB3C1A6EA7A40B724C7F8FB /* SplitPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E3E4715565F7F2A0692381 /* SplitPaneView.swift */; };
 		7D091993AB5BE99384B40BC9 /* WorkspaceStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15E65AC2F1EE235651418B43 /* WorkspaceStoreTests.swift */; };
@@ -155,7 +156,6 @@
 		6828870E05C9747F55C30BEE /* SettingsResetRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsResetRow.swift; sourceTree = "<group>"; };
 		6A963A750BA08BAAF5629075 /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 		6B95FF6C4289EE3D48831A08 /* BoundControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoundControls.swift; sourceTree = "<group>"; };
-		6C02DE9F1EA5DB3D6EFBA311 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		6CB172F8B41CDB874661F90C /* QuickActionsSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickActionsSectionView.swift; sourceTree = "<group>"; };
 		6E913A692A8A268E63CF1022 /* GhosttyBridgeOpenURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyBridgeOpenURLTests.swift; sourceTree = "<group>"; };
 		6E9FA78211379FE745A2A306 /* UpdateUserDriver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateUserDriver.swift; sourceTree = "<group>"; };
@@ -163,10 +163,12 @@
 		70BBA11237B9EA46D6D3FFD6 /* ThemeManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeManagerTests.swift; sourceTree = "<group>"; };
 		70C36BFEC0226AFCE5094D35 /* ThemeCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeCatalog.swift; sourceTree = "<group>"; };
 		7156642613E48755F3EFC8AC /* LinkHintTooltip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkHintTooltip.swift; sourceTree = "<group>"; };
+		7A67C3840F9E9CD13F7F49C4 /* TabCloseConfirmationPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabCloseConfirmationPolicyTests.swift; sourceTree = "<group>"; };
 		7B93B019349B80C08FDBBF7D /* HookDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookDispatcher.swift; sourceTree = "<group>"; };
 		81CD12FFB88B2BE6DFCE9F2A /* UpdateState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateState.swift; sourceTree = "<group>"; };
 		821BF7B943BBA8650E8769A4 /* TerminalPwdStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalPwdStoreTests.swift; sourceTree = "<group>"; };
 		829BFF63567D2305C599651B /* NotificationNamesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationNamesTests.swift; sourceTree = "<group>"; };
+		830B2ED6AC65D014EA0D7276 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		84326382AC1806C28810AF31 /* TabContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabContentView.swift; sourceTree = "<group>"; };
 		880E1BD0DC5DE3BD5E58FDAC /* WorkspaceListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceListView.swift; sourceTree = "<group>"; };
 		8B5435F2C6AADD54DE910072 /* QuickActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickActionTests.swift; sourceTree = "<group>"; };
@@ -251,6 +253,15 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		398EC5E5F6A5EC3699262CD6 /* MUX0 */ = {
+			isa = PBXGroup;
+			children = (
+				830B2ED6AC65D014EA0D7276 /* Config.xcconfig */,
+			);
+			name = MUX0;
+			path = .;
+			sourceTree = "<group>";
+		};
 		4F8B81D2162BAF843BC15DA4 /* Components */ = {
 			isa = PBXGroup;
 			children = (
@@ -284,7 +295,7 @@
 			isa = PBXGroup;
 			children = (
 				8F879EC56F1D67764C5600D3 /* mux0 */,
-				8ACE2B16A3A3CAFBED7A2D9D /* mux0 */,
+				398EC5E5F6A5EC3699262CD6 /* MUX0 */,
 				AA4BB6C5568DC3C2B9738AAB /* mux0Tests */,
 				E888840EACC9BB25B4089E7E /* Frameworks */,
 				2FB96E5465A56EFDD3EE380E /* Products */,
@@ -349,15 +360,6 @@
 			path = Metadata;
 			sourceTree = "<group>";
 		};
-		8ACE2B16A3A3CAFBED7A2D9D /* mux0 */ = {
-			isa = PBXGroup;
-			children = (
-				6C02DE9F1EA5DB3D6EFBA311 /* Config.xcconfig */,
-			);
-			name = mux0;
-			path = .;
-			sourceTree = "<group>";
-		};
 		8F879EC56F1D67764C5600D3 /* mux0 */ = {
 			isa = PBXGroup;
 			children = (
@@ -405,6 +407,7 @@
 				2445B39E48FEA8F4AC318C08 /* SidebarListBridgeTests.swift */,
 				0520C77C17845C086A5E597A /* StartupCommandResolverTests.swift */,
 				CC7EFDC8D28B1681B068CE01 /* StatusIndicatorGateTests.swift */,
+				7A67C3840F9E9CD13F7F49C4 /* TabCloseConfirmationPolicyTests.swift */,
 				821BF7B943BBA8650E8769A4 /* TerminalPwdStoreTests.swift */,
 				08C44043B923CC4EF74123D4 /* TerminalSessionTitleStoreTests.swift */,
 				CC8D978AA26C3DD97EF58200 /* TerminalStatusIconViewTests.swift */,
@@ -650,6 +653,7 @@
 				50E216D7B2C3E79CC5F2BD35 /* SidebarListBridgeTests.swift in Sources */,
 				39B56550E6DE3A7BF8E95160 /* StartupCommandResolverTests.swift in Sources */,
 				D795617034323AC803958EEE /* StatusIndicatorGateTests.swift in Sources */,
+				76AC0B70AFCC7F438CC69211 /* TabCloseConfirmationPolicyTests.swift in Sources */,
 				A88A524A7FCB090037E7DB2C /* TerminalPwdStoreTests.swift in Sources */,
 				5CCE5836621069FDE33156A4 /* TerminalSessionTitleStoreTests.swift in Sources */,
 				6AA362AD3255878AD318860E /* TerminalStatusIconViewTests.swift in Sources */,
@@ -802,7 +806,7 @@
 		};
 		BED404A181C0A175EED09CF6 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6C02DE9F1EA5DB3D6EFBA311 /* Config.xcconfig */;
+			baseConfigurationReference = 830B2ED6AC65D014EA0D7276 /* Config.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = mux0/mux0.entitlements;
@@ -815,7 +819,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Vendor/ghostty/lib";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.7.0;
+				MARKETING_VERSION = 0.8.2;
 				MUX0_DISPLAY_NAME = Mux0;
 				OTHER_LDFLAGS = "-lghostty -lc++ -framework Carbon";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mux0.app;
@@ -927,7 +931,7 @@
 		};
 		DEF80CCDBF9C05887D16217E /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6C02DE9F1EA5DB3D6EFBA311 /* Config.xcconfig */;
+			baseConfigurationReference = 830B2ED6AC65D014EA0D7276 /* Config.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = mux0/mux0.entitlements;
@@ -940,7 +944,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Vendor/ghostty/lib";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.7.0;
+				MARKETING_VERSION = 0.8.2;
 				MUX0_DISPLAY_NAME = "Mux0 Dev";
 				OTHER_LDFLAGS = "-lghostty -lc++ -framework Carbon";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mux0.app.dev;

--- a/mux0/Ghostty/GhosttyTerminalView.swift
+++ b/mux0/Ghostty/GhosttyTerminalView.swift
@@ -567,6 +567,14 @@ final class GhosttyTerminalView: NSView, NSTextInputClient {
     @discardableResult
     func selectAllRows() -> Bool { runBindingAction("select_all") }
 
+    /// Mirrors ghostty's own `confirm-close-surface` decision for this surface.
+    /// Used by mux0's tab lifecycle because mux0 owns tab removal outside
+    /// ghostty's built-in surface tree.
+    var needsConfirmQuit: Bool {
+        guard let surface else { return false }
+        return ghostty_surface_needs_confirm_quit(surface)
+    }
+
     // MARK: - Standard Edit-menu actions (responder chain entry points)
     //
     // mux0App 的 Edit > Copy/Paste/Select All 用 NSApp.sendAction(:to:nil) 沿

--- a/mux0/TabContent/TabBarView.swift
+++ b/mux0/TabContent/TabBarView.swift
@@ -1,6 +1,12 @@
 import AppKit
 import SwiftUI
 
+enum TabMiddleClickClosePolicy {
+    static func shouldClose(buttonNumber: Int, canClose: Bool) -> Bool {
+        canClose && buttonNumber == 2
+    }
+}
+
 /// NSView 子类，点击不触发窗口拖动。tab 栏上移进顶部标题栏拖拽区后，透明 NSView
 /// 默认 `mouseDownCanMoveWindow=true`，点击会被 titlebar 拖窗行为吞掉而不触发选中。
 private final class NonDraggableView: NSView {
@@ -1018,7 +1024,10 @@ private final class TabItemView: NSView, NSTextFieldDelegate, NSDraggingSource {
     }
 
     override func otherMouseDown(with event: NSEvent) {
-        guard canClose else { return }
+        guard TabMiddleClickClosePolicy.shouldClose(
+            buttonNumber: event.buttonNumber,
+            canClose: canClose
+        ) else { return }
         onClose?()
     }
 

--- a/mux0/TabContent/TabBarView.swift
+++ b/mux0/TabContent/TabBarView.swift
@@ -1017,6 +1017,11 @@ private final class TabItemView: NSView, NSTextFieldDelegate, NSDraggingSource {
         onSelect?()
     }
 
+    override func otherMouseDown(with event: NSEvent) {
+        guard canClose else { return }
+        onClose?()
+    }
+
     override func mouseDragged(with event: NSEvent) {
         // Rename 中不启动拖拽
         if isRenaming { return }

--- a/mux0/TabContent/TabContentView.swift
+++ b/mux0/TabContent/TabContentView.swift
@@ -527,6 +527,13 @@ final class TabContentView: NSView {
         guard let ws = store?.selectedWorkspace,
               let wsId = store?.selectedId,
               let tab = ws.selectedTab else { return }
+
+        let terminalIds = tab.layout.allTerminalIds()
+        if terminalIds.count <= 1 {
+            confirmCloseTab(tab.id)
+            return
+        }
+
         store?.closeTerminal(id: tab.focusedTerminalId, in: wsId, tabId: tab.id)
         reloadFromStore()
     }

--- a/mux0/TabContent/TabContentView.swift
+++ b/mux0/TabContent/TabContentView.swift
@@ -460,10 +460,26 @@ final class TabContentView: NSView {
     // MARK: - Close confirmation
 
     private func confirmCloseTab(_ tabId: UUID) {
-        guard let window,
-              let wsId = store?.selectedId,
+        guard let wsId = store?.selectedId,
               let ws = store?.workspaces.first(where: { $0.id == wsId }),
+              ws.tabs.count > 1,
               let tab = ws.tabs.first(where: { $0.id == tabId }) else { return }
+
+        let terminalStatuses = tab.layout.allTerminalIds().map { terminalId in
+            statusStore?.status(for: terminalId) ?? .neverRan
+        }
+        let needsConfirm = TabCloseConfirmationPolicy.needsConfirmation(
+            setting: settingsStore?.get("confirm-close-surface"),
+            statuses: terminalStatuses
+        )
+
+        guard needsConfirm else {
+            store?.removeTab(id: tabId, from: wsId)
+            reloadFromStore()
+            return
+        }
+
+        guard let window else { return }
 
         let alert = NSAlert()
         alert.messageText = L10n.string("tab.close.alert.title")

--- a/mux0/TabContent/TabContentView.swift
+++ b/mux0/TabContent/TabContentView.swift
@@ -2,7 +2,8 @@ import AppKit
 
 enum TabCloseConfirmationPolicy {
     static func needsConfirmation(setting rawSetting: String?,
-                                  statuses: [TerminalStatus]) -> Bool {
+                                  statuses: [TerminalStatus],
+                                  surfaceNeedsConfirmation: Bool = false) -> Bool {
         let setting = rawSetting?
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
@@ -13,7 +14,7 @@ enum TabCloseConfirmationPolicy {
         case "always":
             return true
         default:
-            return statuses.contains { status in
+            return surfaceNeedsConfirmation || statuses.contains { status in
                 switch status {
                 case .running, .needsInput:
                     return true
@@ -468,9 +469,13 @@ final class TabContentView: NSView {
         let terminalStatuses = tab.layout.allTerminalIds().map { terminalId in
             statusStore?.status(for: terminalId) ?? .neverRan
         }
+        let surfaceNeedsConfirmation = tab.layout.allTerminalIds().contains { terminalId in
+            terminalViews[terminalId]?.needsConfirmQuit ?? false
+        }
         let needsConfirm = TabCloseConfirmationPolicy.needsConfirmation(
             setting: settingsStore?.get("confirm-close-surface"),
-            statuses: terminalStatuses
+            statuses: terminalStatuses,
+            surfaceNeedsConfirmation: surfaceNeedsConfirmation
         )
 
         guard needsConfirm else {

--- a/mux0/TabContent/TabContentView.swift
+++ b/mux0/TabContent/TabContentView.swift
@@ -1,5 +1,30 @@
 import AppKit
 
+enum TabCloseConfirmationPolicy {
+    static func needsConfirmation(setting rawSetting: String?,
+                                  statuses: [TerminalStatus]) -> Bool {
+        let setting = rawSetting?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+
+        switch setting {
+        case "false":
+            return false
+        case "always":
+            return true
+        default:
+            return statuses.contains { status in
+                switch status {
+                case .running, .needsInput:
+                    return true
+                case .neverRan, .idle, .success, .failed:
+                    return false
+                }
+            }
+        }
+    }
+}
+
 /// Top-level content view that combines the tab bar and the active tab's split pane.
 ///
 /// ## Caching strategy

--- a/mux0Tests/TabCloseConfirmationPolicyTests.swift
+++ b/mux0Tests/TabCloseConfirmationPolicyTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+@testable import mux0
+
+final class TabCloseConfirmationPolicyTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_000)
+
+    func testFalseSettingNeverConfirmsEvenForActiveStatuses() {
+        let statuses: [TerminalStatus] = [
+            .running(startedAt: now),
+            .needsInput(since: now),
+        ]
+
+        XCTAssertFalse(TabCloseConfirmationPolicy.needsConfirmation(
+            setting: "false",
+            statuses: statuses
+        ))
+    }
+
+    func testAlwaysSettingConfirmsWithoutActiveStatuses() {
+        let statuses: [TerminalStatus] = [
+            .neverRan,
+            .idle(since: now),
+        ]
+
+        XCTAssertTrue(TabCloseConfirmationPolicy.needsConfirmation(
+            setting: "always",
+            statuses: statuses
+        ))
+    }
+
+    func testTrueSettingConfirmsForRunningStatus() {
+        XCTAssertTrue(TabCloseConfirmationPolicy.needsConfirmation(
+            setting: "true",
+            statuses: [.running(startedAt: now)]
+        ))
+    }
+
+    func testTrueSettingConfirmsForNeedsInputStatus() {
+        XCTAssertTrue(TabCloseConfirmationPolicy.needsConfirmation(
+            setting: "true",
+            statuses: [.needsInput(since: now)]
+        ))
+    }
+
+    func testTrueSettingDoesNotConfirmForInactiveStatuses() {
+        let statuses: [TerminalStatus] = [
+            .neverRan,
+            .idle(since: now),
+            .success(exitCode: 0, duration: 2, finishedAt: now, agent: .claude),
+            .failed(exitCode: 1, duration: 3, finishedAt: now, agent: .codex),
+        ]
+
+        XCTAssertFalse(TabCloseConfirmationPolicy.needsConfirmation(
+            setting: "true",
+            statuses: statuses
+        ))
+    }
+
+    func testMissingSettingBehavesLikeTrue() {
+        XCTAssertTrue(TabCloseConfirmationPolicy.needsConfirmation(
+            setting: nil,
+            statuses: [.running(startedAt: now)]
+        ))
+        XCTAssertFalse(TabCloseConfirmationPolicy.needsConfirmation(
+            setting: nil,
+            statuses: [.idle(since: now)]
+        ))
+    }
+
+    func testUnknownSettingBehavesLikeTrue() {
+        XCTAssertTrue(TabCloseConfirmationPolicy.needsConfirmation(
+            setting: "maybe",
+            statuses: [.needsInput(since: now)]
+        ))
+        XCTAssertFalse(TabCloseConfirmationPolicy.needsConfirmation(
+            setting: "maybe",
+            statuses: [.neverRan]
+        ))
+    }
+
+    func testSettingComparisonTrimsWhitespaceAndIgnoresCase() {
+        XCTAssertFalse(TabCloseConfirmationPolicy.needsConfirmation(
+            setting: " FALSE \n",
+            statuses: [.running(startedAt: now)]
+        ))
+        XCTAssertTrue(TabCloseConfirmationPolicy.needsConfirmation(
+            setting: " Always ",
+            statuses: [.neverRan]
+        ))
+    }
+}

--- a/mux0Tests/TabCloseConfirmationPolicyTests.swift
+++ b/mux0Tests/TabCloseConfirmationPolicyTests.swift
@@ -38,7 +38,16 @@ final class TabCloseConfirmationPolicyTests: XCTestCase {
     func testTrueSettingConfirmsForNeedsInputStatus() {
         XCTAssertTrue(TabCloseConfirmationPolicy.needsConfirmation(
             setting: "true",
-            statuses: [.needsInput(since: now)]
+            statuses: [.needsInput(since: now)],
+            surfaceNeedsConfirmation: false
+        ))
+    }
+
+    func testTrueSettingConfirmsWhenGhosttySurfaceNeedsConfirmation() {
+        XCTAssertTrue(TabCloseConfirmationPolicy.needsConfirmation(
+            setting: "true",
+            statuses: [.neverRan, .idle(since: now)],
+            surfaceNeedsConfirmation: true
         ))
     }
 
@@ -86,6 +95,30 @@ final class TabCloseConfirmationPolicyTests: XCTestCase {
         XCTAssertTrue(TabCloseConfirmationPolicy.needsConfirmation(
             setting: " Always ",
             statuses: [.neverRan]
+        ))
+    }
+}
+
+final class TabMiddleClickClosePolicyTests: XCTestCase {
+    func testOnlyMiddleMouseButtonClosesTab() {
+        XCTAssertTrue(TabMiddleClickClosePolicy.shouldClose(
+            buttonNumber: 2,
+            canClose: true
+        ))
+        XCTAssertFalse(TabMiddleClickClosePolicy.shouldClose(
+            buttonNumber: 3,
+            canClose: true
+        ))
+        XCTAssertFalse(TabMiddleClickClosePolicy.shouldClose(
+            buttonNumber: 4,
+            canClose: true
+        ))
+    }
+
+    func testMiddleMouseButtonRespectsCanClose() {
+        XCTAssertFalse(TabMiddleClickClosePolicy.shouldClose(
+            buttonNumber: 2,
+            canClose: false
         ))
     }
 }


### PR DESCRIPTION
### Problem

- Closing a tab ignored the `confirm-close-surface` setting — only split panes went through the confirmation flow
- Closing the last pane in a tab called `closeTerminal` directly, bypassing ghostty's `confirm-close-surface` judgment
- No mouse middle-click support for closing tabs

### Approach

**Unified close confirmation**
- Added `TabCloseConfirmationPolicy` — determines whether confirmation is needed based on the `confirm-close-surface` setting value (`false` / `always` / default `true`) and terminal status (`running` / `needsInput`)
- `GhosttyTerminalView.needsConfirmQuit` exposes ghostty's `ghostty_surface_needs_confirm_quit`, incorporating ghostty's foreground-process check into mux0's tab close flow
- `confirmCloseTab` now runs the policy check first and removes the tab directly when no confirmation is needed
- Closing the last pane routes through `confirmCloseTab` instead of bypassing confirmation

**Middle-click close**
- `TabItemView.otherMouseDown` captures middle-click (button 2) and triggers `onClose` after `TabMiddleClickClosePolicy` validation

### Changes

| File | Change |
|------|--------|
| `TabContentView.swift` | `TabCloseConfirmationPolicy` enum + `confirmCloseTab` rewrite + last-pane routing |
| `TabBarView.swift` | `TabMiddleClickClosePolicy` + `otherMouseDown` |
| `GhosttyTerminalView.swift` | `needsConfirmQuit` computed property |
| `TabCloseConfirmationPolicyTests.swift` | Unit tests for both policies (new file) |
| `ghostty-integration.md` | Close confirmation section |
| `settings-reference.md` | `confirm-close-surface` description updated for tab / last pane |
| `README.md` | Tab close methods updated with middle-click |

### Screenshot

<img width="1306" height="858" alt="iShot_2026-06-28_09 33 18" src="https://github.com/user-attachments/assets/8356e2ca-ec84-4f48-8d94-01a820b69043" />
